### PR TITLE
Add ultimate-ready pulse to fighter portraits

### DIFF
--- a/frontend/.codex/implementation/battle-effects.md
+++ b/frontend/.codex/implementation/battle-effects.md
@@ -10,7 +10,10 @@ display passive stack indicators beside the element chip: passives with
 five or fewer maximum stacks render pips that fill as stacks accrue,
 larger finite stacks show `current/max`, and unlimited stacks display the
 raw count. These indicators respect Reduced Motion settings and expose
-tooltips for screen readers and mouse users.
+tooltips for screen readers and mouse users. When a fighter's ultimate
+becomes ready, an element-colored pulse briefly radiates from the
+ultimate ring in `FighterPortrait`; this animation is skipped when
+Reduced Motion is enabled.
 
 ## Stained-Glass Palette
 

--- a/frontend/src/lib/battle/FighterPortrait.svelte
+++ b/frontend/src/lib/battle/FighterPortrait.svelte
@@ -25,6 +25,16 @@
   $: elColor = getElementColor(fighter.element);
   $: ultProgress = Math.max(0, Math.min(1, Number(fighter?.ultimate_charge || 0) / 15));
   let lowContrast = false;
+  let prevUltReady = false;
+  let showUltPulse = false;
+
+  $: if (fighter.ultimate_ready && !prevUltReady && !reducedMotion) {
+    showUltPulse = true;
+    setTimeout(() => {
+      showUltPulse = false;
+    }, 600);
+  }
+  $: prevUltReady = fighter.ultimate_ready;
 
   // Improve ring readability for dark-type or low-brightness colors
   function parseHex(hex) {
@@ -71,6 +81,9 @@
       style={`border-color: ${elColor}`}
     />
     <div class="element-chip" class:low-contrast={lowContrast}>
+      {#if showUltPulse}
+        <div class="ult-ready-pulse"></div>
+      {/if}
       <svg class="ultimate-ring" viewBox="0 0 20 20">
         <circle class="track" cx="10" cy="10" r="9" />
         <circle
@@ -205,6 +218,21 @@
   /* Remove outer fade/glow around the element chip per feedback */
   .element-chip::before { content: none; }
   .ultimate-ring { position: absolute; inset: 0; transform: rotate(-90deg); }
+  .ult-ready-pulse {
+    position: absolute;
+    inset: -2px;
+    border-radius: 50%;
+    border: 2px solid var(--el-color);
+    box-shadow: 0 0 6px var(--el-color);
+    opacity: 0.8;
+    animation: ult-pulse 0.6s ease-out;
+    pointer-events: none;
+    z-index: -1;
+  }
+  @keyframes ult-pulse {
+    from { transform: scale(1); opacity: 0.8; }
+    to { transform: scale(1.6); opacity: 0; }
+  }
   .track {
     fill: none;
     stroke: rgba(0, 0, 0, 0.4);

--- a/frontend/tests/battleview.test.js
+++ b/frontend/tests/battleview.test.js
@@ -68,6 +68,11 @@ describe('BattleView layout and polling', () => {
     expect(fighterPortrait).toContain('getElementColor(fighter.element)');
   });
 
+  test('pulses ultimate ring when ready', () => {
+    expect(fighterPortrait).toContain('ult-ready-pulse');
+    expect(fighterPortrait).toContain('@keyframes ult-pulse');
+  });
+
   test('polling respects framerate settings', async () => {
     async function measure(fps) {
       const pollDelay = 1000 / fps;


### PR DESCRIPTION
## Summary
- flash element-colored pulse around ultimate ring when a fighter's ultimate becomes ready
- document ultimate-ready pulse behavior
- note pulse animation in test suite

## Testing
- `bun run lint:fix`
- `./run-tests.sh` *(fails: ENOENT missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_68b6efb13da8832c847a0bc62e3238a6