### PR TITLE
[ENHANCEMENT] Buffer battle logs in memory and flush on finalize

### DIFF
--- a/backend/.codex/implementation/battle-logging.md
+++ b/backend/.codex/implementation/battle-logging.md
@@ -142,7 +142,7 @@ Total Events: 45
 
 ## Implementation Notes
 
-- Uses thread-safe logging to handle concurrent battle events
+- Uses an async-friendly queue and timed memory buffer so log writes happen off the event loop and flush to disk roughly every 15 seconds or when a battle ends
 - Automatically creates directory structure as needed
 - Integrates with existing event bus system
 - Does not interfere with existing logging to `backend.log`


### PR DESCRIPTION
## Summary
- buffer battle logs via queue and timed memory handler
- flush buffered events every 15s or on battle end
- run log flushing asynchronously to avoid blocking the event loop

## Testing
- `ruff check backend --fix`
- `./run-tests.sh` *(fails: missing frontend modules; backend tests timeout)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ab03d118832c8eafd8db65e763f2