### PR TITLE
[FIX] Refine coin icon shine class

### DIFF
--- a/frontend/src/lib/RestRoom.svelte
+++ b/frontend/src/lib/RestRoom.svelte
@@ -19,7 +19,10 @@
 {:else}
   <MenuPanel data-testid="rest-room">
     <h3>Rest Room</h3>
-    <p class="currency"><Coins size={16} class="coin-icon" class:shine={!reducedMotion} /> {gold}</p>
+    <p class="currency"><Coins
+        size={16}
+        class={`coin-icon${!reducedMotion ? ' shine' : ''}`}
+      /> {gold}</p>
     <div class="actions">
       <button on:click={pull}>Pull Character</button>
       <button on:click={swap}>Switch Party</button>


### PR DESCRIPTION
## Summary
- simplify RestRoom coin icon styling by replacing Svelte class directive with conditional class string

## Testing
- `uv run pytest`
- `uvx ruff check .`
- `bun test`
- `ESLINT_USE_FLAT_CONFIG=false bunx eslint .`


------
https://chatgpt.com/codex/tasks/task_b_68a2d1da68c0832cb3cd19385b78f0a4