### PR TITLE
[FEAT] implement remaining relic behaviors

### DIFF
--- a/backend/plugins/relics/null_lantern.py
+++ b/backend/plugins/relics/null_lantern.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
 
 
@@ -12,3 +13,35 @@ class NullLantern(RelicBase):
     name: str = "Null Lantern"
     stars: int = 4
     effects: dict[str, float] = field(default_factory=lambda: {})
+
+    def apply(self, party) -> None:
+        """Disable shops/rests, buff foes, and award pull tokens."""
+        super().apply(party)
+
+        party.no_shops = True
+        party.no_rests = True
+        stacks = party.relics.count(self.id)
+        state = {"cleared": 0}
+
+        if not hasattr(party, "pull_tokens"):
+            party.pull_tokens = 0
+
+        def _battle_start(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            if isinstance(entity, FoeBase):
+                mult = 1 + 1.5 * state["cleared"]
+                entity.atk = int(entity.atk * mult)
+                entity.defense = int(entity.defense * mult)
+                entity.max_hp = int(entity.max_hp * mult)
+                entity.hp = entity.max_hp
+
+        def _battle_end(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            if isinstance(entity, FoeBase):
+                state["cleared"] += 1
+                party.pull_tokens += 1 + (stacks - 1)
+
+        BUS.subscribe("battle_start", _battle_start)
+        BUS.subscribe("battle_end", _battle_end)

--- a/backend/plugins/relics/omega_core.py
+++ b/backend/plugins/relics/omega_core.py
@@ -1,6 +1,9 @@
+"""Omega Core relic effects."""
+
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
 
 
@@ -12,3 +15,76 @@ class OmegaCore(RelicBase):
     name: str = "Omega Core"
     stars: int = 5
     effects: dict[str, float] = field(default_factory=lambda: {"atk": 5.0, "defense": 5.0})
+
+    def apply(self, party) -> None:
+        """Burst of power followed by increasing HP drain."""
+        super().apply(party)
+
+        stacks = party.relics.count(self.id)
+        delay = 10 + 2 * (stacks - 1)
+        mult = 6.0
+        state = {"bases": {}, "turn": 0}
+
+        def _battle_start(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            if isinstance(entity, FoeBase) or state["bases"]:
+                return
+            for member in party.members:
+                state["bases"][id(member)] = {
+                    "atk": member.atk,
+                    "defense": member.defense,
+                    "max_hp": member.max_hp,
+                    "crit_rate": member.crit_rate,
+                    "crit_damage": member.crit_damage,
+                    "effect_hit_rate": member.effect_hit_rate,
+                    "effect_resistance": member.effect_resistance,
+                    "vitality": member.vitality,
+                    "mitigation": member.mitigation,
+                }
+                member.atk = int(member.atk * mult)
+                member.defense = int(member.defense * mult)
+                member.max_hp = int(member.max_hp * mult)
+                member.hp = member.max_hp
+                member.crit_rate *= mult
+                member.crit_damage *= mult
+                member.effect_hit_rate *= mult
+                member.effect_resistance *= mult
+                member.vitality *= mult
+                member.mitigation *= mult
+            state["turn"] = 0
+
+        def _turn_start() -> None:
+            if not state["bases"]:
+                return
+            state["turn"] += 1
+            if state["turn"] <= delay:
+                return
+            drain = (state["turn"] - delay) * 0.01
+            for member in party.members:
+                dmg = int(member.max_hp * drain)
+                member.hp = max(member.hp - dmg, 0)
+
+        def _battle_end(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            if not isinstance(entity, FoeBase):
+                return
+            for member in party.members:
+                base = state["bases"].get(id(member))
+                if base:
+                    member.atk = base["atk"]
+                    member.defense = base["defense"]
+                    member.max_hp = base["max_hp"]
+                    member.hp = min(member.hp, member.max_hp)
+                    member.crit_rate = base["crit_rate"]
+                    member.crit_damage = base["crit_damage"]
+                    member.effect_hit_rate = base["effect_hit_rate"]
+                    member.effect_resistance = base["effect_resistance"]
+                    member.vitality = base["vitality"]
+                    member.mitigation = base["mitigation"]
+            state["bases"].clear()
+
+        BUS.subscribe("battle_start", _battle_start)
+        BUS.subscribe("turn_start", _turn_start)
+        BUS.subscribe("battle_end", _battle_end)

--- a/backend/plugins/relics/paradox_hourglass.py
+++ b/backend/plugins/relics/paradox_hourglass.py
@@ -1,6 +1,10 @@
+"""Paradox Hourglass relic effects."""
+
+import random
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
 
 
@@ -12,3 +16,88 @@ class ParadoxHourglass(RelicBase):
     name: str = "Paradox Hourglass"
     stars: int = 5
     effects: dict[str, float] = field(default_factory=lambda: {"atk": 2.0, "defense": 2.0})
+
+    def apply(self, party) -> None:
+        """On battle start possibly sacrifices allies for massive buffs."""
+        super().apply(party)
+
+        stacks = party.relics.count(self.id)
+        state: dict[str, dict] = {"buffs": {}, "foe": {}}
+
+        def _battle_start(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            if isinstance(entity, FoeBase):
+                base_def = entity.defense
+                div = 4 + (stacks - 1)
+                entity.defense = max(100, int(base_def / div))
+                state["foe"][id(entity)] = base_def
+                return
+
+            if state.get("done"):
+                return
+            state["done"] = True
+
+            alive = [m for m in party.members if m.hp > 0]
+            if len(alive) <= 1:
+                return
+            chance = 0.6 * (len(alive) - 1) / len(alive)
+            if random.random() >= chance:
+                return
+            kill_count = min(stacks, len(alive) - 1)
+            to_kill = random.sample(alive, kill_count)
+            for m in to_kill:
+                m.hp = 0
+            survivors = [m for m in party.members if m.hp > 0]
+            mult = 3 + (stacks - 1)
+            for m in survivors:
+                state["buffs"][id(m)] = {
+                    "atk": m.atk,
+                    "defense": m.defense,
+                    "max_hp": m.max_hp,
+                    "crit_rate": m.crit_rate,
+                    "crit_damage": m.crit_damage,
+                    "effect_hit_rate": m.effect_hit_rate,
+                    "effect_resistance": m.effect_resistance,
+                    "vitality": m.vitality,
+                    "mitigation": m.mitigation,
+                }
+                m.atk = int(m.atk * mult)
+                m.defense = int(m.defense * mult)
+                m.max_hp = int(m.max_hp * mult)
+                m.hp = m.max_hp
+                m.crit_rate *= mult
+                m.crit_damage *= mult
+                m.effect_hit_rate *= mult
+                m.effect_resistance *= mult
+                m.vitality *= mult
+                m.mitigation *= mult
+
+        def _battle_end(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            if isinstance(entity, FoeBase):
+                base = state["foe"].pop(id(entity), None)
+                if base is not None:
+                    entity.defense = base
+                return
+
+            if state.get("buffs"):
+                for member in party.members:
+                    base = state["buffs"].get(id(member))
+                    if base:
+                        member.atk = base["atk"]
+                        member.defense = base["defense"]
+                        member.max_hp = base["max_hp"]
+                        member.hp = min(member.hp, member.max_hp)
+                        member.crit_rate = base["crit_rate"]
+                        member.crit_damage = base["crit_damage"]
+                        member.effect_hit_rate = base["effect_hit_rate"]
+                        member.effect_resistance = base["effect_resistance"]
+                        member.vitality = base["vitality"]
+                        member.mitigation = base["mitigation"]
+                state["buffs"].clear()
+                state.pop("done", None)
+
+        BUS.subscribe("battle_start", _battle_start)
+        BUS.subscribe("battle_end", _battle_end)

--- a/backend/plugins/relics/rusty_buckle.py
+++ b/backend/plugins/relics/rusty_buckle.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
 
 
@@ -12,3 +13,43 @@ class RustyBuckle(RelicBase):
     name: str = "Rusty Buckle"
     stars: int = 1
     effects: dict[str, float] = field(default_factory=lambda: {})
+
+    def apply(self, party) -> None:
+        """Bleed weakest ally and ping foes as their HP drops."""
+        super().apply(party)
+
+        stacks = party.relics.count(self.id)
+        state: dict[str, object] = {"foes": [], "ally": None, "triggers": 0}
+
+        def _battle_start(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            if isinstance(entity, FoeBase):
+                state["foes"].append(entity)
+                return
+
+            if state["ally"] is None and party.members:
+                ally = min(party.members, key=lambda m: m.max_hp)
+                bleed = int(ally.max_hp * 0.01 * stacks)
+                ally.hp = max(ally.hp - bleed, 1)
+                state["ally"] = ally
+                state["triggers"] = 0
+
+        def _damage(target, attacker, amount) -> None:
+            ally = state.get("ally")
+            if target is not ally:
+                return
+            max_hp = ally.max_hp
+            triggers = state["triggers"]
+            lost_frac = 1 - (ally.hp / max_hp)
+            while lost_frac >= 0.1 * (triggers + 1):
+                triggers += 1
+                state["triggers"] = triggers
+                total_lost = max_hp * 0.1 * triggers
+                dmg = int(total_lost * 0.005)
+                hits = 5 + 3 * (stacks - 1)
+                for foe in state["foes"]:
+                    foe.hp = max(foe.hp - dmg * hits, 0)
+
+        BUS.subscribe("battle_start", _battle_start)
+        BUS.subscribe("damage_taken", _damage)

--- a/backend/plugins/relics/soul_prism.py
+++ b/backend/plugins/relics/soul_prism.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
 
 
@@ -12,3 +13,29 @@ class SoulPrism(RelicBase):
     name: str = "Soul Prism"
     stars: int = 5
     effects: dict[str, float] = field(default_factory=lambda: {"defense": 0.05, "mitigation": 0.05})
+
+    def apply(self, party) -> None:
+        """Revive fallen allies after battles with reduced Max HP."""
+        super().apply(party)
+
+        stacks = party.relics.count(self.id)
+        penalty = 0.75 - 0.05 * (stacks - 1)
+        multiplier = 1 - penalty
+        buff = 0.05 + 0.02 * (stacks - 1)
+
+        def _battle_end(entity) -> None:
+            from plugins.foes._base import FoeBase
+
+            if not isinstance(entity, FoeBase):
+                return
+            for member in party.members:
+                if member.hp > 0:
+                    continue
+                base = getattr(member, "_soul_prism_hp", member.max_hp)
+                member._soul_prism_hp = base
+                member.max_hp = int(base * multiplier)
+                member.hp = max(1, int(member.max_hp * 0.01))
+                member.defense = int(member.defense * (1 + buff))
+                member.mitigation *= 1 + buff
+
+        BUS.subscribe("battle_end", _battle_end)


### PR DESCRIPTION
## Summary
- implement Rusty Buckle HP bleed and Aftertaste triggers
- add Null Lantern combat buffs and pull rewards
- add Paradox Hourglass sacrifice mechanic and survivor buffs
- revive allies with Soul Prism
- add Omega Core burst buff with delayed HP drain
- include vitality and effect hit rate in Omega Core and Paradox Hourglass buffs

## Testing
- `uv run --project backend pytest backend/tests/test_relics.py`
- `uv run --project backend pytest` *(fails: KeyboardInterrupt after ~125s)*
- `uvx ruff check backend/plugins/relics/omega_core.py backend/plugins/relics/paradox_hourglass.py`


------
https://chatgpt.com/codex/tasks/task_b_68a6b6f22f30832cbaf83adf2a2ed71d