### PR TITLE
feat: instantiate damage types in fighters

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -1,5 +1,9 @@
 # Player and Foe Reference
 
+Player and Foe base classes assign a random damage type when one is not
+provided, and battle rooms respect these preset elements without selecting new
+types.
+
 ## Player Roster
 All legacy characters from the Pygame version have been ported as plugins.
 Each entry notes the character's `CharacterType` and starting damage type.

--- a/backend/README.md
+++ b/backend/README.md
@@ -29,6 +29,9 @@ names. Run state is stored through the `SaveManager` in `backend/save.db` by
 default; `compose.yaml` bind-mounts the `backend/` directory so the database is
 persisted on the host.
 
+Player and foe base classes assign a random damage type when none is
+specified, and battles respect these preset elements without rolling new ones.
+
 Battle resolution awards experience to all party members. Characters below
 level 1000 receive a 10× boost to earned experience, and level-ups are synced
 back to the run along with updated stats.

--- a/backend/plugins/damage_types/__init__.py
+++ b/backend/plugins/damage_types/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 from random import choice
+from importlib import import_module
+
+from plugins.damage_types._base import DamageTypeBase
 
 ALL_DAMAGE_TYPES = [
     "Light",
@@ -12,15 +15,36 @@ ALL_DAMAGE_TYPES = [
 ]
 
 
-def random_damage_type() -> str:
-    return choice(ALL_DAMAGE_TYPES)
+def _load_cls(name: str) -> type[DamageTypeBase]:
+    try:
+        module = import_module(f"plugins.damage_types.{name.lower()}")
+        return getattr(module, name)
+    except Exception:
+        module = import_module("plugins.damage_types.generic")
+        return getattr(module, "Generic")
 
 
-def get_damage_type(name: str) -> str:
+def random_damage_type() -> DamageTypeBase:
+    return _load_cls(choice(ALL_DAMAGE_TYPES))()
+
+
+def get_damage_type(name: str) -> DamageTypeBase:
     lowered = name.lower()
     if "luna" in lowered:
-        return "Generic"
+        return _load_cls("Generic")()
     matches = [dtype for dtype in ALL_DAMAGE_TYPES if dtype.lower() in lowered]
     if matches:
-        return choice(matches)
+        return _load_cls(choice(matches))()
     return random_damage_type()
+
+
+def load_damage_type(name: str) -> DamageTypeBase:
+    return _load_cls(name)()
+
+
+__all__ = [
+    "ALL_DAMAGE_TYPES",
+    "random_damage_type",
+    "get_damage_type",
+    "load_damage_type",
+]

--- a/backend/plugins/damage_types/dark.py
+++ b/backend/plugins/damage_types/dark.py
@@ -9,9 +9,9 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Dark(DamageTypeBase):
-    id = "Dark"
-    weakness = "Light"
-    color = (145, 0, 145)
+    id: str = "Dark"
+    weakness: str = "Light"
+    color: tuple[int, int, int] = (145, 0, 145)
 
     _cleanup_registered: bool = False
 

--- a/backend/plugins/damage_types/fire.py
+++ b/backend/plugins/damage_types/fire.py
@@ -8,9 +8,9 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Fire(DamageTypeBase):
-    id = "Fire"
-    weakness = "Ice"
-    color = (255, 0, 0)
+    id: str = "Fire"
+    weakness: str = "Ice"
+    color: tuple[int, int, int] = (255, 0, 0)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         dot = BlazingTorment(int(damage * 0.5), 3)

--- a/backend/plugins/damage_types/generic.py
+++ b/backend/plugins/damage_types/generic.py
@@ -5,6 +5,6 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Generic(DamageTypeBase):
-    id = "Generic"
-    weakness = "none"
-    color = (255, 255, 255)
+    id: str = "Generic"
+    weakness: str = "none"
+    color: tuple[int, int, int] = (255, 255, 255)

--- a/backend/plugins/damage_types/ice.py
+++ b/backend/plugins/damage_types/ice.py
@@ -7,9 +7,9 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Ice(DamageTypeBase):
-    id = "Ice"
-    weakness = "Fire"
-    color = (0, 255, 255)
+    id: str = "Ice"
+    weakness: str = "Fire"
+    color: tuple[int, int, int] = (0, 255, 255)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         dot = FrozenWound(int(damage * 0.25), 3)

--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -8,9 +8,9 @@ from plugins.hots.radiant_regeneration import RadiantRegeneration
 
 @dataclass
 class Light(DamageTypeBase):
-    id = "Light"
-    weakness = "Dark"
-    color = (255, 255, 255)
+    id: str = "Light"
+    weakness: str = "Dark"
+    color: tuple[int, int, int] = (255, 255, 255)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         dot = CelestialAtrophy(int(damage * 0.3), 3)

--- a/backend/plugins/damage_types/lightning.py
+++ b/backend/plugins/damage_types/lightning.py
@@ -8,9 +8,9 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Lightning(DamageTypeBase):
-    id = "Lightning"
-    weakness = "Wind"
-    color = (255, 255, 0)
+    id: str = "Lightning"
+    weakness: str = "Wind"
+    color: tuple[int, int, int] = (255, 255, 0)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         dot = ChargedDecay(int(damage * 0.25), 3)

--- a/backend/plugins/damage_types/wind.py
+++ b/backend/plugins/damage_types/wind.py
@@ -7,9 +7,9 @@ from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class Wind(DamageTypeBase):
-    id = "Wind"
-    weakness = "Lightning"
-    color = (0, 255, 0)
+    id: str = "Wind"
+    weakness: str = "Lightning"
+    color: tuple[int, int, int] = (0, 255, 0)
 
     def create_dot(self, damage: float, source) -> DamageOverTime | None:
         dot = GaleErosion(int(damage * 0.25), 3)

--- a/backend/plugins/foes/_base.py
+++ b/backend/plugins/foes/_base.py
@@ -5,6 +5,8 @@ from dataclasses import field
 
 from autofighter.stats import Stats
 from autofighter.character import CharacterType
+from plugins.damage_types import random_damage_type
+from plugins.damage_types._base import DamageTypeBase
 
 
 @dataclass
@@ -28,6 +30,7 @@ class FoeBase(Stats):
     crit_rate: float = 0.05
     crit_damage: float = 2
     effect_hit_rate: float = 0.01
+    damage_type: DamageTypeBase = field(default_factory=random_damage_type)
 
     mitigation: float = 0.001
     regain: int = 1

--- a/backend/plugins/foes/slime.py
+++ b/backend/plugins/foes/slime.py
@@ -1,6 +1,9 @@
-from dataclasses import fields
 from dataclasses import dataclass
+from dataclasses import field
+from dataclasses import fields
 
+from plugins.damage_types import random_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.foes._base import FoeBase
 
 
@@ -10,10 +13,10 @@ class Slime(FoeBase):
     name = "Slime"
     prompt: str = "Foe prompt placeholder"
     about: str = "Foe description placeholder"
+    damage_type: DamageTypeBase = field(default_factory=random_damage_type)
 
     def __post_init__(self) -> None:  # noqa: D401 - short init
-        super().__post_init__()
-        for field in fields(FoeBase):
-            value = getattr(self, field.name)
+        for f in fields(FoeBase):
+            value = getattr(self, f.name)
             if isinstance(value, (int, float)):
-                setattr(self, field.name, type(value)(value * 0.1))
+                setattr(self, f.name, type(value)(value * 0.1))

--- a/backend/plugins/players/_base.py
+++ b/backend/plugins/players/_base.py
@@ -5,6 +5,8 @@ from dataclasses import field
 
 from autofighter.stats import Stats
 from autofighter.character import CharacterType
+from plugins.damage_types import random_damage_type
+from plugins.damage_types._base import DamageTypeBase
 
 @dataclass
 class PlayerBase(Stats):
@@ -26,6 +28,7 @@ class PlayerBase(Stats):
     crit_rate: float = 0.05
     crit_damage: float = 2
     effect_hit_rate: float = 0.01
+    damage_type: DamageTypeBase = field(default_factory=random_damage_type)
 
     mitigation: int = 100
     regain: int = 1

--- a/backend/plugins/players/ally.py
+++ b/backend/plugins/players/ally.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class Ally(PlayerBase):
     name = "Ally"
     char_type = CharacterType.B
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("Ally"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Ally")
+    )

--- a/backend/plugins/players/becca.py
+++ b/backend/plugins/players/becca.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class Becca(PlayerBase):
     name = "Becca"
     char_type = CharacterType.B
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("Becca"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Becca")
+    )

--- a/backend/plugins/players/bubbles.py
+++ b/backend/plugins/players/bubbles.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class Bubbles(PlayerBase):
     name = "Bubbles"
     char_type = CharacterType.A
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("Bubbles"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Bubbles")
+    )

--- a/backend/plugins/players/carly.py
+++ b/backend/plugins/players/carly.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
+from dataclasses import field
 
 from autofighter.character import CharacterType
+from plugins.damage_types.light import Light
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -9,5 +12,5 @@ class Carly(PlayerBase):
     name = "Carly"
     char_type = CharacterType.B
     gacha_rarity = 5
-    damage_type: str = "Light"
+    damage_type: DamageTypeBase = field(default_factory=Light)
 

--- a/backend/plugins/players/chibi.py
+++ b/backend/plugins/players/chibi.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class Chibi(PlayerBase):
     name = "Chibi"
     char_type = CharacterType.A
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("Chibi"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Chibi")
+    )

--- a/backend/plugins/players/graygray.py
+++ b/backend/plugins/players/graygray.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class Graygray(PlayerBase):
     name = "Graygray"
     char_type = CharacterType.B
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("Graygray"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Graygray")
+    )

--- a/backend/plugins/players/hilander.py
+++ b/backend/plugins/players/hilander.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class Hilander(PlayerBase):
     name = "Hilander"
     char_type = CharacterType.A
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("Hilander"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Hilander")
+    )

--- a/backend/plugins/players/kboshi.py
+++ b/backend/plugins/players/kboshi.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class Kboshi(PlayerBase):
     name = "Kboshi"
     char_type = CharacterType.A
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("Kboshi"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Kboshi")
+    )

--- a/backend/plugins/players/lady_darkness.py
+++ b/backend/plugins/players/lady_darkness.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types.dark import Dark
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,4 @@ class LadyDarkness(PlayerBase):
     name = "LadyDarkness"
     char_type = CharacterType.B
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("LadyDarkness"))
+    damage_type: DamageTypeBase = field(default_factory=Dark)

