### PR TITLE
Fix party picker player selection display

### DIFF
--- a/.codex/implementation/party-picker.md
+++ b/.codex/implementation/party-picker.md
@@ -19,6 +19,12 @@ through the same selection handler so their stats panel refreshes like any
 other character. Their stats populate the panel by default so a damage type can
 be chosen even on a fresh save where no other characters are owned.
 
+Selecting any portrait swaps the 3D body preview and stat readout to match that
+character. Clicking the player when their stats are uninitialized (the default
+`hp=1` placeholder) returns to the Edit Player menu instead of displaying
+stats, ensuring new saves guide the user through player creation before
+starting a run.
+
 A placeholder 3D body model (`body_a`, `body_b`, or `body_c`) sits in the center
 and can be rotated left or right with the arrow keys. Models live in
 `assets/models` as `.egg` files that are converted to `.bam` when Panda3D tools


### PR DESCRIPTION
## Summary
- Load and track 3D body models based on each character's type
- Show stats and model when selecting any character and redirect uninitialized player to Edit Player menu
- Document and test party picker behavior

## Testing
- `uv run pytest` *(fails: 30 failed, 118 passed, 2 skipped)*
- `PYTHONPATH=. uv run pytest tests/test_party_picker.py::test_selecting_player_shows_stats tests/test_party_picker.py::test_clicking_unset_player_opens_editor`


------
https://chatgpt.com/codex/tasks/task_b_689a18a1e0b8832c9c7bf6cdfe556b8b