### PR TITLE
[FEAT] add radiant regeneration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,8 +144,10 @@ DoT and HoT plugins manage ongoing damage or recovery. Supported DoTs include
 Bleed, Celestial Atrophy, Abyssal Corruption (spreads on death), Blazing
 Torment (extra tick on action), Cold Wound (five-stack cap), and Impact Echo
 (half of the last hit each turn). HoTs cover Regeneration, Player Echo, and
-Player Heal. Foes regenerate at one hundredth the player rate to prevent drawn
-out encounters.
+Player Heal. Light characters additionally apply a weak Radiant Regeneration
+HoT to all allies each action, and if an ally falls below a quarter of their
+health they prioritize a direct heal over attacking. Foes regenerate at one
+hundredth the player rate to prevent drawn-out encounters.
 
 ## Battle Room
 

--- a/backend/.codex/implementation/vitality-effects.md
+++ b/backend/.codex/implementation/vitality-effects.md
@@ -2,3 +2,6 @@
 
 - Direct healing and healing over time scale with both the healer's vitality and the target's vitality: `healing * healer_vitality * target_vitality`.
 - Damage over time uses the same vitality modifiers as direct damage; source vitality increases damage while target vitality reduces it with a minimum of 1 per tick.
+- Light damage type users grant all allies a stack of Radiant Regeneration
+  (5 HP over 2 turns) on each action and will directly heal allies under 25%
+  HP instead of attacking.

--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
 from plugins.damage_types._base import DamageTypeBase
+from plugins.hots.radiant_regeneration import RadiantRegeneration
 
 
 @dataclass
@@ -12,3 +13,12 @@ class Light(DamageTypeBase):
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         return DamageOverTime("Celestial Atrophy", int(damage * 0.3), 3, "light_dot", source)
+
+    async def on_action(self, actor, allies, enemies):
+        for ally in allies:
+            ally.effect_manager.add_hot(RadiantRegeneration())
+        for ally in allies:
+            if ally.hp > 0 and ally.hp / ally.max_hp < 0.25:
+                await ally.apply_healing(actor.atk, healer=actor)
+                return False
+        return True

--- a/backend/plugins/hots/radiant_regeneration.py
+++ b/backend/plugins/hots/radiant_regeneration.py
@@ -1,0 +1,9 @@
+from autofighter.effects import HealingOverTime
+
+
+class RadiantRegeneration(HealingOverTime):
+    plugin_type = "hot"
+    id = "radiant_regeneration"
+
+    def __init__(self, healing: int = 5, turns: int = 2) -> None:
+        super().__init__("Radiant Regeneration", healing, turns, self.id)

--- a/backend/tests/test_light_hot.py
+++ b/backend/tests/test_light_hot.py
@@ -1,0 +1,30 @@
+import pytest
+
+from autofighter.stats import Stats
+from autofighter.effects import EffectManager
+from plugins.damage_types.light import Light
+
+
+@pytest.mark.asyncio
+async def test_radiant_regeneration_stacks():
+    light = Light()
+    actor = Stats(base_damage_type=light)
+    ally = Stats()
+    actor.effect_manager = EffectManager(actor)
+    ally.effect_manager = EffectManager(ally)
+    await light.on_action(actor, [actor, ally], [])
+    await light.on_action(actor, [actor, ally], [])
+    stacks = [h for h in ally.effect_manager.hots if h.id == "radiant_regeneration"]
+    assert len(stacks) == 2
+
+
+@pytest.mark.asyncio
+async def test_light_heals_low_hp_ally():
+    light = Light()
+    actor = Stats(atk=50, base_damage_type=light)
+    ally = Stats(hp=20, max_hp=100)
+    actor.effect_manager = EffectManager(actor)
+    ally.effect_manager = EffectManager(ally)
+    proceed = await light.on_action(actor, [actor, ally], [])
+    assert ally.hp > 20
+    assert not proceed


### PR DESCRIPTION
## Summary
- add Radiant Regeneration HoT plugin
- Light applies Radiant Regeneration to allies and heals those below 25% HP
- document Light support behavior and add tests

## Testing
- `uv run pytest tests/test_light_hot.py`


------
https://chatgpt.com/codex/tasks/task_b_68a730865c78832cb6bdf30381dff475