### PR TITLE
[TST] Document and test foe rank field

### DIFF
--- a/.codex/implementation/battle-endpoint-payload.md
+++ b/.codex/implementation/battle-endpoint-payload.md
@@ -16,7 +16,7 @@
 - `card_choices` (array): up to three card options with `id`, `name`, and `stars`.
 - `relic_choices` (array): up to three relic options with `id`, `name`, and `stars`.
 - `loot` (object): summary of rewards with `gold`, `card_choices`, `relic_choices`, and `items` arrays.
-- `foes` (array): stats for spawned foes.
+- `foes` (array): stats for spawned foes. Each foe entry includes a `rank` string such as `"normal"` or `"boss"` indicating encounter difficulty.
 
 Generic damage types are reserved for the Luna player character; other combatants use elemental types such as Fire, Ice, Lightning, Light, Dark, or Wind.
 
@@ -107,7 +107,8 @@ Example:
       "passives": [],
       "dots": [],
       "hots": [],
-      "gold": 0
+      "gold": 0,
+      "rank": "normal"
     }
   ]
 }

--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -73,7 +73,9 @@ Each foe defeated during a battle temporarily raises the party's rare drop rate
 by 55% for that room, increasing gold rewards and element-based item drops.
 
 Foes also expose a `rank` field to describe encounter tier. Supported ranks are
-`normal`, `prime`, `glitched prime`, `boss`, and `glitched boss`.
+`normal`, `prime`, `glitched prime`, `boss`, and `glitched boss`. Battle and
+boss room responses include this field for every foe so the frontend can render
+appropriate tags or behaviors.
  
 They are procedurally named by prefixing a randomly selected adjective plugin
 from `plugins/themedadj` to a player name. Adjective plugins are

--- a/backend/README.md
+++ b/backend/README.md
@@ -69,6 +69,8 @@ for details.
 
 Player and foe base classes assign a random damage type when none is
 specified, and battles respect these preset elements without rolling new ones.
+Foe data returned from battle endpoints now includes a `rank` string such as
+`normal` or `boss` so clients can distinguish encounter difficulty.
 
 Foe balance: foes receive a 10× debuff to core stats (HP, ATK, DEF) before
 room scaling is applied. This global pre‑scale adjustment happens in

--- a/backend/tests/test_foe_rank.py
+++ b/backend/tests/test_foe_rank.py
@@ -1,0 +1,52 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+sys.modules.setdefault("llms.torch_checker", types.SimpleNamespace(is_torch_available=lambda: False))
+
+from autofighter.mapgen import MapNode  # noqa: E402
+from autofighter.party import Party  # noqa: E402
+from plugins.players import Player  # noqa: E402
+
+sys.modules.setdefault("autofighter.rooms", types.ModuleType("autofighter.rooms"))
+
+spec = importlib.util.spec_from_file_location(
+    "autofighter.rooms.utils",
+    Path(__file__).resolve().parents[1] / "autofighter/rooms/utils.py",
+)
+room_utils = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(room_utils)
+_build_foes = room_utils._build_foes
+_serialize = room_utils._serialize
+
+
+def test_normal_foe_rank() -> None:
+    party = Party(members=[Player()])
+    node = MapNode(
+        room_id=0,
+        room_type="battle-normal",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+    foes = _build_foes(node, party)
+    data = [_serialize(f) for f in foes]
+    assert all(f["rank"] == "normal" for f in data)
+
+
+def test_boss_foe_rank() -> None:
+    party = Party(members=[Player()])
+    node = MapNode(
+        room_id=0,
+        room_type="battle-boss-floor",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+    foes = _build_foes(node, party)
+    data = [_serialize(f) for f in foes]
+    assert data[0]["rank"] == "boss"


### PR DESCRIPTION
## Summary
- document foe rank in battle endpoint payload and backend README
- test serialization for normal and boss foe ranks

## Testing
- `uv run ruff check . --fix`
- `uv run pytest tests/test_foe_rank.py`
- `uv run pytest tests/test_app.py::test_players_and_rooms` *(fails: KeyError: 'map')*


------
https://chatgpt.com/codex/tasks/task_b_68bb2b8c91a8832cada362222c959965