### PR TITLE
[FIX] add delay in dark damage type ultimate

### DIFF
--- a/backend/plugins/damage_types/dark.py
+++ b/backend/plugins/damage_types/dark.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
@@ -120,6 +121,7 @@ class Dark(DamageTypeBase):
         target = enemies[0]
         for _ in range(6):
             dealt = await target.apply_damage(dmg, attacker=actor, action_name="Dark Ultimate")
+            await asyncio.sleep(0.002)
             await BUS.emit_async("damage", actor, target, dealt)
         return True
 


### PR DESCRIPTION
## Summary
- add asyncio sleep after each damage application in Dark damage type ultimate

## Testing
- `ruff check . --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'llms', TypeError: Stats.__init__ got unexpected keyword argument)*

------
https://chatgpt.com/codex/tasks/task_b_68c30648ea94832cbd5170e148cc98fe