### PR TITLE
feat: add rank tag placeholder

### DIFF
--- a/frontend/.codex/implementation/rank-badges.md
+++ b/frontend/.codex/implementation/rank-badges.md
@@ -1,0 +1,29 @@
+# Rank Badge Plan
+
+Fighter portraits now accept an optional `rankTag` property reserved for future badge rendering. The component currently ignores the tag until a design is finalized.
+
+## Badge Tiers
+- Bronze `#cd7f32`
+- Silver `#c0c0c0`
+- Gold `#ffd700`
+- Platinum `#e5e4e2`
+- Diamond `#b9f2ff`
+
+## Backend Rank Mapping
+| Backend Rank   | Badge Tier | Notes |
+|---------------|------------|-------|
+| `normal`      | Bronze     | |
+| `prime`       | Silver     | |
+| `boss`        | Platinum   | |
+| `glitched prime` | Gold     | Glitchy outline effect |
+| `glitched boss`  | Diamond  | Glitchy outline effect |
+
+## Badge Style
+- Small circular badge overlay anchored to a portrait corner.
+- Star icons for Bronze through Gold.
+- Laurel wreath for Platinum.
+- Diamond glyph for Diamond tier.
+- Subtle drop shadow to distinguish from the portrait.
+- Glitched ranks reuse the same tier color but add a jittering, glitchy outline.
+
+These guidelines outline future UI work for rank badges.

--- a/frontend/src/lib/battle/FighterPortrait.svelte
+++ b/frontend/src/lib/battle/FighterPortrait.svelte
@@ -7,6 +7,9 @@
 
   export let fighter = {};
   export let reducedMotion = false;
+  // Optional rank identifier; reserved for future badge rendering
+  // eslint-disable-next-line no-unused-vars
+  export let rankTag = null;
   $: passiveTip = (fighter.passives || [])
     .map((p) => `${p.id}${p.stacks > 1 ? ` x${p.stacks}` : ''}`)
     .join(', ');

--- a/frontend/tests/battleview.test.js
+++ b/frontend/tests/battleview.test.js
@@ -73,6 +73,10 @@ describe('BattleView layout and polling', () => {
     expect(fighterPortrait).toContain('@keyframes ult-pulse');
   });
 
+  test('accepts optional rank tag prop', () => {
+    expect(fighterPortrait).toContain('rankTag');
+  });
+
   test('polling respects framerate settings', async () => {
     async function measure(fps) {
       const pollDelay = 1000 / fps;


### PR DESCRIPTION
## Summary
- add optional `rankTag` prop to FighterPortrait for future rank badges
- document planned badge tiers with backend rank mapping and glitch outline guidance
- cover new prop in BattleView tests
- correct badge tier mapping for boss and glitched prime ranks

## Testing
- `bun run lint`
- `./run-tests.sh` *(fails: AttributeError: type object 'Wind' has no attribute '_players')*


------
https://chatgpt.com/codex/tasks/task_b_68bb31b88adc832cb2be68d616d4502b