### PR TITLE
fix: refine wind ultimate yielding

### DIFF
--- a/backend/plugins/damage_types/wind.py
+++ b/backend/plugins/damage_types/wind.py
@@ -104,10 +104,8 @@ class Wind(DamageTypeBase):
                     f_mgr.maybe_inflict_dot(actor, dmg)
                 except Exception:
                     pass
-                # Yield briefly to keep event loop responsive during large hit counts
-                # Reduce frequency of yields for better performance with many hits
-                if i % 5 == 0:  # Only yield every 5 hits instead of every hit
-                    await asyncio.sleep(0)
+                # Yield briefly each hit to keep the event loop responsive
+                await asyncio.sleep(0.002)
 
         # Clean up the temporary buff immediately after the sequence
         try:


### PR DESCRIPTION
## Summary
- tune wind ultimate to yield every hit with short async sleep

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: missing modules and backend tests, e.g., Stats.__init__ unexpected keyword 'max_hp')*

------
https://chatgpt.com/codex/tasks/task_b_68c30653a420832c9ea6d0f0c507b585