### PR TITLE
[FEAT] sequential pull results overlay

### DIFF
--- a/frontend/.codex/implementation/pull-results-overlay.md
+++ b/frontend/.codex/implementation/pull-results-overlay.md
@@ -1,0 +1,7 @@
+# Pull Results Overlay
+
+`src/lib/components/PullResultsOverlay.svelte` displays gacha pull results.
+It accepts a `results` array and uses `CurioChoice.svelte` to render each
+entry. Results are queued and revealed one at a time with a simple slide/fade
+animation. After all items appear a Done button lets the player close the
+overlay.

--- a/frontend/.codex/implementation/pulls-menu.md
+++ b/frontend/.codex/implementation/pulls-menu.md
@@ -2,5 +2,6 @@
 
 The `PullsMenu.svelte` component lets players spend gacha tickets. It shows
 current pity and ticket counts and provides buttons for one, five, or ten
-pulls. Each button disables when the player lacks enough tickets. Pull results
-list the type, id, rarity, and stacks of each item.
+pulls. Each button disables when the player lacks enough tickets. After a
+successful pull it opens `PullResultsOverlay.svelte`, which queues the
+returned items and reveals them one at a time.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -35,8 +35,9 @@ browser reads this value instead of scanning the network directly.
   (open the Party overlay to refresh), but do not retroactively modify an
   active battle.
 - Pulls: Calls `/gacha/pull` so players can recruit 5★ or 6★ characters or
-  earn 1★–4★ upgrade items between runs. Pity raises the odds of higher‑tier
-  items; an auto‑craft toggle is available in Settings.
+  earn 1★–4★ upgrade items between runs. Results now open an overlay that
+  reveals each pull one at a time. Pity raises the odds of higher‑tier items;
+  an auto‑craft toggle is available in Settings.
 - Inventory: Displays cards, relics, and upgrade materials in the in‑run
   top‑left NavBar (disabled during battles).
 - Feedback: Opens a pre‑filled GitHub issue in a new tab.

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -12,6 +12,7 @@
   import PullsMenu from './PullsMenu.svelte';
   import BattleReview from './BattleReview.svelte';
   import RewardOverlay from './RewardOverlay.svelte';
+  import PullResultsOverlay from './PullResultsOverlay.svelte';
   import CharacterEditor from './CharacterEditor.svelte';
   import Inventory from './Inventory.svelte';
   import SettingsMenu from './SettingsMenu.svelte';
