### PR TITLE
[FIX] handle Carly's Aegis stack object in UI

### DIFF
--- a/frontend/src/lib/battle/FighterPortrait.svelte
+++ b/frontend/src/lib/battle/FighterPortrait.svelte
@@ -10,8 +10,20 @@
   // Optional rank identifier; reserved for future badge rendering
   // eslint-disable-next-line no-unused-vars
   export let rankTag = null;
+  function getStackCount(stacks) {
+    return typeof stacks === 'object' ? stacks.mitigation ?? 0 : stacks ?? 0;
+  }
+
+  function isOvercharged(stacks) {
+    return typeof stacks === 'object' && stacks.overcharged;
+  }
+
   $: passiveTip = (fighter.passives || [])
-    .map((p) => `${p.id}${p.stacks > 1 ? ` x${p.stacks}` : ''}`)
+    .map((p) => {
+      const count = getStackCount(p.stacks);
+      const oc = isOvercharged(p.stacks);
+      return `${p.id}${count > 1 ? ` x${count}` : ''}${oc ? ' (overcharged)' : ''}`;
+    })
     .join(', ');
 
   // Percent helpers for HP and overheal (shields)
@@ -118,13 +130,15 @@
     {#if (fighter.passives || []).length}
       <div class="passive-indicators" class:reduced={reducedMotion}>
         {#each fighter.passives as p (p.id)}
-          {@const tip = `${p.id} ${p.stacks}${p.max_stacks ? `/${p.max_stacks}` : ''}`}
+          {@const count = getStackCount(p.stacks)}
+          {@const oc = isOvercharged(p.stacks)}
+          {@const tip = `${p.id} ${count}${p.max_stacks ? `/${p.max_stacks}` : ''}${oc ? ' (overcharged)' : ''}`}
           <div class="passive" class:pips-mode={(p.max_stacks && p.max_stacks <= 5)} aria-label={tip} title={tip}>
             {#if p.max_stacks && p.max_stacks <= 5}
             <div class="pips">
                 {#each Array(p.max_stacks) as _, i (i)}
                   <PipCircle
-                    class={`pip-icon${i < p.stacks ? ' filled' : ''}`}
+                    class={`pip-icon${i < count ? ' filled' : ''}`}
                     stroke="none"
                     fill="currentColor"
                     aria-hidden="true"
@@ -132,9 +146,9 @@
                 {/each}
               </div>
             {:else if p.max_stacks}
-              <span class="count">{p.stacks > p.max_stacks ? `${p.stacks}+` : p.stacks}/{p.max_stacks}</span>
+              <span class="count">{count > p.max_stacks ? `${count}+` : count}/{p.max_stacks}</span>
             {:else}
-              <span class="count">{p.stacks}</span>
+              <span class="count">{count}</span>
             {/if}
           </div>
         {/each}

--- a/frontend/src/lib/components/CombatViewer.svelte
+++ b/frontend/src/lib/components/CombatViewer.svelte
@@ -197,17 +197,22 @@
                 about: 'Passive ability',
                 source: 'passive',
                 stacks: 1,
-                max_stacks: 1
+                max_stacks: 1,
+                overcharged: false
               };
             }
+            const stackData = passive.stacks;
+            const count = typeof stackData === 'object' ? stackData.mitigation ?? 0 : stackData ?? 1;
+            const overcharged = typeof stackData === 'object' && stackData.overcharged;
             return {
               name: passive.name || passive.id || 'Unknown',
               id: passive.id || passive.name || 'unknown',
               duration: passive.duration || passive.turns_left || 'Permanent',
               about: passive.description || 'Passive ability',
               source: 'passive',
-              stacks: passive.stacks ?? 1,
-              max_stacks: passive.max_stacks ?? passive.stacks ?? 1
+              stacks: count,
+              max_stacks: passive.max_stacks ?? count ?? 1,
+              overcharged
             };
           });
         }
@@ -251,7 +256,11 @@
         description += ` x${effect.stacks}`;
       }
     }
-    
+
+    if (effect.overcharged) {
+      description += ' (overcharged)';
+    }
+
     return description;
   }
 


### PR DESCRIPTION
## Summary
- normalize passive stack objects in FighterPortrait
- parse mitigation and overcharge stacks in CombatViewer and indicate overcharge state

## Testing
- `bun run lint`
- `uv tool run ruff check backend/plugins/passives/carly_guardians_aegis.py backend/tests/test_passive_stacks.py --fix`
- `./run-tests.sh >/tmp/test.log 2>&1; tail -n 20 /tmp/test.log` *(fails: backend tests timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68bdf1b41aec832c9d74bebdf8ec97ac