### PR TITLE
fix: route run helpers through runApi

### DIFF
--- a/frontend/src/lib/BattleView.svelte
+++ b/frontend/src/lib/BattleView.svelte
@@ -1,6 +1,6 @@
 <script>
   import { onMount, onDestroy, createEventDispatcher } from 'svelte';
-  import { roomAction } from './api.js';
+  import { roomAction } from '$lib';
   import { getRandomBackground } from './assetLoader.js';
   import FighterPortrait from './battle/FighterPortrait.svelte';
   import EnrageIndicator from './battle/EnrageIndicator.svelte';

--- a/frontend/src/lib/index.js
+++ b/frontend/src/lib/index.js
@@ -21,7 +21,7 @@ export {
   roomAction,
   chooseCard,
   chooseRelic
-} from './api.js';
+} from './runApi.js';
 export { default as NavBar } from './NavBar.svelte';
 export { default as OverlayHost } from './OverlayHost.svelte';
 export {


### PR DESCRIPTION
## Summary
- export run helpers from `runApi.js` so `$lib` exposes `roomAction` and related functions
- update `BattleView.svelte` to pull `roomAction` from `$lib`

## Testing
- `bun test`
- `bun run build` *(fails: process hung after warnings)*
- `./run-tests.sh` *(fails: AttributeError: '<module 'app' ...> has no attribute '_scale_stats')`

------
https://chatgpt.com/codex/tasks/task_b_68a8d0e5ae44832cb0fa0c0010c2581f