### PR TITLE
[FIX] yield on every generic ultimate hit

### DIFF
--- a/backend/plugins/damage_types/generic.py
+++ b/backend/plugins/damage_types/generic.py
@@ -57,8 +57,7 @@ class Generic(DamageTypeBase):
                 party=allies,
                 foes=enemies,
             )
-            if i % 5 == 0:
-                await asyncio.sleep(0)
+            await asyncio.sleep(0.002)
         return True
 
     @classmethod


### PR DESCRIPTION
## Summary
- yield 2ms on every strike of generic ultimate instead of every fifth hit

## Testing
- `uvx ruff check . --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging'; multiple TypeErrors for Stats initialization)*

------
https://chatgpt.com/codex/tasks/task_b_68c306560a38832c82241b7e4b05320b