### PR TITLE
[TASK] add battle UI and run persistence tasks

### DIFF
--- a/.codex/tasks/46287b2d-player-stats-reset.md
+++ b/.codex/tasks/46287b2d-player-stats-reset.md
@@ -1,0 +1,18 @@
+# Preserve player editor stats between battles
+
+## Context
+- Allocations made in the Player Editor apply in the first fight but reset afterward.
+- `load_party` in `backend/app.py` expects a `player` snapshot in the saved party to reapply custom stats via `_apply_player_stats`.
+- `save_party` omits this snapshot, so subsequent loads rebuild the player with default stats.
+
+## Task
+1. Extend `save_party` in `backend/app.py` to include a `player` entry containing the player's current `damage_type` and `stats` (HP, attack, defense, etc.).
+2. Confirm `load_party` continues to read this snapshot and apply `_apply_player_stats` when constructing the party.
+3. Add a backend test ensuring stats edited via `/player/editor` persist across multiple battles without reverting.
+4. Document the save data change in appropriate backend docs.
+5. Run `uv run pytest` and `bun test` after implementing.
+
+## Acceptance Criteria
+- Player stat allocations remain intact for the entire run.
+- New test verifies persistence across battles.
+- `uv run pytest` and `bun test` executed.

--- a/.codex/tasks/4fa956ad-enrage-bg.md
+++ b/.codex/tasks/4fa956ad-enrage-bg.md
@@ -1,0 +1,18 @@
+# Fix enrage background animation
+
+## Context
+- Battle docs state the background should pulse red/blue when foes enter **Enrage** after the turn threshold (`.codex/instructions/battle-room.md`).
+- In practice, the background never changes because `frontend/src/lib/BattleView.svelte` does not update its `enrage` state from battle snapshots.
+- `rooms.py` includes `enrage` data in the snapshot payload, but the frontend ignores it, leaving `.battle-field.enraged` inactive.
+
+## Task
+1. In `fetchSnapshot()` inside `frontend/src/lib/BattleView.svelte`, assign `enrage` when the snapshot contains an `enrage` field and it differs from the current value.
+2. Ensure `rooms.py` continues to expose `enrage` with `active` and `stacks` so the frontend can react.
+3. Verify that when `enrage.active` becomes true, the `.battle-field` element gains the `enraged` class and the red/blue cycling animation plays.
+4. Add a frontend regression test that simulates an enrage snapshot and confirms the class toggles.
+5. Run `bun test` and `uv run pytest` after making changes.
+
+## Acceptance Criteria
+- Background animation activates once foes become enraged and stops when combat ends.
+- New test covers enrage background behavior.
+- `bun test` and `uv run pytest` executed.

--- a/.codex/tasks/55c01e9e-party-picker-memory.md
+++ b/.codex/tasks/55c01e9e-party-picker-memory.md
@@ -1,0 +1,21 @@
+# Retain party picker selections and persist to backend
+
+## Context
+- Closing and reopening the Party Picker resets the selection to only the player.
+- In `frontend/src/lib/PartyPicker.svelte`, `onMount` unconditionally assigns `selected = [player.id]`, discarding prior choices passed from the parent.
+- The Party Picker never syncs selections to the backend, so runs forget party composition and no ownership check occurs.
+
+## Task
+1. Modify `onMount` in `PartyPicker.svelte` so it only defaults to the player when the incoming `selected` array is empty.
+2. When the party confirmation button is used, send the selected IDs to the backend so the active run saves the full party.
+3. Extend backend party save/load logic to return the stored party to the frontend on load and reject characters the player does not own.
+4. Ensure existing selections from `GameViewport` persist when the component remounts and after a page refresh using data from the backend.
+5. Add a frontend test that selects additional characters, closes and reopens the picker, refreshes the page, and asserts the selection is preserved.
+6. Add a backend test that saves a party, reloads it, and fails when unowned characters are provided.
+7. Run `bun test` and `uv run pytest` after changes.
+
+## Acceptance Criteria
+- Party choices survive closing and reopening the Party Picker and reloading the page.
+- Backend stores and restores the party while refusing unowned characters.
+- New tests confirm selection persistence and backend validation.
+- `bun test` and `uv run pytest` executed.

