### PR TITLE
Add tabbed Settings menu with icon navigation

### DIFF
--- a/frontend/.codex/implementation/settings-menu.md
+++ b/frontend/.codex/implementation/settings-menu.md
@@ -1,9 +1,15 @@
 # Settings Menu
 
-The settings overlay exposes audio, system, and gameplay options.
+The settings overlay now uses a tabbed layout with icon-only buttons
+for each category:
 
-- `SettingsMenu.svelte` receives `backendFlavor` from the page and
-  checks it for `"llm"` to decide whether language reasoning model
-  controls should appear.
-- When the flavor string omits `"llm"`, the component skips
-  `getLrmConfig()` and hides the LRM model selector and test button.
+- **Audio**: `Volume2` icon.
+- **System**: `Cog` icon.
+- **LLM**: `Brain` icon, shown only when language model controls are
+  available.
+- **Gameplay**: `Gamepad` icon.
+
+`SettingsMenu.svelte` receives `backendFlavor` from the page and
+checks it for `"llm"` to decide whether the LLM tab should appear. When
+the flavor string omits `"llm"`, the component skips `getLrmConfig()`
+and hides the model selector and test button.

--- a/frontend/src/lib/OverlayHost.svelte
+++ b/frontend/src/lib/OverlayHost.svelte
@@ -162,7 +162,7 @@
 {/if}
 
 {#if $overlayView === 'settings'}
-  <PopupWindow title="Settings" zIndex={1300} on:close={() => dispatch('back')}>
+  <PopupWindow title="Settings" maxWidth="960px" maxHeight="90vh" zIndex={1300} on:close={() => dispatch('back')}>
     <SettingsMenu
       {sfxVolume}
       {musicVolume}

--- a/frontend/src/lib/SettingsMenu.svelte
+++ b/frontend/src/lib/SettingsMenu.svelte
@@ -1,6 +1,17 @@
 <script>
   import { createEventDispatcher, onMount } from 'svelte';
-  import { Volume2, Music, Mic, Power, Trash2, Download, Upload } from 'lucide-svelte';
+  import {
+    Volume2,
+    Music,
+    Mic,
+    Power,
+    Trash2,
+    Download,
+    Upload,
+    Cog,
+    Brain,
+    Gamepad
+  } from 'lucide-svelte';
   import { endRun, wipeData, exportSave, importSave, setAutoCraft, getGacha, getLrmConfig, setLrmModel, testLrmModel } from './api.js';
   import { saveSettings, clearSettings, clearAllClientData } from './settingsStorage.js';
 
@@ -23,6 +34,8 @@
   let resetTimeout;
   let lrmOptions = [];
   let testReply = '';
+
+  let activeTab = 'audio';
 
   // Keep autocraft in sync with backend flag so this toggle
   // mirrors the Crafting menu's auto-craft behavior.
@@ -162,10 +175,26 @@
   }
 </script>
 
