### PR TITLE
[TASK] Add plugin system tasks

### DIFF
--- a/.codex/ideas/boss-fight-and-event-ideas.md
+++ b/.codex/ideas/boss-fight-and-event-ideas.md
@@ -1,0 +1,6 @@
+# Gameplay Enhancement Ideas
+
+- Introduce a boss encounter every 5 stages with unique mechanics and rewards.
+- Provide optional side events between stages that grant temporary buffs or items.
+- Scale enemy difficulty dynamically based on player performance to keep battles engaging.
+- Support custom boss plugins so community members can contribute new encounters.

--- a/.codex/tasks/08810a94-player-plugin-support.md
+++ b/.codex/tasks/08810a94-player-plugin-support.md
@@ -1,0 +1,18 @@
+# Player Plugin Support
+
+## Summary
+Refactor player creation so new player classes can be loaded as plugins instead of being embedded directly in `player.py` or `buldfoepassives.py`.
+
+## Tasks
+- [ ] Create `plugins/players/base.py` defining a `PlayerPlugin` protocol with required fields such as `id`, `name`, and `build(**kwargs) -> Player`.
+- [ ] Extend `plugins/plugin_loader.py` to scan `plugins/players/` and register each `PlayerPlugin` under the `player` category.
+- [ ] Refactor `player.py` and `buldfoepassives.py` to construct player instances by querying the plugin registry instead of using hard-coded classes.
+- [ ] Move an existing player (e.g., the default warrior) into `plugins/players/warrior.py` as an example plugin.
+- [ ] Provide a fallback path so legacy player definitions still load if no matching plugin is found.
+
+## Context
+Player behaviors and stats are presently derived from hard-coded logic, making it difficult to extend. A plugin-based approach will simplify adding new player types.
+
+## Testing
+- [ ] Add tests in `tests/test_player_plugins.py` confirming the example plugin registers and `Player` instances build successfully.
+- [ ] Start a demo game using only legacy players and then with the plugin-enabled path to ensure both modes work.

--- a/.codex/tasks/123fff60-ci-workflow.md
+++ b/.codex/tasks/123fff60-ci-workflow.md
@@ -1,0 +1,15 @@
+# Continuous Integration Workflow
+
+## Summary
+Establish a GitHub Actions workflow to run tests on every push and pull request.
+
+## Tasks
+- [ ] Add `.github/workflows/tests.yml` that installs `uv`, sets up the environment, and executes `uv run pytest`.
+- [ ] Configure workflow triggers for `push` and `pull_request` events.
+- [ ] Document the workflow in the README or `.codex/implementation/` to guide contributors.
+
+## Context
+The repository lacks continuous integration, so failing tests may go unnoticed.
+
+## Testing
+- [ ] Submit a pull request to confirm the workflow runs and reports test results.

--- a/.codex/tasks/156002a8-passive-plugin-support.md
+++ b/.codex/tasks/156002a8-passive-plugin-support.md
@@ -1,0 +1,17 @@
+# Passive Plugin Support
+
+## Summary
+Enable passive effects to be implemented as plugins and automatically loaded at boot, replacing the hard-coded definitions in `passives_folder` and related files.
+
+## Tasks
+- [ ] Add `plugins/passives/base.py` defining a `PassivePlugin` protocol derived from `PassiveType` with hooks such as `on_apply`, `on_turn_start`, and damage callbacks.
+- [ ] Extend `plugins/plugin_loader.py` to scan `plugins/passives/` and register each implementation under the `passive` category.
+- [ ] Refactor `buldfoepassives.py` and any direct passive imports to query the registry for available passives.
+- [ ] Relocate `passives_folder/bleeding_blow.py` to `plugins/passives/bleeding_blow.py` and adapt it to the new interface.
+
+## Context
+Passives are currently stored in a dedicated folder but not dynamically loaded. Using the plugin system will allow new passive effects without changing core game code.
+
+## Testing
+- [ ] Add tests in `tests/test_passive_plugins.py` asserting that runtime-discovered passives trigger their hooks and alter game state.
+- [ ] Run the game with the `plugins/passives/` directory removed to confirm startup continues without available passives.

--- a/.codex/tasks/24e7a0e2-readme-overhaul.md
+++ b/.codex/tasks/24e7a0e2-readme-overhaul.md
@@ -1,0 +1,16 @@
+# README Overhaul
+
+## Summary
+Expand the project's README with clear gameplay, setup, and contribution guidance.
+
+## Tasks
+- [ ] Describe the game's objective, controls, and progression in dedicated sections.
+- [ ] Document how to install dependencies and run the game using `uv`.
+- [ ] Explain the plugin directory layout and how to create custom player or passive plugins.
+- [ ] Add instructions for running tests and submitting pull requests.
+
+## Context
+`README.md` currently provides only a single command, leaving newcomers without context or setup steps.
+
+## Testing
+- [ ] Preview the README in a markdown viewer to verify formatting and links.

