### PR TITLE
[Fix] add tiny delay to fire ultimate

### DIFF
--- a/backend/plugins/damage_types/fire.py
+++ b/backend/plugins/damage_types/fire.py
@@ -57,6 +57,7 @@ class Fire(DamageTypeBase):
                 mgr.maybe_inflict_dot(actor, dealt)
             except Exception:
                 pass
+            await asyncio.sleep(0.002)
         return True
 
     def _on_ultimate_used(self, user: Stats) -> None:


### PR DESCRIPTION
## Summary
- add a short `asyncio.sleep` after dealing fire ultimate damage

## Testing
- `cd backend && ruff check . --fix`
- `./run-tests.sh` *(fails: tests/test_fire_ultimate.py)*

------
https://chatgpt.com/codex/tasks/task_b_68c3064a33d4832c80823c853fbee742