-<div data-testid="settings-menu">
-  <div class="cols">
-    <div class="col">
-      <h4>Audio</h4>
+<div data-testid="settings-menu" class="tabbed">
+  <div class="tabs">
+    <button class:active={activeTab === 'audio'} on:click={() => (activeTab = 'audio')} title="Audio">
+      <Volume2 />
+    </button>
+    <button class:active={activeTab === 'system'} on:click={() => (activeTab = 'system')} title="System">
+      <Cog />
+    </button>
+    {#if showLrm}
+      <button class:active={activeTab === 'llm'} on:click={() => (activeTab = 'llm')} title="LLM">
+        <Brain />
+      </button>
+    {/if}
+    <button class:active={activeTab === 'gameplay'} on:click={() => (activeTab = 'gameplay')} title="Gameplay">
+      <Gamepad />
+    </button>
+  </div>
+
+  {#if activeTab === 'audio'}
+    <div class="panel">
       <div class="control" title="Adjust sound effect volume.">
         <Volume2 />
         <label>SFX Volume</label>
@@ -182,8 +211,8 @@
         <input type="range" min="0" max="100" bind:value={voiceVolume} on:input={scheduleSave} />
       </div>
     </div>
-    <div class="col">
-      <h4>System</h4>
+  {:else if activeTab === 'system'}
+    <div class="panel">
       <div class="control" title="Limit server polling frequency.">
         <label>Framerate</label>
         <select bind:value={framerate} on:change={scheduleSave}>
@@ -196,23 +225,6 @@
         <label>Reduced Motion</label>
         <input type="checkbox" bind:checked={reducedMotion} on:change={scheduleSave} />
       </div>
-      {#if showLrm}
-        <div class="control" title="Select language reasoning model.">
-          <label>LRM Model</label>
-          <select bind:value={lrmModel} on:change={handleModelChange}>
-            {#each lrmOptions as opt}
-              <option value={opt}>{opt}</option>
-            {/each}
-          </select>
-        </div>
-        <div class="control" title="Send a sample prompt to the selected model.">
-          <label>Test Model</label>
-          <button on:click={handleTestModel}>Test</button>
-        </div>
-        {#if testReply}
-          <p class="status" data-testid="lrm-test-reply">{testReply}</p>
-        {/if}
-      {/if}
       <div class="control" title="Clear all save data.">
         <Trash2 />
         <label>Wipe Save Data</label>
@@ -232,8 +244,26 @@
         <input type="file" accept=".afsave" on:change={handleImport} />
       </div>
     </div>
-    <div class="col">
-      <h4>Gameplay</h4>
+  {:else if activeTab === 'llm' && showLrm}
+    <div class="panel">
+      <div class="control" title="Select language reasoning model.">
+        <label>LRM Model</label>
+        <select bind:value={lrmModel} on:change={handleModelChange}>
+          {#each lrmOptions as opt}
+            <option value={opt}>{opt}</option>
+          {/each}
+        </select>
+      </div>
+      <div class="control" title="Send a sample prompt to the selected model.">
+        <label>Test Model</label>
+        <button on:click={handleTestModel}>Test</button>
+      </div>
+      {#if testReply}
+        <p class="status" data-testid="lrm-test-reply">{testReply}</p>
+      {/if}
+    </div>
+  {:else if activeTab === 'gameplay'}
+    <div class="panel">
       <div class="control" title="Automatically craft materials when possible.">
         <label>Autocraft</label>
         <input type="checkbox" bind:checked={autocraft} on:change={handleAutocraftToggle} />
@@ -244,7 +274,8 @@
         <button on:click={handleEndRun} disabled={!runId}>End</button>
       </div>
     </div>
-  </div>
+  {/if}
+
   <div class="actions">
     {#if saveStatus}
       <p class="status" data-testid="save-status">{saveStatus}</p>
@@ -253,21 +284,36 @@
 </div>
 
 <style>
-  .cols {
-    display: flex;
-    gap: 1rem;
+  .tabbed {
+    min-width: 600px;
+    min-height: 360px;
   }
 
-  .col {
-    flex: 1;
+  .tabs {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .tabs button {
+    border: 2px solid #fff;
+    background: #0a0a0a;
+    color: #fff;
+    padding: 0.3rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  .tabs button.active {
+    background: #fff;
+    color: #0a0a0a;
+  }
+
+  .panel {
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-  }
-
-  h4 {
-    margin: 0 0 0.25rem 0;
-    font-size: 1rem;
   }
 
   .control {

--- a/frontend/tests/settingsmenu.test.js
+++ b/frontend/tests/settingsmenu.test.js
@@ -3,14 +3,16 @@ import { readFileSync } from 'fs';
 import { join } from 'path';
 
 describe('SettingsMenu component', () => {
-  test('renders volume sliders and headings', () => {
+  test('renders tab icons and panels', () => {
     const content = readFileSync(join(import.meta.dir, '../src/lib/SettingsMenu.svelte'), 'utf8');
+    expect(content).toContain('class="tabs"');
+    expect(content).toContain('<Volume2 />');
+    expect(content).toContain('<Cog />');
+    expect(content).toContain('<Brain />');
+    expect(content).toContain('<Gamepad />');
     expect(content).toContain('SFX Volume');
     expect(content).toContain('Music Volume');
     expect(content).toContain('Voice Volume');
-    expect(content).toContain('<h4>Audio</h4>');
-    expect(content).toContain('<h4>System</h4>');
-    expect(content).toContain('<h4>Gameplay</h4>');
     expect(content).toContain('Wipe Save Data');
     expect(content).toContain('Backup Save Data');
     expect(content).toContain('Import Save Data');


### PR DESCRIPTION
## Summary
- Rework SettingsMenu into a tabbed interface with icon buttons for Audio, System, optional LLM, and Gameplay settings
- Enlarge settings popup and update documentation
- Adjust tests for new tab structure

## Testing
- `bun run lint` (warnings)
- `./run-tests.sh` (backend and frontend failures: missing modules, assertion errors)


------
https://chatgpt.com/codex/tasks/task_b_68b103edfbe8832c81ac44e251bd7b43