### PR TITLE
fix: update AUR PKGBUILD to use uv and bun

### DIFF
--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -2,8 +2,8 @@ pkgname=autofighter-git
 pkgver=1.0
 pkgrel=1
 arch=('any')
-depends=('python' 'nodejs')
-source=('git+https://github.com/Midori-AI/Midori-AI-AutoFighter.git')
+depends=('uv' 'bun')
+source=('git+https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter.git')
 md5sums=('SKIP')
 
 pkgver() {


### PR DESCRIPTION
## Summary
- fix AUR PKGBUILD to depend on uv and bun
- point source to Midori-AI-OSS repository

## Testing
- `ruff check . --fix`
- `./run-tests.sh` *(fails: multiple backend tests failed or timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68af20f52740832cbe9d98bfdf22ad04