@@ -211,6 +212,12 @@
 {#if $overlayView === 'pulls'}
   <OverlaySurface zIndex={1300}>
     <PullsMenu on:close={() => dispatch('back')} />
+  </OverlaySurface>
+{/if}
+
+{#if $overlayView === 'pull-results'}
+  <OverlaySurface zIndex={1400}>
+    <PullResultsOverlay results={$overlayData.results || []} on:close={() => dispatch('back')} />
   </OverlaySurface>
 {/if}
 

--- a/frontend/src/lib/components/PullResultsOverlay.svelte
+++ b/frontend/src/lib/components/PullResultsOverlay.svelte
@@ -1,0 +1,70 @@
+<script>
+  import { onMount, createEventDispatcher } from 'svelte';
+  import CurioChoice from './CurioChoice.svelte';
+
+  export let results = [];
+
+  const dispatch = createEventDispatcher();
+  let queue = [];
+  let visible = [];
+
+  onMount(() => {
+    queue = Array.isArray(results) ? [...results] : [];
+    showNext();
+  });
+
+  function showNext() {
+    if (queue.length === 0) return;
+    visible = [...visible, queue.shift()];
+    if (queue.length > 0) {
+      setTimeout(showNext, 400);
+    }
+  }
+
+  function close() {
+    dispatch('close');
+  }
+</script>
+
+<div class="layout">
+  <div class="choices">
+    {#each visible as r, i (i)}
+      <div class="reveal" style={`--delay: ${i * 120}ms`}>
+        <CurioChoice entry={r} disabled={true} />
+      </div>
+    {/each}
+  </div>
+  {#if queue.length === 0 && visible.length}
+    <button class="done" on:click={close}>Done</button>
+  {/if}
+</div>
+
+<style>
+  .layout {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+  .choices {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    justify-content: center;
+  }
+  .done {
+    padding: 0.5rem 1rem;
+    background: #0a0a0a;
+    color: #fff;
+    border: 2px solid #fff;
+    cursor: pointer;
+  }
+  .reveal {
+    opacity: 0;
+    animation: overlay-reveal 0.4s forwards;
+  }
+  @keyframes overlay-reveal {
+    from { transform: translateY(-20px); opacity: 0; }
+    to { transform: translateY(0); opacity: 1; }
+  }
+</style>

--- a/frontend/src/lib/components/PullsMenu.svelte
+++ b/frontend/src/lib/components/PullsMenu.svelte
@@ -8,7 +8,6 @@
   const dispatch = createEventDispatcher();
   let pity = 0;
   let items = {};
-  let results = [];
   let loading = false;
   onMount(async () => {
     const data = await getGacha();
@@ -21,7 +20,10 @@
       const data = await pullGacha(count);
       pity = data.pity;
       items = data.items;
-      results = data.results || [];
+      const results = data.results || [];
+      if (results.length) {
+        openOverlay('pull-results', { results });
+      }
     } catch (err) {
       if (dev || !browser) {
         const { error } = await import('$lib/systems/logger.js');
@@ -46,13 +48,6 @@
     <button disabled={loading || (items.ticket || 0) < 10} on:click={() => pull(10)}>Pull 10</button>
     <button on:click={close}>Done</button>
   </div>
-  {#if results.length}
-    <ul>
-      {#each results as r}
-        <li>{r.type}: {r.id} ({r.rarity}★){#if r.stacks} x{r.stacks}{/if}</li>
-      {/each}
-    </ul>
-  {/if}
 </MenuPanel>
 
 <style>
@@ -66,9 +61,5 @@
     background: #0a0a0a;
     color: #fff;
     padding: 0.3rem 0.6rem;
-  }
-  ul {
-    margin: 0;
-    padding-left: 1rem;
   }
 </style>

--- a/frontend/tests/pullresultsoverlay.test.js
+++ b/frontend/tests/pullresultsoverlay.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('PullResultsOverlay component', () => {
+  test('queues results and reveals sequentially', () => {
+    const content = readFileSync(
+      join(import.meta.dir, '../src/lib/components/PullResultsOverlay.svelte'),
+      'utf8'
+    );
+    expect(content).toContain('CurioChoice');
+    expect(content).toContain('queue = Array.isArray(results) ? [...results] : []');
+    expect(content).toContain('setTimeout(showNext');
+  });
+});

--- a/frontend/tests/pullsmenu.test.js
+++ b/frontend/tests/pullsmenu.test.js
@@ -14,5 +14,7 @@ describe('PullsMenu component', () => {
     expect(content).toContain('Pull 10');
     expect(content).toContain('(items.ticket || 0) < 1');
     expect(content).toContain('(items.ticket || 0) < 5');
+    expect(content).toContain("openOverlay('pull-results'");
+    expect(content).not.toContain('<ul>');
   });
 });


### PR DESCRIPTION
## Summary
- show gacha pull results in new PullResultsOverlay with sequential reveal
- open overlay from PullsMenu and route through OverlayHost
- document pull results overlay and updated pulls menu

## Testing
- `bun run lint`
- `bun test tests/pullsmenu.test.js tests/pullresultsoverlay.test.js`
- `./run-tests.sh` *(fails: multiple backend tests such as test_enhanced_map.py)*

------
https://chatgpt.com/codex/tasks/task_b_68be0d03f410832caeaef9939ba82b12