### PR TITLE
[FIX] Reduce foe health regain

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -34,9 +34,10 @@ Characters marked as "random" roll one of the six elements when first loaded
 and reuse that element in future sessions.
 
 ## Foe Generation
-Foe plugins inherit from `FoeBase`, which mirrors `PlayerBase` stats. They are
-procedurally named by pairing an adjective from `themed_ajt` with a themed name
-from `themed_names` in `themedstuff.py`. After naming,
+Foe plugins inherit from `FoeBase`, which mirrors `PlayerBase` stats. To keep
+encounters from stalling, foes regain health at one hundredth the player rate.
+They are procedurally named by pairing an adjective from `themed_ajt` with a
+themed name from `themed_names` in `themedstuff.py`. After naming,
 `foe_passive_builder.build_foe_stats` applies stat modifiers:
 
 1. `_apply_high_level_lady` boosts high-level foes with *Lady* in their names,

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ DoT and HoT plugins manage ongoing damage or recovery. Supported DoTs include
 Bleed, Celestial Atrophy, Abyssal Corruption (spreads on death), Blazing
 Torment (extra tick on action), Cold Wound (five-stack cap), and Impact Echo
 (half of the last hit each turn). HoTs cover Regeneration, Player Echo, and
-Player Heal.
+Player Heal. Foes regenerate at one hundredth the player rate to prevent drawn
+out encounters.
 
 ## Battle Room
 

--- a/backend/plugins/foes/_base.py
+++ b/backend/plugins/foes/_base.py
@@ -52,3 +52,12 @@ class FoeBase(Stats):
 
     def __post_init__(self) -> None:
         self.damage_types = [getattr(self.base_damage_type, "id", str(self.base_damage_type))]
+
+    async def maybe_regain(self, turn: int) -> None:  # noqa: D401
+        """Regain a fraction of HP every other turn."""
+        if turn % 2 != 0:
+            return
+        bonus = max(self.regain - 100, 0) * 0.00005
+        percent = (0.01 + bonus) / 100
+        heal = int(self.max_hp * percent)
+        await self.apply_healing(heal)


### PR DESCRIPTION
## Summary
- Make foe regeneration 100x slower by overriding `maybe_regain`
- Document reduced foe healing rate in README and foe reference

## Testing
- `uv run pytest` *(fails: assert True is False; IndexError: list index out of range)*
- `uvx ruff check .` *(fails: F811 redefinition of unused `pytest` in tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a5a7a0bed0832c88bc4fbfc9d51d3e