### PR TITLE
feat: animate fighter element changes

### DIFF
--- a/frontend/.codex/implementation/battle-effects.md
+++ b/frontend/.codex/implementation/battle-effects.md
@@ -26,6 +26,11 @@ also slowly tilts left and right, the sway intensifying up to a
 one-degree angle around 98% charge. Reduced Motion disables both the
 transition and the tilt.
 
+When a fighter's element changes mid-battle, the portrait outline and
+ultimate icon briefly flash using the `element-change` animation. The
+update transitions the element color and icon smoothly and is skipped
+when Reduced Motion is enabled.
+
 HP bars for party members, foes, and their summons animate their fill widths
 and overheal overlays with short transitions. When Reduced Motion is enabled,
 these transitions are removed for instant updates.

--- a/frontend/tests/battleview.test.js
+++ b/frontend/tests/battleview.test.js
@@ -74,6 +74,11 @@ describe('BattleView layout and polling', () => {
     expect(fighterUIItem).toContain('ult-icon');
   });
 
+  test('animates element changes', () => {
+    expect(fighterUIItem).toContain('element-change');
+    expect(fighterUIItem).toContain('@keyframes element-change');
+  });
+
   test('uses normalized element for portraits', () => {
     expect(fighterPortrait).toContain('getElementIcon(fighter.element)');
     expect(fighterPortrait).toContain('getElementColor(fighter.element)');


### PR DESCRIPTION
## Summary
- add reactive element-change animation in `FighterUIItem.svelte`
- cover element swap animation and keyframes in tests
- document element change flash in battle effects notes

## Testing
- `ruff check backend`
- `./run-tests.sh` *(fails: missing modules and async plugin issues)*
- `bun test tests/battleview.test.js` *(fails: BattleView.svelte missing)*

------
https://chatgpt.com/codex/tasks/task_b_68c0059cb5b0832cb10969f8bcd725ff