--- a/.codex/tasks/5a5a4595-rest-room-exit.md
+++ b/.codex/tasks/5a5a4595-rest-room-exit.md
@@ -1,0 +1,18 @@
+# Fix Rest Room exit flow
+
+## Context
+- After winning a battle, entering a Rest Room leaves the player stuck; the "Leave" button emits an event but the next room never loads.
+- `frontend/src/routes/+page.svelte` clears `nextRoom` when entering the Rest Room because `RestRoom.resolve` does not return a `next_room` property.
+- `handleRestLeave` calls `advanceRoom` without capturing its response, so `nextRoom` stays empty and `enterRoom()` returns early.
+
+## Task
+1. Update `handleRestLeave` in `frontend/src/routes/+page.svelte` to store the `next_room` value returned by `advanceRoom` and assign it to `nextRoom` before calling `enterRoom()`.
+2. Confirm that the Shop leave flow handles `next_room` similarly; adjust `handleShopLeave` if needed so both non-battle rooms can be exited.
+3. Verify that clicking **Leave** in a Rest Room after a battle advances to the next map node.
+4. Run `bun test` and `uv run pytest` to ensure existing tests pass (tests currently failing should be addressed separately).
+
+## Acceptance Criteria
+- Leaving a Rest Room after a battle loads the subsequent room without requiring a manual page refresh.
+- Shop leave flow remains functional.
+- All frontend tests pass (`bun test`).
+- Backend test suite (`uv run pytest`) is executed with best effort.

--- a/.codex/tasks/760c68eb-stats-stained-glass.md
+++ b/.codex/tasks/760c68eb-stats-stained-glass.md
@@ -1,0 +1,19 @@
+# Improve battle stats readability
+
+## Context
+- Players report that stat text during battles is difficult to read against the background.
+- Navigation elements use a stained-glass theme (`.stained-glass-bar`, `.stained-glass-side` in `frontend/src/lib/GameViewport.svelte`) and the UI plan (`.codex/planning/e26e5ed7-ui-foundation-plan.md`) calls for frosted glass surfaces with high contrast text.
+- `frontend/src/lib/BattleView.svelte` currently renders stats directly over the battlefield without any container or theme.
+
+## Task
+1. Wrap the party and foe stat sections in `BattleView.svelte` with resizable stained-glass containers that match the top-left bar and right sidebar styling.
+2. Reuse or extract shared stained-glass styles so both containers use consistent gradients, borders, and backdrop blur.
+3. Ensure the containers adjust to viewport size, keeping portraits and HP bars visible while improving text contrast.
+4. Update CSS and layout to prevent overlap with existing elements and keep readability on desktop and mobile.
+5. Add a frontend test verifying that the new container classes render for both party and foe columns.
+6. Run `bun test` and `uv run pytest` after changes.
+
+## Acceptance Criteria
+- Stats for both allies and foes appear within stained-glass containers and remain legible across screen sizes.
+- New test confirms containers render.
+- `bun test` and `uv run pytest` executed.

--- a/.codex/tasks/9d2ed303-run-persistence.md
+++ b/.codex/tasks/9d2ed303-run-persistence.md
@@ -1,0 +1,17 @@
+# Persist active run across reloads
+
+## Context
+- Refreshing the site always starts a new run; the frontend does not remember ongoing runs.
+- `frontend/src/routes/+page.svelte` initializes `runId` to an empty string and never checks for a previous value.
+
+## Task
+1. Store `runId` (and any required room state) in `localStorage` whenever a run starts or advances to a new room.
+2. On page load, read the stored `runId` and verify it with the backend (e.g., fetch `/map/{runId}`); if valid, restore `runId` and current room data instead of starting a new run.
+3. Provide a cleanup path that removes stored values when the run ends or verification fails.
+4. Add a frontend test that simulates a stored `runId` and confirms `GameViewport` resumes the existing run after a page refresh.
+5. Run `bun test` and `uv run pytest` after implementing.
+
+## Acceptance Criteria
+- Reloading the page during an active run resumes that run rather than creating a new one.
+- New test demonstrates run persistence.
+- `bun test` and `uv run pytest` executed.


### PR DESCRIPTION
## Summary
- add Task Master notes to fix rest room exit navigation
- document fixes for enrage background, battle stats containers, player stat persistence, party picker retention with backend syncing, and run resume logic

## Testing
- `bun test`
- `uv run pytest` *(fails: tests/test_app.py::test_players_and_rooms)*

------
https://chatgpt.com/codex/tasks/task_b_68a5a3181458832c8f44f1a3d901c31d