### PR TITLE
[CI] Switch auto merge workflow to Ubuntu

### DIFF
--- a/.github/workflows/auto-merge-lunamidori.yml
+++ b/.github/workflows/auto-merge-lunamidori.yml
@@ -7,11 +7,11 @@ on:
 
 jobs:
   auto_merge:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'lunamidori5'
     steps:
       - name: Install GitHub CLI if missing
-        run: command -v gh || yay -Syu --noconfirm github-cli
+        run: command -v gh >/dev/null || (sudo apt-get update && sudo apt-get install -y gh)
       - name: Checkout
         uses: actions/checkout@v4
       - name: Enable Pull Request Automerge


### PR DESCRIPTION
## Changes
- run auto-merge workflow on ubuntu-latest instead of self-hosted
- install GitHub CLI via apt when missing

## Testing
- `uv run pytest` (49 passed, 4 skipped)


------
https://chatgpt.com/codex/tasks/task_b_6891a567bb10832cb928a4104525501d