### PR TITLE
Cache stat editor values per character

### DIFF
--- a/frontend/.codex/implementation/party-ui.md
+++ b/frontend/.codex/implementation/party-ui.md
@@ -22,7 +22,8 @@ Implementation details:
 - `StatTabs.svelte` now embeds an `UpgradePanel` beneath the stats list,
   showing upgrade level and per-star item counts with a button disabled until
   enough materials are available (20×4★ or 100×3★ or 500×2★ or 1000×1★).
-- `StatTabs.svelte` caches per-character stat editor values and persists
-  allocations through `/players/<id>/editor` so non-player tweaks are saved
-  across sessions.
+- `StatTabs.svelte` caches per-character stat editor values in a module-scoped
+  `Map` keyed by character ID and persists allocations through
+  `/players/<id>/editor` so non-player tweaks are saved across sessions and
+  restored when reopening the editor or switching characters.
 

--- a/frontend/src/lib/components/StatTabs.svelte
+++ b/frontend/src/lib/components/StatTabs.svelte
@@ -1,3 +1,8 @@
+<script context="module">
+  // Cache per-character editor values across component instances
+  export const editorConfigs = new Map();
+</script>
+
 <script>
   /*
    * StatTabs.svelte
@@ -43,7 +48,6 @@
   let loadingEditorCfg = false;
   let saveTimer = null;
   let lastPreviewId = null; // track last character ID to detect switches
-  const editorConfigs = new Map();
 
   // Upgrade system state
   let upgradeData = null;

--- a/frontend/tests/stat-tabs-persistence.test.js
+++ b/frontend/tests/stat-tabs-persistence.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('StatTabs editor persistence', () => {
+  const content = readFileSync(join(import.meta.dir, '../src/lib/components/StatTabs.svelte'), 'utf8');
+
+  test('stores editor values by character id', () => {
+    expect(content).toContain('context="module"');
+    expect(content).toMatch(/editorConfigs\s*=\s*new Map/);
+    expect(content).toContain('editorConfigs.set(previewId, { ...editorVals });');
+  });
+
+  test('restores cached values when switching', () => {
+    expect(content).toContain('const cached = editorConfigs.get(previewChar.id)');
+  });
+});


### PR DESCRIPTION
## Summary
- cache stat editor values per character using a module-scoped map in StatTabs
- document per-character stat persistence in party UI implementation notes
- add frontend test covering StatTabs editor persistence

## Testing
- [ ] Backend tests
- [x] Frontend tests
- [x] Linting
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies

------
https://chatgpt.com/codex/tasks/task_b_68be0f2d0af4832cb49658870b0c1555