### PR TITLE
[ENHANCE] add brief delay after Aftertaste damage

### DIFF
--- a/backend/plugins/effects/aftertaste.py
+++ b/backend/plugins/effects/aftertaste.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 from dataclasses import field
 import random
@@ -94,4 +95,5 @@ class Aftertaste:
 
             dmg = await target.apply_damage(amount, temp_attacker, action_name="Aftertaste")
             results.append(dmg)
+            await asyncio.sleep(0.002)
         return results


### PR DESCRIPTION
## Summary
- pause briefly after each Aftertaste damage application to allow event loop tasks to run

## Testing
- `ruff check . --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging')*

------
https://chatgpt.com/codex/tasks/task_b_68c3063bb870832c9da3ffd6e405e1ea