### PR TITLE
[FEATURE] Add Guardian Shard mitigation bonus

### DIFF
--- a/backend/plugins/cards/guardian_shard.py
+++ b/backend/plugins/cards/guardian_shard.py
@@ -28,8 +28,17 @@ class GuardianShard(CardBase):
             if target in party.members:
                 battle_deaths += 1
 
-        def _on_battle_end():
+        def _on_battle_end(target):
             nonlocal mitigation_bonus_pending, active_members
+
+            if target is None:
+                return
+            if (
+                target is not party
+                and target not in party.members
+                and getattr(target, "plugin_type", None) != "foe"
+            ):
+                return
 
             # Remove any active mitigation buffs
             for member in active_members:

--- a/backend/tests/test_guardian_shard.py
+++ b/backend/tests/test_guardian_shard.py
@@ -6,6 +6,7 @@ from autofighter.cards import apply_cards
 from autofighter.cards import award_card
 from autofighter.party import Party
 from autofighter.stats import BUS
+from plugins.foes._base import FoeBase
 from plugins.players._base import PlayerBase
 
 
@@ -27,7 +28,7 @@ def test_guardian_shard_applies_bonus_after_no_deaths():
     BUS.emit("battle_start", ally1)
     BUS.emit("battle_start", ally2)
     loop.run_until_complete(asyncio.sleep(0))
-    BUS.emit("battle_end")
+    BUS.emit("battle_end", FoeBase())
     loop.run_until_complete(asyncio.sleep(0))
 
     pre = ally1.mitigation
@@ -36,7 +37,7 @@ def test_guardian_shard_applies_bonus_after_no_deaths():
     loop.run_until_complete(asyncio.sleep(0))
     assert ally1.mitigation == pytest.approx(pre + 1)
 
-    BUS.emit("battle_end")
+    BUS.emit("battle_end", FoeBase())
     loop.run_until_complete(asyncio.sleep(0))
     assert ally1.mitigation == pytest.approx(pre)
 
@@ -54,7 +55,7 @@ def test_guardian_shard_no_bonus_after_death():
     BUS.emit("battle_start", ally2)
     BUS.emit("death", ally1)
     loop.run_until_complete(asyncio.sleep(0))
-    BUS.emit("battle_end")
+    BUS.emit("battle_end", FoeBase())
     loop.run_until_complete(asyncio.sleep(0))
 
     pre = ally1.mitigation


### PR DESCRIPTION
## Summary
- apply temporary +1 mitigation buff at battle start if previous fight had no ally deaths
- remove Guardian Shard mitigation buff at battle end
- test Guardian Shard mitigation bonus only applies after a death-free battle

## Testing
- `./run-tests.sh` *(fails: Cannot find module '$app/environment' in frontend tests; various backend tests timed out)*

------
https://chatgpt.com/codex/tasks/task_b_68c0ea91361c832c9a4464e679779f88