### PR TITLE
Add five-star card mechanics

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,10 @@ victory presents three unused cards of the appropriate star rank. Selecting one
 adds it to the party, and card and relic bonuses are applied at the start of the
 next battle.
 
+5★ cards such as Phantom Ally, Temporal Shield, and Reality Split introduce
+summoned allies, turn-based damage reduction, and afterimage attacks that echo
+damage across all foes.
+
 Parties also track a rare drop rate (`rdr`) that boosts relic drops, gold
 rewards, upgrade item counts, and pull ticket chances. At extreme values it can
 roll to raise relic and card star ranks (3★→4★ at 1000% `rdr`, 4★→5★ at

--- a/backend/.codex/implementation/loot-tables.md
+++ b/backend/.codex/implementation/loot-tables.md
@@ -45,3 +45,6 @@ other rewards.
 ticket chances. It can also roll to raise relic and card star ranks when `rdr`
 is extraordinarily high (3★→4★ at 1000%, 4★→5★ at 1,000,000%) but never
 upgrades item stars.
+
+Top-tier drops may award 5★ cards like Phantom Ally, Temporal Shield, or
+Reality Split, each capable of dramatically altering battle flow.

--- a/backend/README.md
+++ b/backend/README.md
@@ -76,6 +76,8 @@ chance to award a pull ticket. `rdr` boosts drop quantity and odds and, at
 extreme values, can roll to upgrade relic and card star ranks (3★→4★ at 1000%
 `rdr`, 4★→5★ at 1,000,000%) though success is never guaranteed.
 
+Current 5★ cards include Phantom Ally, Temporal Shield, and Reality Split.
+
 `GET /gacha` returns the current pity counter, element-based upgrade items,
 owned characters with their duplicate stacks, and whether auto-crafting is
 enabled. `POST /gacha/pull` performs 1, 5, or 10 pulls, awarding 5★ or 6★

--- a/backend/plugins/cards/phantom_ally.py
+++ b/backend/plugins/cards/phantom_ally.py
@@ -1,0 +1,34 @@
+import copy
+from dataclasses import dataclass
+from dataclasses import field
+import random
+
+from autofighter.stats import BUS
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class PhantomAlly(CardBase):
+    id: str = "phantom_ally"
+    name: str = "Phantom Ally"
+    stars: int = 5
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 15.0})
+    about: str = (
+        "+1500% ATK; on the first turn, summon a temporary copy of a random ally."
+    )
+
+    async def apply(self, party):
+        await super().apply(party)
+        if not party.members:
+            return
+        original = random.choice(party.members)
+        summon = copy.deepcopy(original)
+        summon.id = f"{original.id}_phantom"
+        party.members.append(summon)
+
+        def _cleanup(_entity):
+            if summon in party.members:
+                party.members.remove(summon)
+            BUS.unsubscribe("battle_end", _cleanup)
+
+        BUS.subscribe("battle_end", _cleanup)

--- a/backend/plugins/cards/reality_split.py
+++ b/backend/plugins/cards/reality_split.py
@@ -1,0 +1,77 @@
+import asyncio
+from dataclasses import dataclass
+from dataclasses import field
+import random
+
+from autofighter.effects import EffectManager
+from autofighter.effects import create_stat_buff
+from autofighter.stats import BUS
+from plugins.cards._base import CardBase
+from plugins.foes._base import FoeBase
+
+
+@dataclass
+class RealitySplit(CardBase):
+    id: str = "reality_split"
+    name: str = "Reality Split"
+    stars: int = 5
+    effects: dict[str, float] = field(default_factory=lambda: {"atk": 15.0})
+    about: str = (
+        "+1500% ATK; at the start of each turn, a random ally gains +50% Crit Rate "
+        "and their attacks leave an Afterimage that echoes 25% of the damage to all foes."
+    )
+
+    async def apply(self, party):
+        await super().apply(party)
+        state: dict[str, object] = {"active": None, "foes": []}
+
+        def _battle_start(entity) -> None:
+            if isinstance(entity, FoeBase):
+                state["foes"].append(entity)
+
+        def _battle_end(entity) -> None:
+            if isinstance(entity, FoeBase):
+                state["foes"].clear()
+                state["active"] = None
+
+        def _turn_start() -> None:
+            if not party.members:
+                return
+            target = random.choice(party.members)
+            state["active"] = target
+            mgr = getattr(target, "effect_manager", None)
+            if mgr is None:
+                mgr = EffectManager(target)
+                target.effect_manager = mgr
+            mod = create_stat_buff(
+                target,
+                name=f"{self.id}_crit",
+                turns=1,
+                crit_rate=0.5,
+            )
+            mgr.add_modifier(mod)
+
+        def _hit_landed(attacker, _target, amount, *_args) -> None:
+            if attacker is not state["active"]:
+                return
+            foes = state["foes"]
+            if not foes:
+                return
+            echo = int(amount * 0.25)
+            for foe in foes:
+                if foe.hp <= 0:
+                    continue
+                asyncio.create_task(foe.apply_damage(echo, attacker=attacker))
+                BUS.emit(
+                    "card_effect",
+                    self.id,
+                    attacker,
+                    "afterimage_echo",
+                    echo,
+                    {"foe": getattr(foe, "id", "foe")},
+                )
+
+        BUS.subscribe("battle_start", _battle_start)
+        BUS.subscribe("battle_end", _battle_end)
+        BUS.subscribe("turn_start", lambda: _turn_start())
+        BUS.subscribe("hit_landed", _hit_landed)

