### PR TITLE
[ENH] halve battle action pacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Midori AI AutoFighter
 
 A web-based auto-battler game featuring strategic party management, elemental combat, and character progression.
-Now includes an in-game Guidebook (Damage Types, Ults, Shops, Mechs, Passives) accessible from the main menu.
 
 ## Quick Start with Docker Compose (Recommended)
 

--- a/backend/.codex/implementation/battle-action-events.md
+++ b/backend/.codex/implementation/battle-action-events.md
@@ -14,3 +14,9 @@ Damage type ultimates now consume charge via `use_ultimate()` and are invoked by
 `rooms/battle.py` when `ultimate_ready` is set.  Damage type plugins may add
 additional effects in their `ultimate` methods or respond to the
 `ultimate_used` event.
+
+## Pacing
+
+Each action calls the internal `_pace` helper, which yields for roughly half a
+second based on the time spent executing the move. This per-actor pacing keeps
+combat readable while avoiding full-turn delays.

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -318,8 +318,8 @@ class BattleRoom(Room):
             except Exception:
                 elapsed = 0.0
 
-            # Enforce a minimum one-second delay between turns for pacing
-            base_wait = 1.0
+            # Enforce a half-second delay after each action for pacing
+            base_wait = 0.5
             wait = base_wait - elapsed
             if wait > 0:
                 try:
@@ -676,6 +676,7 @@ class BattleRoom(Room):
                             _EXTRA_TURNS[id(acting_foe)] -= 1
                             await _pace(action_start)
                             continue
+                        await _pace(action_start)
                         await asyncio.sleep(0.001)
                         break
                     dmg = await target.apply_damage(acting_foe.atk, attacker=acting_foe)

--- a/backend/tests/test_battle_timing.py
+++ b/backend/tests/test_battle_timing.py
@@ -9,12 +9,13 @@ from autofighter.stats import Stats
 
 
 @pytest.mark.asyncio
-async def test_turn_pacing():
+async def test_per_actor_pacing():
     node = MapNode(room_id=0, room_type="battle-normal", floor=1, index=1, loop=1, pressure=0)
     room = BattleRoom(node)
-    player = Stats(hp=100, max_hp=100, atk=2000, defense=0)
+    # Set stats so both sides act once before the foe is defeated
+    player = Stats(hp=100, max_hp=100, atk=50, defense=0)
     player.id = "p1"
-    foe = Stats(hp=100, max_hp=100, atk=1, defense=0)
+    foe = Stats(hp=100, max_hp=100, atk=50, defense=0)
     foe.id = "f1"
     party = Party(members=[player])
 
@@ -25,4 +26,5 @@ async def test_turn_pacing():
     await room.resolve(party, {})
     elapsed = time.perf_counter() - start
     rooms_module._choose_foe = original
-    assert elapsed >= 1.0
+    # Three total actions -> at least 1.5s of pacing (0.5s per action)
+    assert elapsed >= 1.5


### PR DESCRIPTION
## Summary
- shorten battle `_pace` delay to 0.5s and ensure it's applied after every action
- test per-actor pacing and document new 0.5s timing
- note half-second pacing in docs; remove extraneous README note per review

## Testing
- `uvx ruff check . --fix --exclude .codex/prototypes`
- `./run-tests.sh` *(fails: numerous backend tests due to missing modules and async plugin errors)*

------
https://chatgpt.com/codex/tasks/task_b_68c015475184832cb140c9d47ee7cb9c