### PR TITLE
[FIX] construct Stats properly in Bubble Burst tests

### DIFF
--- a/backend/tests/test_bubbles_bubble_burst_logic.py
+++ b/backend/tests/test_bubbles_bubble_burst_logic.py
@@ -23,7 +23,8 @@ async def test_bubbles_random_damage_type():
 async def test_bubble_burst_stacks_and_dot():
     set_battle_active(True)
     try:
-        bubbles = Stats(hp=1000, atk=100, damage_type=load_damage_type("Fire"))
+        bubbles = Stats(hp=1000, damage_type=load_damage_type("Fire"))
+        bubbles.set_base_stat("atk", 100)
         ally = Stats(hp=1000, damage_type=Generic())
         enemy1 = Stats(hp=1000, damage_type=Generic())
         enemy2 = Stats(hp=1000, damage_type=Generic())


### PR DESCRIPTION
## Summary
- set Bubble Burst test Stats attack using `set_base_stat`

## Testing
- `uv tool run ruff check backend --fix`
- `uv run pytest tests/test_bubbles_bubble_burst_logic.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68bdda1fc1d0832cbe3d2d0f11e329e1