### PR TITLE
[FIX] yield control in ice damage

### DIFF
--- a/backend/plugins/damage_types/ice.py
+++ b/backend/plugins/damage_types/ice.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 
 from autofighter.effects import DamageOverTime
@@ -26,7 +27,9 @@ class Ice(DamageTypeBase):
             for foe in foes:
                 dmg = int(base * bonus)
                 await foe.apply_damage(dmg, attacker=user, action_name="Ice Ultimate")
+                await asyncio.sleep(0.002)
                 bonus += 0.3
+            await asyncio.sleep(0.002)
         return True
 
     @classmethod


### PR DESCRIPTION
## Summary
- standardize Ice ultimate's yield delay to 2ms after each wave and foe hit

## Testing
- `uv run ruff check plugins/damage_types/ice.py --fix`
- `uv run pytest tests/test_800_dots_performance.py::test_many_dots_performance -q` *(fails: Stats.__init__() got unexpected keyword argument 'max_hp')*
- `uv run pytest tests/test_battle_logging.py -q` *(fails: ModuleNotFoundError: No module named 'battle_logging')*

------
https://chatgpt.com/codex/tasks/task_b_68c30647d260832ca19e1c4524fc0c13