### PR TITLE
[FEAT] Add startup log and smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,21 @@ legacy/
    uv sync
    ```
 
-   - NVIDIA GPU extras: `uv sync --extra llm-cuda`
-   - AMD/Intel GPU extras: `uv sync --extra llm-amd`
-   - CPU-only extras: `uv sync --extra llm-cpu`
+   Panda3D ships prebuilt wheels.
 
-   Panda3D ships prebuilt wheels. The LLM extras pull in PyTorch and related
-   libraries, so match the extra to your hardware for best performance.
+### Optional LLM Dependencies
+
+Install extras to experiment with local language models. Each extra bundles
+LangChain, Transformers, and a matching PyTorch build.
+
+```bash
+uv sync --extra llm-cuda  # NVIDIA GPUs (CUDA drivers required)
+uv sync --extra llm-amd   # AMD/Intel GPUs (ROCm or oneAPI)
+uv sync --extra llm-cpu   # CPU-only
+```
+
+Selecting the correct extra ensures hardware acceleration when available. These
+packages are optional; the core game runs without them.
 
 3. Run the game:
 

--- a/main.py
+++ b/main.py
@@ -4,9 +4,12 @@ from panda3d.core import WindowProperties
 from direct.showbase.ShowBase import ShowBase
 
 from autofighter.menu import MainMenu
-from plugins.event_bus import EventBus
 from autofighter.scene import SceneManager
+from plugins.event_bus import EventBus
 from plugins.plugin_loader import PluginLoader
+
+
+logger = logging.getLogger(__name__)
 
 
 class AutoFighterApp(ShowBase):
@@ -14,6 +17,7 @@ class AutoFighterApp(ShowBase):
         super().__init__()
 
         logging.basicConfig(level=logging.INFO)
+        logger.info("Panda3D initialized successfully")
 
         self.scene_manager = SceneManager(self)
         self.event_bus = EventBus()
@@ -40,6 +44,7 @@ class AutoFighterApp(ShowBase):
         self._placeholder = self.loader.loadModel("models/box")
         self._placeholder.reparentTo(self.render)
         self._placeholder.setPos(0, 10, 0)
+        logger.info("Placeholder model attached")
 
         self.task_mgr.add(self.update, "update")
 

--- a/tests/test_main_smoke.py
+++ b/tests/test_main_smoke.py
@@ -1,0 +1,13 @@
+from panda3d.core import loadPrcFileData
+
+from main import AutoFighterApp
+
+
+def test_placeholder_attached() -> None:
+    loadPrcFileData("", "window-type none")
+    app = AutoFighterApp()
+    try:
+        assert app._placeholder.get_parent() is app.render
+    finally:
+        app.userExit()
+


### PR DESCRIPTION
## Summary
- log Panda3D initialization and attach a placeholder model on startup
- document optional LLM extras with platform-specific notes
- add a smoke test verifying the placeholder model is in the scene graph

## Testing
- `uv run pytest` *(fails: ModuleNotFoundError: No module named 'panda3d')*


------
https://chatgpt.com/codex/tasks/task_b_6891a9ff5eac832c82307f528da99801