### PR TITLE
[FIX] Forward attributes through MenuPanel

### DIFF
--- a/frontend/src/lib/components/MenuPanel.svelte
+++ b/frontend/src/lib/components/MenuPanel.svelte
@@ -3,6 +3,8 @@
   export let padding = '0.5rem';
   export let reducedMotion = false;
   export let starColor = '';
+  export let class = '';
+  export let style = '';
 </script>
 
 <style>
@@ -46,7 +48,11 @@
   }
 </style>
 
-<div class="panel" style={`--padding: ${padding}`}>
+<div
+  {...$$restProps}
+  class={`panel ${class}`}
+  style={`--padding: ${padding}; ${style}`}
+>
   <StarStorm color={starColor} {reducedMotion} />
   <slot />
 </div>


### PR DESCRIPTION
## Summary
- allow `MenuPanel` to forward `class` and other HTML attributes

## Testing
- `bun run lint:fix`
- `bun test tests/starstorm.test.js`
- `ruff check . --fix` *(fails: unused variables and whitespace in `.codex/prototypes`)*
- `./run-tests.sh` *(fails: missing modules and timed out backend tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c09b4027c4832cacbdec72423b279d