--- a/backend/plugins/players/lady_echo.py
+++ b/backend/plugins/players/lady_echo.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
+from dataclasses import field
 
 from autofighter.character import CharacterType
+from plugins.damage_types.lightning import Lightning
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -9,5 +12,5 @@ class LadyEcho(PlayerBase):
     name = "LadyEcho"
     char_type = CharacterType.B
     gacha_rarity = 5
-    damage_type: str = "Lightning"
+    damage_type: DamageTypeBase = field(default_factory=Lightning)
 

--- a/backend/plugins/players/lady_fire_and_ice.py
+++ b/backend/plugins/players/lady_fire_and_ice.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class LadyFireAndIce(PlayerBase):
     name = "LadyFireAndIce"
     char_type = CharacterType.B
     gacha_rarity = 6
-    damage_type: str = field(default_factory=lambda: get_damage_type("LadyFireAndIce"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("LadyFireAndIce")
+    )

--- a/backend/plugins/players/lady_light.py
+++ b/backend/plugins/players/lady_light.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types.light import Light
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,4 @@ class LadyLight(PlayerBase):
     name = "LadyLight"
     char_type = CharacterType.B
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("LadyLight"))
+    damage_type: DamageTypeBase = field(default_factory=Light)

--- a/backend/plugins/players/lady_of_fire.py
+++ b/backend/plugins/players/lady_of_fire.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types.fire import Fire
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -10,4 +11,4 @@ class LadyOfFire(PlayerBase):
     id = "lady_of_fire"
     name = "LadyOfFire"
     char_type = CharacterType.B
