### PR TITLE
[FEAT] Add feedback menu option

### DIFF
--- a/.codex/implementation/game-workflow.md
+++ b/.codex/implementation/game-workflow.md
@@ -6,7 +6,7 @@ This document describes the full runtime sequence of Midori AI AutoFighter and h
 - `PluginLoader` scans the `plugins/` directory to register available classes.
 - `SceneManager` swaps scenes and manages an overlay stack for menus or pause screens.
 - `MapGenerator` creates 45-room floors seeded per run, guaranteeing at least two shops and two rest rooms. Pressure Level adds extra rooms and boss encounters, and chat rooms may appear after battle nodes without increasing the room count.
-- The main menu stacks *New Run*, *Load Run*, *Edit Player*, *Options*, and *Quit* vertically and highlights the current choice for keyboard navigation.
+- The main menu stacks *New Run*, *Load Run*, *Edit Player*, *Options*, *Give Feedback*, and *Quit* vertically and highlights the current choice for keyboard navigation. The **Give Feedback** button opens a pre-filled GitHub issue in the user's browser.
 - A Player Creator offers body style, hair style, hair color, and accessory options while distributing 100 stat points as +1% increments. Spending 100 of each damage type's 4★ upgrade items adds one extra point, and remaining inventory is saved when confirming.
 - Confirmed choices are saved to `player.json` and loaded for new runs. A Load Run menu lists available save files, and an Options screen adjusts sound volumes, Stat Screen refresh rate, and toggles Stat Screen pausing.
 - A Stat Screen scene displays grouped stats (core, offense, defense, vitality, advanced) and status lists for passives, DoTs, HoTs, damage types, and relic stacks, refreshing every few frames.

--- a/autofighter/menu.py
+++ b/autofighter/menu.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import webbrowser
+
 from pathlib import Path
 
 try:
@@ -39,15 +41,21 @@ except Exception:  # pragma: no cover - fallback for headless tests
     class ShowBase:  # type: ignore[dead-code]
         pass
 
-from autofighter.scene import Scene
-from autofighter.save import load_run
 from autofighter.gui import TEXT_COLOR
-from autofighter.audio import get_audio
 from autofighter.gui import FRAME_COLOR
 from autofighter.gui import SLIDER_SCALE
 from autofighter.gui import WIDGET_SCALE
-from autofighter.save import load_player
 from autofighter.gui import set_widget_pos
+from autofighter.save import load_run
+from autofighter.save import load_player
+from autofighter.audio import get_audio
+from autofighter.scene import Scene
+
+
+ISSUE_URL = (
+    "https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/"
+    "new?template=feedback.md&title=Feedback"
+)
 
 
 class MainMenu(Scene):
@@ -64,6 +72,7 @@ class MainMenu(Scene):
             ("Load Run", self.load_run),
             ("Edit Player", self.edit_player),
             ("Options", self.open_options),
+            ("Give Feedback", self.give_feedback),
             ("Quit", self.app.userExit),
         ]
         top = self.BUTTON_SPACING * (len(labels) - 1) / 2
@@ -118,6 +127,12 @@ class MainMenu(Scene):
 
     def load_run(self) -> None:
         self.app.scene_manager.switch_to(LoadRunMenu(self.app))
+
+    def give_feedback(self) -> None:
+        try:
+            webbrowser.open(ISSUE_URL)
+        except Exception:
+            print(f"Open this page to give feedback: {ISSUE_URL}")
 
     def edit_player(self) -> None:
         from autofighter.player_creator import PlayerCreator  # local import to defer Panda3D dependency

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -5,13 +5,20 @@ import types
 
 from pathlib import Path
 
+from unittest.mock import patch
+
 import autofighter.audio as audio
 
-from autofighter.menu import MainMenu
 from autofighter.gui import FRAME_COLOR
+from autofighter.menu import MainMenu
+from autofighter.menu import ISSUE_URL
 from autofighter.menu import LoadRunMenu
 from autofighter.menu import OptionsMenu
 
+EXPECTED_URL = (
+    "https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/"
+    "new?template=feedback.md&title=Feedback"
+)
 
 class DummyApp:
     def __init__(self) -> None:
@@ -126,3 +133,12 @@ def test_main_menu_buttons_stack_vertically() -> None:
     assert zs == sorted(zs, reverse=True)
     assert len(set(zs)) == len(zs)
     menu.teardown()
+
+
+def test_main_menu_feedback_opens_issue() -> None:
+    assert ISSUE_URL == EXPECTED_URL
+    app = DummyApp()
+    menu = MainMenu(app)
+    with patch("webbrowser.open") as mock_open:
+        menu.give_feedback()
+    mock_open.assert_called_once_with(ISSUE_URL)


### PR DESCRIPTION
## Summary
- add Give Feedback button that opens pre-filled GitHub issue in OSS repository
- document feedback option in game workflow
- test feedback button opens browser URL

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68927af3b40c832c80b3908c0ef05a96