### PR TITLE
Mixed workspace: fix Hilander crit ferment subscription leak

### DIFF
--- a/.codex/tasks/character_passive_ultimate_review.md
+++ b/.codex/tasks/character_passive_ultimate_review.md
@@ -52,7 +52,7 @@ This task list catalogs each playable character's listed passive ability and ult
   - **Actual**: `HilanderCriticalFerment` adds +5% crit rate and +10% crit damage per hit, drops stack gain odds past 20, and on crit triggers Aftertaste then removes highest stack.
 - **Ultimate – Random element**
 - **Tasks**:
-  - Confirm stack removal works for both crit rate and damage effects.
+  - [x] Confirm stack removal works for both crit rate and damage effects.
   - Decide on a fixed element if random damage type is not desired.
 
 ## Kboshi


### PR DESCRIPTION
## Summary
- switch Hilander's Critical Ferment to track subscriptions with `WeakKeyDictionary`
- mark Critical Ferment stack removal task as complete

## Testing
- `uv run ruff check backend/plugins/passives/hilander_critical_ferment.py --fix`
- `./run-tests.sh` *(fails: tests/test_battle_snapshot_consistency.py::test_foe_element_stable_across_snapshots - KeyError: 'foes')*


------
https://chatgpt.com/codex/tasks/task_b_68beade84ff4832cb9b97e11ce6e8de7