--- a/backend/plugins/cards/temporal_shield.py
+++ b/backend/plugins/cards/temporal_shield.py
@@ -1,0 +1,49 @@
+from dataclasses import dataclass
+from dataclasses import field
+import random
+
+from autofighter.effects import EffectManager
+from autofighter.effects import create_stat_buff
+from autofighter.stats import BUS
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class TemporalShield(CardBase):
+    id: str = "temporal_shield"
+    name: str = "Temporal Shield"
+    stars: int = 5
+    effects: dict[str, float] = field(
+        default_factory=lambda: {"defense": 30.0, "max_hp": 30.0}
+    )
+    about: str = (
+        "+3000% DEF & HP; each turn has a 50% chance to grant 99% damage reduction for that turn."
+    )
+
+    async def apply(self, party):
+        await super().apply(party)
+
+        def _turn_start() -> None:
+            for member in party.members:
+                if random.random() < 0.5:
+                    mgr = getattr(member, "effect_manager", None)
+                    if mgr is None:
+                        mgr = EffectManager(member)
+                        member.effect_manager = mgr
+                    mod = create_stat_buff(
+                        member,
+                        name=f"{self.id}_mitigation",
+                        turns=1,
+                        mitigation_mult=100.0,
+                    )
+                    mgr.add_modifier(mod)
+                    BUS.emit(
+                        "card_effect",
+                        self.id,
+                        member,
+                        "damage_reduction",
+                        99,
+                        {"reduction_percent": 99},
+                    )
+
+        BUS.subscribe("turn_start", lambda: _turn_start())

--- a/backend/tests/test_five_star_cards.py
+++ b/backend/tests/test_five_star_cards.py
@@ -1,0 +1,75 @@
+import asyncio
+from pathlib import Path
+import random
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import llms.torch_checker as torch_checker
+
+from autofighter.party import Party
+from autofighter.stats import BUS
+from plugins.cards.phantom_ally import PhantomAlly
+from plugins.cards.reality_split import RealitySplit
+from plugins.cards.temporal_shield import TemporalShield
+from plugins.foes._base import FoeBase
+from plugins.players.ally import Ally
+from plugins.players.becca import Becca
+
+
+@pytest.mark.asyncio
+async def test_phantom_ally_summon_lifecycle(monkeypatch):
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+    a = Ally()
+    a.id = "a"
+    b = Becca()
+    b.id = "b"
+    party = Party(members=[a, b])
+    await PhantomAlly().apply(party)
+    assert len(party.members) == 3
+    assert any(m.id.endswith("_phantom") for m in party.members)
+    BUS.emit("battle_end", FoeBase())
+    assert len(party.members) == 2
+
+
+@pytest.mark.asyncio
+async def test_temporal_shield_damage_reduction(monkeypatch):
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+    member = Ally()
+    member.id = "a"
+    party = Party(members=[member])
+    await TemporalShield().apply(party)
+    base_mit = member.mitigation
+    monkeypatch.setattr(random, "random", lambda: 0.4)
+    BUS.emit("turn_start")
+    assert member.mitigation >= base_mit * 50
+    await member.effect_manager.cleanup(member)
+    monkeypatch.setattr(random, "random", lambda: 0.6)
+    BUS.emit("turn_start")
+    assert member.mitigation == base_mit
+
+
+@pytest.mark.asyncio
+async def test_reality_split_afterimage(monkeypatch):
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+    a1 = Ally()
+    a1.id = "a1"
+    a2 = Becca()
+    a2.id = "a2"
+    party = Party(members=[a1, a2])
+    await RealitySplit().apply(party)
+    f1 = FoeBase()
+    f1.id = "f1"
+    f2 = FoeBase()
+    f2.id = "f2"
+    BUS.emit("battle_start", f1)
+    BUS.emit("battle_start", f2)
+    monkeypatch.setattr(random, "choice", lambda seq: a1)
+    monkeypatch.setattr(random, "random", lambda: 1.0)
+    BUS.emit("turn_start")
+    BUS.emit("hit_landed", a1, f1, 100, "attack", "test")
+    await asyncio.sleep(0)
+    loss1 = f1.max_hp - f1.hp
+    loss2 = f2.max_hp - f2.hp
+    assert loss1 > 0 and loss1 == loss2

--- a/luna_items_prompts.txt
+++ b/luna_items_prompts.txt
@@ -35,6 +35,10 @@ Tactical Kit: Luna spreading out a tactical kit, a compact roll of tools—lockp
 Thick Skin: Luna coating herself with thick skin, a tough hide-like armor grafted to her flesh, textured like rugged bark yet flexible.
 Vital Core: Luna holding a vital core, a luminous orb encased in a metal cage, throbbing with rhythmic pulses like a mechanical heart.
 
+Phantom Ally: Luna summoning a phantom ally, a translucent double stepping from swirling mist with mirrored gear and stance.
+Temporal Shield: Luna raising a temporal shield, a rippling bubble that bends light as clockwork glyphs spin around its edge.
+Reality Split: Luna slashing through reality, twin afterimages trailing her blade as echoes of the strike cut the air.
+
 === Relics ===
 Arcane Flask: Luna swirling an arcane flask, a crystalline bottle filled with swirling violet energy, corked with a rune-carved stopper.
 Echo Bell: Luna ringing an echo bell, a tiny silver bell whose chime reverberates impossibly long, shimmering in concentric waves.


### PR DESCRIPTION
## Summary
- introduce Phantom Ally card that summons a temporary clone on battle start
- add Temporal Shield card with turn-based 99% damage reduction chance
- implement Reality Split card granting crit boosts and afterimage damage echoes
- document new 5★ cards across README, loot tables, and prompts
- add tests for summons, mitigation, and afterimage effects

## Testing
- `uv run pytest tests/test_five_star_cards.py`
- `./run-tests.sh` *(fails: missing dependencies and module import errors)*

------
https://chatgpt.com/codex/tasks/task_b_68b110921884832c800a3ef65bc8224f