### PR TITLE
Scale Fire damage with missing HP

### DIFF
--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -23,7 +23,7 @@ normal rate to accelerate early progression. Level-ups increase core stats but
 no longer restore HP, preserving damage taken.
 
 `apply_damage()` and `apply_healing()` update `hp`, fire damage and healing hooks on the attacker and target damage types, and emit
-global `damage_taken`, `damage_dealt`, `heal_received`, and `heal` events on the repository-wide event bus.
+global `damage_taken`, `damage_dealt`, `heal_received`, and `heal` events on the repository-wide event bus. Fire's `on_damage` hook multiplies outgoing damage by `1 + (1 - hp/max_hp)`, doubling attacks at zero HP.
 
 ## Modifiers
 Stat changes may be applied in two ways:
@@ -37,7 +37,7 @@ Effects and passives mutate these fields directly. Percentage values are express
 `EffectManager` tracks `DamageOverTime` and `HealingOverTime` instances on a `Stats` object. Ticks call the target's damage type
 hooks so plugins can modify dot damage or hot healing globally. Damage types may also create new DoT effects when they land
 attacks via `maybe_inflict_dot`, which rolls the attacker's `effect_hit_rate` against the target's `effect_resistance` before
-adding the effect. The difference is clamped to zero and jittered by ±10%, and there is always at least a 1% chance to apply the status.
+adding the effect. The difference is clamped to zero and jittered by ±10%, and there is always at least a 1% chance to apply the status. Fire strikes apply the stackable Blazing Torment DoT, which gains an extra tick whenever the target acts.
 
 - `add_dot(effect, max_stacks=None)` – registers a DoT. Effects with the same
   ID stack independently, but a `max_stacks` cap can limit simultaneous copies.

--- a/.codex/instructions/damage-healing.md
+++ b/.codex/instructions/damage-healing.md
@@ -11,6 +11,7 @@ Combatants use the shared `Stats` dataclass from `autofighter/stats.py`. Integer
 
 Plugins under `plugins/dots/` and `plugins/hots/` subclass the base effect classes to implement specific behaviors.
 Lightning damage pops all active DoTs on hit, applying 25% of each effect's damage immediately without reducing remaining turns.
+Fire damage scales with missing HP, multiplying outgoing damage by `1 + (1 - hp/max_hp)` so attacks double at zero health.
 
 ## Supported DoTs
 - Bleed – deals 2% of Max HP each turn.
@@ -20,7 +21,7 @@ Lightning damage pops all active DoTs on hit, applying 25% of each effect's dama
 - Gale Erosion – strips Mitigation each tick.
 - Charged Decay – stuns on the final tick.
 - Frozen Wound – reduces Actions per Turn.
-- Blazing Torment – gains an extra tick whenever the target acts.
+- Blazing Torment – stackable and gains an extra tick whenever the target acts.
 - Cold Wound – stacks up to five times.
 - Twilight Decay – drains Vitality per tick.
 - Impact Echo – repeats 50% of the last damage taken for three turns.

--- a/README.md
+++ b/README.md
@@ -140,9 +140,10 @@ types.
 
 ## Damage and Healing Effects
 
+Fire attacks grow stronger as the attacker loses HP, doubling at zero health.
 DoT and HoT plugins manage ongoing damage or recovery. Supported DoTs include
 Bleed, Celestial Atrophy, Abyssal Corruption (spreads on death), Blazing
-Torment (extra tick on action), Cold Wound (five-stack cap), Impact Echo
+Torment (stacking, extra tick on action), Cold Wound (five-stack cap), Impact Echo
 (half of the last hit each turn), and Shadow Siphon. Shadow Siphon is applied by
 Dark characters to every party member on each action; stacks never expire and
 drain 5% of max HP per tick while granting the caster matching attack and

--- a/backend/plugins/damage_types/fire.py
+++ b/backend/plugins/damage_types/fire.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 
+from autofighter.stats import Stats
 from autofighter.effects import DamageOverTime
 from plugins.damage_types._base import DamageTypeBase
 
@@ -12,3 +13,9 @@ class Fire(DamageTypeBase):
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         return DamageOverTime("Blazing Torment", int(damage * 0.5), 3, "fire_dot", source)
+
+    def on_damage(self, damage: float, attacker: Stats, target: Stats) -> float:
+        if attacker.max_hp <= 0:
+            return damage
+        missing_ratio = 1 - (attacker.hp / attacker.max_hp)
+        return damage * (1 + missing_ratio)

--- a/backend/tests/test_effects.py
+++ b/backend/tests/test_effects.py
@@ -1,11 +1,11 @@
-import autofighter.effects as effects
-
 import pytest
 
-from autofighter.stats import Stats
-from plugins.event_bus import EventBus
+import autofighter.effects as effects
+
 from autofighter.effects import EffectManager
+from autofighter.stats import Stats
 from plugins.damage_types.fire import Fire
+from plugins.event_bus import EventBus
 
 
 def test_dot_applies_with_hit_rate():
@@ -16,7 +16,13 @@ def test_dot_applies_with_hit_rate():
     assert target.dots
 
 
-import pytest
+def test_blazing_torment_stacks():
+    attacker = Stats(atk=50, effect_hit_rate=2.0, base_damage_type=Fire())
+    target = Stats(effect_resistance=0.0)
+    manager = EffectManager(target)
+    manager.maybe_inflict_dot(attacker, 50)
+    manager.maybe_inflict_dot(attacker, 50)
+    assert target.dots.count("fire_dot") == 2
 
 
 @pytest.mark.asyncio
@@ -49,3 +55,4 @@ def test_dot_has_minimum_chance(monkeypatch):
     monkeypatch.setattr(effects.random, "random", lambda: 0.0)
     manager.maybe_inflict_dot(attacker, 10)
     assert target.dots
+

--- a/backend/tests/test_fire_damage_scaling.py
+++ b/backend/tests/test_fire_damage_scaling.py
@@ -1,0 +1,21 @@
+import pytest
+
+from autofighter.stats import Stats
+from plugins.damage_types.fire import Fire
+
+
+@pytest.mark.asyncio
+async def test_fire_damage_increases_as_hp_drops():
+    attacker = Stats(defense=0, base_damage_type=Fire())
+    target_full = Stats(defense=0)
+    dmg_full = await target_full.apply_damage(100, attacker)
+
+    attacker.hp = attacker.max_hp // 2
+    target_half = Stats(defense=0)
+    dmg_half = await target_half.apply_damage(100, attacker)
+
+    attacker.hp = 1
+    target_low = Stats(defense=0)
+    dmg_low = await target_low.apply_damage(100, attacker)
+
+    assert dmg_full < dmg_half < dmg_low


### PR DESCRIPTION
## Summary
- boost Fire damage as HP drops via new `on_damage` hook
- document Fire's scaling and Blazing Torment stacking
- test Fire damage scaling and Blazing Torment stack behavior

## Testing
- `uv run ruff check plugins/damage_types/fire.py tests/test_fire_damage_scaling.py tests/test_effects.py`
- `uv run pytest` *(incomplete: KeyboardInterrupt after some tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a7575c4648832c84406186f1f8ec45