-    damage_type: str = field(default_factory=lambda: get_damage_type("LadyOfFire"))
+    damage_type: DamageTypeBase = field(default_factory=Fire)

--- a/backend/plugins/players/luna.py
+++ b/backend/plugins/players/luna.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -10,4 +11,6 @@ class Luna(PlayerBase):
     id = "luna"
     name = "Luna"
     char_type = CharacterType.B
-    damage_type: str = field(default_factory=lambda: get_damage_type("Luna"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Luna")
+    )

--- a/backend/plugins/players/mezzy.py
+++ b/backend/plugins/players/mezzy.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class Mezzy(PlayerBase):
     name = "Mezzy"
     char_type = CharacterType.B
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("Mezzy"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Mezzy")
+    )

--- a/backend/plugins/players/mimic.py
+++ b/backend/plugins/players/mimic.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass
 from dataclasses import field
 
-from plugins.damage_types import get_damage_type
 from autofighter.character import CharacterType
+from plugins.damage_types import get_damage_type
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -11,4 +12,6 @@ class Mimic(PlayerBase):
     name = "Mimic"
     char_type = CharacterType.C
     gacha_rarity = 5
-    damage_type: str = field(default_factory=lambda: get_damage_type("Mimic"))
+    damage_type: DamageTypeBase = field(
+        default_factory=lambda: get_damage_type("Mimic")
+    )

--- a/backend/plugins/players/player.py
+++ b/backend/plugins/players/player.py
@@ -1,6 +1,9 @@
 from dataclasses import dataclass
+from dataclasses import field
 
 from autofighter.character import CharacterType
+from plugins.damage_types.fire import Fire
+from plugins.damage_types._base import DamageTypeBase
 from plugins.players._base import PlayerBase
 
 @dataclass
@@ -8,6 +11,6 @@ class Player(PlayerBase):
     id = "player"
     name = "Player"
     char_type = CharacterType.C
-    damage_type: str = "Fire"
+    damage_type: DamageTypeBase = field(default_factory=Fire)
     prompt: str = "Player prompt placeholder"
     about: str = "Player description placeholder"

--- a/backend/tests/test_damage_type_assignment.py
+++ b/backend/tests/test_damage_type_assignment.py
@@ -1,0 +1,43 @@
+import random
+import pytest
+
+from autofighter.party import Party
+from autofighter.mapgen import MapNode
+from autofighter.rooms import BattleRoom
+from plugins.foes._base import FoeBase
+from plugins.foes.slime import Slime
+from plugins.players._base import PlayerBase
+from plugins.players.carly import Carly
+from plugins.damage_types._base import DamageTypeBase
+
+
+def test_base_classes_assign_damage_type() -> None:
+    random.seed(0)
+    player = PlayerBase()
+    foe = FoeBase()
+    assert isinstance(player.damage_type, DamageTypeBase)
+    assert isinstance(foe.damage_type, DamageTypeBase)
+
+
+def test_plugin_overrides_damage_type() -> None:
+    carly = Carly()
+    assert carly.damage_type.id == "Light"
+
+
+@pytest.mark.asyncio
+async def test_battle_uses_preset_damage_types() -> None:
+    node = MapNode(
+        room_id=0,
+        room_type="battle-normal",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+    room = BattleRoom(node)
+    player = Carly()
+    foe = Slime()
+    party = Party(members=[player])
+    await room.resolve(party, {}, foe=foe)
+    assert player.damage_type.id == "Light"
+    assert isinstance(foe.damage_type, DamageTypeBase)

--- a/backend/tests/test_player_editor.py
+++ b/backend/tests/test_player_editor.py
@@ -120,6 +120,6 @@ async def test_player_editor_snapshot_during_run(app_with_db):
 
     party = app_module.load_party(run_id)
     player = next(m for m in party.members if m.id == "player")
-    assert player.damage_type == "Fire"
+    assert player.element_id == "Fire"
     assert player.atk == 100
     assert player.max_hp == 1100


### PR DESCRIPTION
## Summary
- move default damage-type randomization into player and foe bases
- drop damage-type overrides from battle rooms
- document element handling and stop battle-room selection

## Testing
- `uv run ruff check plugins/damage_types/__init__.py plugins/players/_base.py plugins/foes/_base.py plugins/players/ally.py plugins/players/becca.py plugins/players/bubbles.py plugins/players/chibi.py plugins/players/graygray.py plugins/players/hilander.py plugins/players/kboshi.py plugins/players/lady_darkness.py plugins/players/lady_echo.py plugins/players/lady_fire_and_ice.py plugins/players/lady_light.py plugins/players/lady_of_fire.py plugins/players/luna.py plugins/players/mezzy.py plugins/players/mimic.py plugins/players/player.py plugins/foes/slime.py autofighter/rooms.py app.py tests/test_player_editor.py tests/test_damage_type_assignment.py`
- `uv run pytest tests/test_damage_type_assignment.py -q`
- `uv run pytest -q` *(KeyboardInterrupt: test run aborted after ~165s)*

------
https://chatgpt.com/codex/tasks/task_b_68a8ad4ee240832cba224de2d289d700