### PR TITLE
Add damage type action hooks

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -115,11 +115,19 @@ class EffectManager:
                 if callable(on_death):
                     on_death(others)
 
-    async def on_action(self) -> None:
+    async def on_action(self) -> bool:
+        """Run any per-action hooks on attached effects.
+
+        Returns ``False`` if any effect cancels the action.
+        """
+
         for eff in list(self.dots) + list(self.hots):
             handler = getattr(eff, "on_action", None)
             if callable(handler):
                 self._console.log(f"{self.stats.id} {eff.name} action")
                 result = handler(self.stats)
                 if hasattr(result, "__await"):
-                    await result
+                    result = await result
+                if result is False:
+                    return False
+        return True

--- a/backend/autofighter/rooms.py
+++ b/backend/autofighter/rooms.py
@@ -295,7 +295,13 @@ class BattleRoom(Room):
         party.rdr = combat_party.rdr
 
         foe_effects = EffectManager(foe)
-        party_effects = [EffectManager(m) for m in combat_party.members]
+        foe.effect_manager = foe_effects
+
+        party_effects = []
+        for member in combat_party.members:
+            mgr = EffectManager(member)
+            member.effect_manager = mgr
+            party_effects.append(mgr)
 
         registry.trigger("battle_start", foe)
         console.log(f"Battle start: {foe.id} vs {[m.id for m in combat_party.members]}")
@@ -343,7 +349,34 @@ class BattleRoom(Room):
                     if elapsed < 0.5:
                         await asyncio.sleep(0.5 - elapsed)
                     continue
-                await member_effect.on_action()
+                proceed = await member_effect.on_action()
+                if proceed:
+                    proceed = await member.base_damage_type.on_action(
+                        member,
+                        combat_party.members,
+                        [foe],
+                    )
+                if not proceed:
+                    registry.trigger("turn_end", member)
+                    if progress is not None:
+                        await progress(
+                            {
+                                "result": "battle",
+                                "party": [
+                                    _serialize(m) for m in combat_party.members
+                                ],
+                                "foes": [_serialize(foe)],
+                                "enrage": {
+                                    "active": enrage_active,
+                                    "stacks": enrage_stacks,
+                                },
+                                "rdr": party.rdr,
+                            }
+                        )
+                    elapsed = time.perf_counter() - turn_start
+                    if elapsed < 0.5:
+                        await asyncio.sleep(0.5 - elapsed)
+                    continue
                 dmg = await foe.apply_damage(member.atk, attacker=member)
                 console.log(
                     f"[light_red]{member.id} hits {foe.id} for {dmg}[/]"
@@ -426,7 +459,34 @@ class BattleRoom(Room):
                     if elapsed < 0.5:
                         await asyncio.sleep(0.5 - elapsed)
                     break
-                await foe_effects.on_action()
+                proceed = await foe_effects.on_action()
+                if proceed:
+                    proceed = await foe.base_damage_type.on_action(
+                        foe,
+                        [foe],
+                        combat_party.members,
+                    )
+                if not proceed:
+                    registry.trigger("turn_end", foe)
+                    if progress is not None:
+                        await progress(
+                            {
+                                "result": "battle",
+                                "party": [
+                                    _serialize(m) for m in combat_party.members
+                                ],
+                                "foes": [_serialize(foe)],
+                                "enrage": {
+                                    "active": enrage_active,
+                                    "stacks": enrage_stacks,
+                                },
+                                "rdr": party.rdr,
+                            }
+                        )
+                    elapsed = time.perf_counter() - turn_start
+                    if elapsed < 0.5:
+                        await asyncio.sleep(0.5 - elapsed)
+                    continue
                 dmg = await target.apply_damage(foe.atk, attacker=foe)
                 console.log(
                     f"[light_red]{foe.id} hits {target.id} for {dmg}[/]"

--- a/backend/plugins/damage_types/_base.py
+++ b/backend/plugins/damage_types/_base.py
@@ -32,6 +32,16 @@ class DamageTypeBase:
             return incoming_damage * 0.75
         return incoming_damage
 
+    async def on_action(
+        self, actor: "Stats", allies: list["Stats"], enemies: list["Stats"]
+    ) -> bool:
+        """Called before ``actor`` takes an action.
+
+        Return ``False`` to cancel the action.
+        """
+
+        return True
+
     # Event hooks -----------------------------------------------------------
 
     def on_hit(self, attacker: Stats, target: Stats) -> None:

--- a/backend/tests/test_damage_type_on_action.py
+++ b/backend/tests/test_damage_type_on_action.py
@@ -1,0 +1,60 @@
+import pytest
+
+from autofighter.party import Party
+from autofighter.rooms import BattleRoom
+from autofighter.stats import Stats
+from autofighter.mapgen import MapNode
+from plugins.damage_types._base import DamageTypeBase
+
+
+class CancelDamage(DamageTypeBase):
+    id = "Cancel"
+
+    async def on_action(self, actor, allies, enemies):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_player_damage_type_cancels_attack():
+    node = MapNode(
+        room_id=0,
+        room_type="battle-normal",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+    room = BattleRoom(node)
+    player = Stats(
+        hp=10,
+        max_hp=10,
+        defense=0,
+        atk=5,
+        base_damage_type=CancelDamage(),
+    )
+    player.id = "p1"
+    foe = Stats(hp=10, max_hp=10, atk=1000, defense=0)
+    foe.id = "f1"
+    party = Party(members=[player])
+    await room.resolve(party, {}, foe=foe)
+    assert foe.hp == foe.max_hp
+
+
+@pytest.mark.asyncio
+async def test_foe_damage_type_cancels_attack():
+    node = MapNode(
+        room_id=0,
+        room_type="battle-normal",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+    room = BattleRoom(node)
+    player = Stats(atk=1000, defense=0)
+    player.id = "p1"
+    foe = Stats(hp=10, max_hp=10, atk=5, defense=0, base_damage_type=CancelDamage())
+    foe.id = "f1"
+    party = Party(members=[player])
+    await room.resolve(party, {}, foe=foe)
+    assert player.hp == player.max_hp


### PR DESCRIPTION
## Summary
- allow damage types and effects to cancel actions via new `on_action` hook
- attach effect managers to stats and respect hook results in battle flow
- add tests for damage type action cancellation

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_68a72a748ddc832c9926fce5cb1e9dc8