### PR TITLE
[FIX] compute coin icon class

### DIFF
--- a/frontend/src/lib/ShopMenu.svelte
+++ b/frontend/src/lib/ShopMenu.svelte
@@ -13,7 +13,12 @@
 
 <MenuPanel data-testid="shop-menu">
   <h3>Shop</h3>
-  <p class="currency"><Coins size={16} class="coin-icon" class:shine={!reducedMotion} /> {gold}</p>
+  <p class="currency">
+    <Coins
+      size={16}
+      class={`coin-icon${!reducedMotion ? ' shine' : ''}`}
+    /> {gold}
+  </p>
   <ul class="items">
     {#each items as item}
       <li>


### PR DESCRIPTION
## Summary
- compute shop coin icon class string so reduced motion disables shine

## Testing
- `uv run pytest` (partial, interrupted after 2 tests)
- `uvx ruff check .`
- `bun test`
- `ESLINT_USE_FLAT_CONFIG=false bunx eslint .`


------
https://chatgpt.com/codex/tasks/task_b_68a2d1d992e0832ca1b47f28809d07c8