### PR TITLE
docs: update player customization docs

### DIFF
--- a/.codex/implementation/player-customization.md
+++ b/.codex/implementation/player-customization.md
@@ -23,22 +23,12 @@ Player customization is applied during character instantiation rather than as te
 - Each customization point provides a 1% multiplier applied once during instantiation
 - This ensures stats remain stable across save/load cycles
 
-### Backwards Compatibility  
-- The `_apply_player_customization()` function now skips the base player (id="player") since customization is built-in
-- Saved effects from older versions are still handled for backwards compatibility
-- Old custom multiplier data is automatically removed from save files to prevent conflicts
-
 ### Save System Integration
-- Player saves no longer store custom multipliers since customization is now permanent
-- Only damage type and other non-stat data are preserved across save/load cycles
-- This prevents the exponential stat growth that occurred when mods were reapplied on each load
+- Player saves store damage type and other non-stat data; stat multipliers are applied once during instantiation and not persisted
+- This approach keeps stats stable across save and load cycles
 
 ## Persistence notes
 
-Earlier builds lost stat allocations because the editor saved `damage` and
-string-valued stats, causing the backend to ignore the update and return zeros
-on the next load. The component now dispatches numeric `hp`, `attack`, and
-`defense` values alongside a `damageType` field that the page converts to the
-API's `damage_type` key, so edited stats persist after saving and reloading.
+The component dispatches numeric `hp`, `attack`, and `defense` values alongside a `damageType` field that the page converts to the API's `damage_type` key, so edited stats persist after saving and reloading.
 
-The current implementation permanently applies customization during player instantiation, ensuring consistent stats while maintaining all editor functionality.
+Customization is applied during player instantiation, ensuring consistent stats while maintaining all editor functionality.

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -7,7 +7,6 @@ import copy
 from dataclasses import dataclass
 import logging
 import random
-import time
 from typing import Any
 
 from autofighter.cards import apply_cards
@@ -241,7 +240,6 @@ class BattleRoom(Room):
                 else:
                     # Not enraged yet; ensure percent is zero
                     set_enrage_percent(0.0)
-                turn_start = time.perf_counter()
                 await registry.trigger("turn_start", member)
                 log.debug("%s turn start", member.id)
                 await member.maybe_regain(turn)
@@ -258,7 +256,6 @@ class BattleRoom(Room):
                 await member_effect.tick(tgt_mgr)
                 if member.hp <= 0:
                     await registry.trigger("turn_end", member)
-                    elapsed = time.perf_counter() - turn_start
                     await asyncio.sleep(0.001)
                     continue
                 proceed = await member_effect.on_action()
@@ -286,7 +283,6 @@ class BattleRoom(Room):
                                 "rdr": party.rdr,
                             }
                         )
-                    elapsed = time.perf_counter() - turn_start
                     await asyncio.sleep(0.001)
                     continue
                 dmg = await tgt_foe.apply_damage(member.atk, attacker=member)
@@ -378,7 +374,6 @@ class BattleRoom(Room):
                                 m.exp_multiplier += 0.025
                     except Exception:
                         pass
-                    elapsed = time.perf_counter() - turn_start
                     await asyncio.sleep(0.001)
                     if all(f.hp <= 0 for f in foes):
                         break
@@ -428,7 +423,6 @@ class BattleRoom(Room):
                     proceed = True if res is None else bool(res)
                 if not proceed:
                     await registry.trigger("turn_end", acting_foe)
-                    elapsed = time.perf_counter() - turn_start
                     await asyncio.sleep(0.001)
                     await asyncio.sleep(0.001)
                     continue
@@ -439,7 +433,6 @@ class BattleRoom(Room):
                     log.info("%s hits %s for %s", acting_foe.id, target.id, dmg)
                 target_effect.maybe_inflict_dot(acting_foe, dmg)
                 await registry.trigger("turn_end", acting_foe)
-                elapsed = time.perf_counter() - turn_start
                 await asyncio.sleep(0.001)
         # Signal completion as soon as the loop ends to help UIs stop polling
         # immediately, even before rewards are fully computed.


### PR DESCRIPTION
## Summary
- drop backward compatibility section from player customization docs
- clean up unused timing logic in battle room

## Testing
- `ruff check backend/autofighter/rooms/battle.py`
- `bash run-tests.sh` *(fails: async def functions are not supported, missing modules, database tables)*

------
https://chatgpt.com/codex/tasks/task_b_68b08421f234832c915c521dcbb858ca