### PR TITLE
Implement Lightning DoT pop mechanic

### DIFF
--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -48,6 +48,9 @@ adding the effect. The difference is clamped to zero and jittered by ±10%, and 
 
 Active effect names are mirrored in the `Stats` lists (`dots`, `hots`) for UI display. Plugins can extend base `DamageOverTime` and `HealingOverTime` classes to implement custom behavior or additional stat modifications.
 
+## Lightning Pop
+Lightning attacks trigger an extra pass over the target's active DoTs. Each effect deals 25% of its damage immediately while leaving remaining turns and stack counts untouched.
+
 ## Critical Boost
 Stackable effect granting +0.5% `crit_rate` and +5% `crit_damage` per stack. All stacks are removed when the affected unit takes damage.
 

--- a/.codex/instructions/damage-healing.md
+++ b/.codex/instructions/damage-healing.md
@@ -10,6 +10,7 @@ Combatants use the shared `Stats` dataclass from `autofighter/stats.py`. Integer
 - Triggers `on_action` hooks when the target acts, letting effects like *Blazing Torment* respond immediately.
 
 Plugins under `plugins/dots/` and `plugins/hots/` subclass the base effect classes to implement specific behaviors.
+Lightning damage pops all active DoTs on hit, applying 25% of each effect's damage immediately without reducing remaining turns.
 
 ## Supported DoTs
 - Bleed – deals 2% of Max HP each turn.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ allies each action, and if an ally falls below a quarter of their health they
 prioritize a direct heal over attacking. Foes regenerate at one hundredth the
 player rate to prevent drawn-out encounters. Wind attackers strike every remaining foe after
 their first hit, repeating the damage and rolling Gale Erosion on each target.
+Lightning hits pop every DoT on the target, dealing 25% of each effect's damage immediately while leaving the stacks intact.
 
 ## Battle Room
 

--- a/backend/plugins/damage_types/lightning.py
+++ b/backend/plugins/damage_types/lightning.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
@@ -12,3 +13,12 @@ class Lightning(DamageTypeBase):
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         return DamageOverTime("Charged Decay", int(damage * 0.25), 3, "lightning_dot", source)
+
+    def on_hit(self, attacker, target) -> None:
+        mgr = getattr(target, "effect_manager", None)
+        if mgr is None:
+            return
+        for effect in list(mgr.dots):
+            dmg = int(effect.damage * 0.25)
+            if dmg > 0:
+                asyncio.create_task(target.apply_damage(dmg, attacker=attacker))

--- a/backend/tests/test_lightning_pop.py
+++ b/backend/tests/test_lightning_pop.py
@@ -1,0 +1,37 @@
+import asyncio
+
+import pytest
+
+from autofighter.effects import DamageOverTime, EffectManager
+from autofighter.stats import Stats
+from plugins.damage_types.lightning import Lightning
+
+
+@pytest.mark.asyncio
+async def test_lightning_pop_damage_and_stacks():
+    lightning = Lightning()
+    attacker = Stats(atk=0, base_damage_type=lightning)
+    attacker.id = "attacker"
+    target = Stats(hp=100, max_hp=100, defense=1, mitigation=1.0, vitality=1.0)
+    target.id = "target"
+    target.effect_manager = EffectManager(target)
+
+    dot1 = DamageOverTime("Test", 40, 3, "t1", attacker)
+    dot2 = DamageOverTime("Test2", 20, 5, "t2", attacker)
+    target.effect_manager.add_dot(dot1)
+    target.effect_manager.add_dot(dot2)
+    initial_turns = [d.turns for d in target.effect_manager.dots]
+    initial_count = len(target.effect_manager.dots)
+    start_hp = target.hp
+
+    base = await target.apply_damage(0, attacker=attacker)
+    await asyncio.sleep(0)
+    dummy = Stats(hp=start_hp, max_hp=start_hp, defense=1, mitigation=1.0, vitality=1.0)
+    dummy.id = "dummy"
+    dmg1 = await dummy.apply_damage(int(dot1.damage * 0.25), attacker=attacker)
+    dummy.hp = start_hp
+    dmg2 = await dummy.apply_damage(int(dot2.damage * 0.25), attacker=attacker)
+    expected = max(start_hp - base - dmg1 - dmg2, 0)
+    assert target.hp == expected
+    assert [d.turns for d in target.effect_manager.dots] == initial_turns
+    assert len(target.effect_manager.dots) == initial_count


### PR DESCRIPTION
## Summary
- pop Lightning damage over time stacks for bonus damage without consuming them
- document Lightning's pop behavior

## Testing
- `uv run pytest tests/test_lightning_pop.py tests/test_effects.py`


------
https://chatgpt.com/codex/tasks/task_b_68a754d02ae4832c905b8276784b7c97