### PR TITLE
feat(frontend): animate summon portraits

### DIFF
--- a/frontend/.codex/implementation/summon-portraits.md
+++ b/frontend/.codex/implementation/summon-portraits.md
@@ -8,3 +8,5 @@ During combat, each fighter renders any summons beside its portrait:
 - Foe summons appear to the left of their owner.
 
 Summon portraits reuse `FighterPortrait` at 60% of the base `--portrait-size` and respect Reduced Motion settings.
+They scale into view using a short Svelte `scale` transition so new summons are noticeable.
+When `BattleEffects.svelte` is active, a `SummonSpawn` effect plays the first time a summon appears.


### PR DESCRIPTION
## Summary
- animate summoned FighterPortraits with scale transition and reduced-motion fallback
- play SummonSpawn effect when new summons appear
- document summon portrait transitions and effect trigger

## Testing
- `uv tool run ruff check backend --fix`
- `bun run lint:fix`
- `./run-tests.sh` *(fails: frontend tests fail to locate modules; backend tests time out)*


------
https://chatgpt.com/codex/tasks/task_b_68b6f0dc076c832cbc6c4ce2daf7d9db