### PR TITLE
[FEAT] expand battle review metrics

### DIFF
--- a/frontend/.codex/implementation/battle-review-ui.md
+++ b/frontend/.codex/implementation/battle-review-ui.md
@@ -8,3 +8,4 @@ The Battle Review interface uses a vertical icon column and a persistent side pa
 - `.icon-btn` provides a square click target with hover and active states.
 - The stats panel hosts the `entity-stats-grid`, ensuring key metrics stay visible during navigation.
 - Colors should match the UI's stained-glass palette, using vibrant hues such as those returned by `getElementBarColor` in `frontend/src/lib/BattleReview.svelte`.
+- The overview and entity panels surface detailed metrics like kills, DoT kills, ultimates used or failed, resources spent and gained, and healing prevented.


### PR DESCRIPTION
## Summary
- surface kills, DoT kills, ultimate usage, resource gains, and healing prevention in battle reviews
- document new battle review metrics in .codex implementation notes

## Testing
- [ ] `bun run lint`
- [ ] `ruff check . --fix`
- [ ] `./run-tests.sh` *(fails: Cannot find module '../src/lib/api.js' from '/workspace/Midori-AI-AutoFighter/frontend/tests/api.test.js')*


------
https://chatgpt.com/codex/tasks/task_b_68b49639bd18832cab55c2e0975c6609