--- a/.codex/tasks/2e5d8c13-dot-plugin-support.md
+++ b/.codex/tasks/2e5d8c13-dot-plugin-support.md
@@ -1,0 +1,18 @@
+# DOT Plugin Support
+
+## Summary
+Enable damage-over-time effects to be implemented as plugins and loaded on boot rather than being hard coded in `damage_over_time.py`.
+
+## Tasks
+- [ ] Add `plugins/dots/base.py` defining a `DotPlugin` protocol with attributes like `id`, `name`, and a `build(**kwargs) -> dot` factory.
+- [ ] Extend `plugins/plugin_loader.py` to scan `plugins/dots/` and register each implementation under the `dot` category.
+- [ ] Refactor `damage_over_time.py` to request DOT implementations from the plugin registry and fall back to the existing `dot` class when no plugin matches.
+- [ ] Move an existing DOT (e.g., poison) into `plugins/dots/poison.py` conforming to the new interface.
+
+## Context
+DOT effects are currently defined in `damage_over_time.py`, forcing edits for every new status effect. A plugin system lets contributors add new DOTs without modifying core code.
+
+## Testing
+- [ ] Add tests in `tests/test_dot_plugins.py` asserting that `plugins/dots/poison.py` registers and instances can be constructed.
+- [ ] Run the game with `plugins/dots/` removed to ensure DOT loading gracefully falls back to legacy behavior.
+

--- a/.codex/tasks/6265d1e4-plugin-docs-and-templates.md
+++ b/.codex/tasks/6265d1e4-plugin-docs-and-templates.md
@@ -1,0 +1,17 @@
+# Plugin Documentation and Examples
+
+## Summary
+Document the plugin system and provide developers with templates for creating new player, passive, dot, hot, and weapon plugins.
+
+## Tasks
+- [ ] Add a guide at `.codex/instructions/plugin-system.md` detailing directory layout, required interfaces, and how the plugin loader discovers modules for player, passive, dot, hot, and weapon categories.
+- [ ] Create template files `plugins/templates/player_plugin.py`, `plugins/templates/passive_plugin.py`, `plugins/templates/dot_plugin.py`, `plugins/templates/hot_plugin.py`, and `plugins/templates/weapon_plugin.py` with docstrings and TODO markers for mandatory methods.
+- [ ] Update `README.md` to mention the `plugins/` folder, how to drop in new plugin modules for all categories, and any configuration flags needed to enable them.
+- [ ] Insert inline comments in `plugins/players/warrior.py`, `plugins/passives/bleeding_blow.py`, `plugins/dots/poison.py`, `plugins/hots/regeneration.py`, and `plugins/weapons/sword.py` describing expected fields and lifecycle hooks.
+
+## Context
+Clear documentation and templates will make it easier for contributors to add new players, passives, dots, hots, and weapons via the plugin system.
+
+## Testing
+- [ ] Run `uv run python -m py_compile plugins/templates/*.py` to confirm template syntax validity.
+- [ ] Import the example templates via `plugins.plugin_loader` in a Python shell to ensure the loader can locate them.

--- a/.codex/tasks/7c0f1a85-weapon-plugin-support.md
+++ b/.codex/tasks/7c0f1a85-weapon-plugin-support.md
@@ -1,0 +1,18 @@
+# Weapon Plugin Support
+
+## Summary
+Allow weapons to be defined as plugins and loaded at runtime instead of being embedded directly in `weapons.py`.
+
+## Tasks
+- [ ] Add `plugins/weapons/base.py` defining a `WeaponPlugin` protocol derived from `WeaponType` with required fields like `id`, `name`, and a `build(**kwargs) -> WeaponType` factory.
+- [ ] Extend `plugins/plugin_loader.py` to scan `plugins/weapons/` and register each implementation under the `weapon` category.
+- [ ] Refactor `weapons.py` to obtain weapon definitions from the plugin registry, preserving a fallback to the current `WeaponType` instances if no plugin exists.
+- [ ] Move an existing weapon (e.g., the default sword) into `plugins/weapons/sword.py` as an example plugin.
+
+## Context
+Weapons are currently defined in a single module, making it difficult to introduce new weapon types. A plugin-based approach simplifies extension.
+
+## Testing
+- [ ] Add tests in `tests/test_weapon_plugins.py` verifying that `plugins/weapons/sword.py` registers and builds a `WeaponType` instance.
+- [ ] Run the game with `plugins/weapons/` absent to confirm legacy weapons still initialize.
+

