### PR TITLE
[FEAT] Introduce queued logging with periodic flush

### DIFF
--- a/backend/.codex/implementation/logging-config.md
+++ b/backend/.codex/implementation/logging-config.md
@@ -1,0 +1,10 @@
+# Logging Configuration
+
+`configure_logging()` establishes a queued logging pipeline for the backend. A
+`QueueHandler` forwards records to a `QueueListener` which writes to a rotating
+file handler stored under `backend/logs/backend.log`.
+
+The file handler is wrapped in a timed memory buffer so log records are flushed
+to disk roughly every 15 seconds. A `RichHandler` remains attached to the root
+logger for colorful console output while the file handler receives buffered
+records.

--- a/backend/README.md
+++ b/backend/README.md
@@ -13,6 +13,10 @@ uv sync
 uv run app.py
 ```
 
+## Logging
+
+Logs write to `logs/backend.log` using a buffered rotating file handler. The buffer flushes roughly every 15 seconds and a Rich handler keeps console output colorful.
+
 The root endpoint returns a simple status payload including the configured flavor. Set `UV_EXTRA` (default `"default"`) to label this instance. Additional routes support
 starting runs with a seeded 45-room map, updating the party, retrieving floor
 maps, listing available player characters, returning room background images,

--- a/backend/app.py
+++ b/backend/app.py
@@ -4,19 +4,9 @@ import os
 import logging
 import traceback
 
-from pathlib import Path
-from logging.handlers import RotatingFileHandler
-
 from quart import Quart
 from quart import jsonify
 from quart import request
-
-from routes.runs import bp as runs_bp
-from routes.gacha import bp as gacha_bp
-from routes.rooms import bp as rooms_bp
-from routes.assets import bp as assets_bp
-from routes.players import bp as players_bp
-from routes.rewards import bp as rewards_bp
 
 from game import FERNET  # noqa: F401
 from game import GachaManager  # noqa: F401  # re-export for tests
@@ -33,20 +23,15 @@ from game import load_map  # noqa: F401
 from game import load_party  # noqa: F401
 from game import save_map  # noqa: F401
 from game import save_party  # noqa: F401
+from routes.runs import bp as runs_bp
+from routes.gacha import bp as gacha_bp
+from routes.rooms import bp as rooms_bp
+from routes.assets import bp as assets_bp
+from logging_config import configure_logging
+from routes.players import bp as players_bp
+from routes.rewards import bp as rewards_bp
 
-LOG_DIR = Path(__file__).resolve().parent / "logs"
-LOG_DIR.mkdir(exist_ok=True)
-
-file_handler = RotatingFileHandler(
-    LOG_DIR / "backend.log", maxBytes=1_048_576, backupCount=5
-)
-file_handler.setFormatter(
-    logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
-)
-
-root_logger = logging.getLogger()
-root_logger.setLevel(logging.INFO)
-root_logger.addHandler(file_handler)
+configure_logging()
 
 log = logging.getLogger(__name__)
 

--- a/backend/logging_config.py
+++ b/backend/logging_config.py
@@ -1,0 +1,65 @@
+import queue
+import logging
+import threading
+
+from pathlib import Path
+from logging.handlers import QueueHandler
+from logging.handlers import MemoryHandler
+from logging.handlers import QueueListener
+from logging.handlers import RotatingFileHandler
+
+from rich.logging import RichHandler
+
+
+class TimedMemoryHandler(MemoryHandler):
+    def __init__(self, capacity: int, target: logging.Handler, flush_interval: float = 15.0) -> None:
+        super().__init__(capacity, target=target, flushLevel=logging.CRITICAL + 1)
+        self.flush_interval = flush_interval
+        self._timer = threading.Timer(self.flush_interval, self._flush)
+        self._timer.daemon = True
+        self._timer.start()
+
+    def _flush(self) -> None:
+        try:
+            super().flush()
+        finally:
+            self._timer = threading.Timer(self.flush_interval, self._flush)
+            self._timer.daemon = True
+            self._timer.start()
+
+    def close(self) -> None:
+        self._timer.cancel()
+        super().flush()
+        super().close()
+
+
+def configure_logging() -> QueueListener:
+    log_dir = Path(__file__).resolve().parent / "logs"
+    log_dir.mkdir(exist_ok=True)
+
+    log_queue: queue.Queue[logging.LogRecord] = queue.Queue()
+
+    file_handler = RotatingFileHandler(
+        log_dir / "backend.log", maxBytes=1_048_576, backupCount=5, delay=True
+    )
+    file_handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    )
+
+    buffer_handler = TimedMemoryHandler(1024, file_handler)
+
+    listener = QueueListener(log_queue, buffer_handler)
+    listener.start()
+
+    queue_handler = QueueHandler(log_queue)
+
+    console_handler = RichHandler(rich_tracebacks=True)
+    console_handler.setFormatter(logging.Formatter("%(message)s"))
+
+    root = logging.getLogger()
+    root.setLevel(logging.INFO)
+    root.handlers.clear()
+    root.addHandler(queue_handler)
+    root.addHandler(console_handler)
+
+    return listener


### PR DESCRIPTION
## Summary
- add `configure_logging` to queue logs and buffer writes before rotating to disk
- integrate new logging setup in app startup and expose Rich console handler
- document logging pipeline and buffered behavior

## Testing
- `uv run ruff check app.py logging_config.py`
- `uv run pytest` *(fails: TypeError 'NoneType' object is not subscriptable, KeyError 'map', KeyError <uuid>, AssertionError None == 1)*

------
https://chatgpt.com/codex/tasks/task_b_68ac252f6e04832ca1c5d3a019b1bf5a