### PR TITLE
[FIX] yield in event bus callbacks

### DIFF
--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -317,14 +317,8 @@ class BattleRoom(Room):
             except Exception:
                 elapsed = 0.0
 
-            # Reduce wait time when there are many combatants to improve performance
-            total_combatants = len(combat_party.members) + len(foes)
-            if total_combatants > 8:
-                # Scale down wait time: 0.5s -> 0.1s for 8+ combatants
-                base_wait = max(0.1, 0.5 - (total_combatants - 8) * 0.05)
-            else:
-                base_wait = 0.5
-
+            # Enforce a minimum one-second delay between turns for pacing
+            base_wait = 1.0
             wait = base_wait - elapsed
             if wait > 0:
                 try:

--- a/backend/tests/test_battle_timing.py
+++ b/backend/tests/test_battle_timing.py
@@ -25,4 +25,4 @@ async def test_turn_pacing():
     await room.resolve(party, {})
     elapsed = time.perf_counter() - start
     rooms_module._choose_foe = original
-    assert elapsed >= 0.5
+    assert elapsed >= 1.0


### PR DESCRIPTION
## Summary
- enforce minimum one-second pause between battle turns
- update timing test to expect 1s pacing

## Testing
- `uvx ruff check backend/autofighter/rooms/battle.py backend/tests/test_battle_timing.py --fix`
- `./run-tests.sh` *(errors: ModuleNotFoundError for `battle_logging` and other dependencies)*

------
https://chatgpt.com/codex/tasks/task_b_68bfdb9092a0832ca98f0e19cb770802