--- a/.codex/tasks/8a2759b7-automated-test-suite.md
+++ b/.codex/tasks/8a2759b7-automated-test-suite.md
@@ -1,0 +1,16 @@
+# Automated Test Suite
+
+## Summary
+Introduce a pytest-based test suite covering core mechanics and plugin discovery.
+
+## Tasks
+- [ ] Create a `tests/` package with an empty `__init__.py`.
+- [ ] Add tests verifying player initialization and basic combat calculations.
+- [ ] Add tests ensuring the plugin loader registers valid modules and skips malformed ones.
+- [ ] Update `pyproject.toml` if necessary so `uv run pytest` locates the tests.
+
+## Context
+Currently `pytest` reports zero collected items, offering no automated regression coverage.
+
+## Testing
+- [ ] Run `uv run pytest` and confirm all tests pass.

--- a/.codex/tasks/950be04b-plugin-loader-system.md
+++ b/.codex/tasks/950be04b-plugin-loader-system.md
@@ -1,0 +1,18 @@
+# Plugin Loader Framework
+
+## Summary
+Create a generic plugin loader that discovers and imports plugin modules from a designated `plugins/` directory on game start.
+
+## Tasks
+- [ ] Create `plugins/plugin_loader.py` containing a `PluginLoader` class with a `discover(plugin_dir: str)` method.
+- [ ] Configure the loader to scan a `plugins/` directory (default at repository root) using `importlib` to import each module dynamically.
+- [ ] Build an internal registry mapping plugin categories (e.g., `player`, `passive`, `dot`, `hot`, `weapon`) to discovered classes so game systems can query available implementations.
+- [ ] Implement error handling that catches `ImportError` and attribute errors, logs a clear message via the `logging` module, and continues loading remaining plugins.
+- [ ] Expose a `get_plugins(plugin_type: str) -> dict[str, type]` helper to retrieve classes for a given category.
+
+## Context
+Currently players and passives are hard coded across large files such as `player.py` and `buldfoepassives.py`. A generic loader is needed to support dynamic additions without modifying core code.
+
+## Testing
+- [ ] Add tests in `tests/test_plugin_loader.py` asserting that valid modules are registered and malformed ones are skipped.
+- [ ] Run the game with an empty `plugins/` directory to ensure startup succeeds without plugins.

--- a/.codex/tasks/e4b7932a-hot-plugin-support.md
+++ b/.codex/tasks/e4b7932a-hot-plugin-support.md
@@ -1,0 +1,18 @@
+# HOT Plugin Support
+
+## Summary
+Enable healing-over-time effects to be implemented as plugins and loaded on boot rather than hard coded in `healing_over_time.py`.
+
+## Tasks
+- [ ] Add `plugins/hots/base.py` defining a `HotPlugin` protocol with attributes like `id`, `name`, and a `build(**kwargs) -> hot` factory.
+- [ ] Extend `plugins/plugin_loader.py` to scan `plugins/hots/` and register each implementation under the `hot` category.
+- [ ] Refactor `healing_over_time.py` to request HOT implementations from the plugin registry and fall back to the existing `hot` class when no plugin matches.
+- [ ] Move an existing HOT (e.g., regeneration) into `plugins/hots/regeneration.py` conforming to the new interface.
+
+## Context
+Healing over time effects are currently defined in `healing_over_time.py`. Turning them into plugins allows new effects without touching core files.
+
+## Testing
+- [ ] Add tests in `tests/test_hot_plugins.py` asserting that `plugins/hots/regeneration.py` registers and instances can be constructed.
+- [ ] Run the game with `plugins/hots/` removed to confirm HOT loading falls back to legacy behavior.
+

--- a/.codex/tasks/f2a1daf0-foe-passive-builder-cleanup.md
+++ b/.codex/tasks/f2a1daf0-foe-passive-builder-cleanup.md
@@ -1,0 +1,16 @@
+# Foe Passive Builder Cleanup
+
+## Summary
+Refactor `buldfoepassives.py` into a maintainable module with smaller, well-named helpers.
+
+## Tasks
+- [ ] Rename `buldfoepassives.py` to `foe_passive_builder.py`.
+- [ ] Break `build_foe_stats` into thematic helper functions grouped by enemy traits.
+- [ ] Replace large conditional blocks with data-driven lookups or plugins where practical.
+- [ ] Add docstrings and type hints for all new helpers.
+
+## Context
+`buldfoepassives.py` is extremely long, poorly named, and relies on hard-coded conditionals that hinder maintainability.
+
+## Testing
+- [ ] Run `uv run pytest` to ensure refactored logic maintains expected behavior.


### PR DESCRIPTION
## Summary
- broaden plugin loader task to cover player, passive, dot, hot, and weapon categories
- expand plugin documentation task with templates and examples for dot, hot, and weapon plugins
- add tasks for DOT, HOT, and weapon plugin support
- record gameplay enhancement ideas and add tasks for README, tests, passive builder cleanup, and CI workflow

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_688d6d18b80c832cbf02e82dee529f28