### PR TITLE
Add yield delay to passive triggers

### DIFF
--- a/backend/autofighter/passives.py
+++ b/backend/autofighter/passives.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections import Counter
 import logging
 from pathlib import Path
@@ -66,6 +67,7 @@ class PassiveRegistry:
                         await passive_instance.apply(owner, stack_index=stack_idx)
                     except TypeError:
                         await passive_instance.apply(owner)
+                await asyncio.sleep(0.002)
 
                 # If this passive provides an event-specific handler, call it too.
                 # This enables richer behaviors (e.g., on_action_taken) while
@@ -75,6 +77,7 @@ class PassiveRegistry:
                         await passive_instance.on_action_taken(owner, **kwargs)
                     except TypeError:
                         await passive_instance.on_action_taken(owner)
+                    await asyncio.sleep(0.002)
 
     async def trigger_damage_taken(self, target, attacker: Optional[Any] = None, damage: int = 0) -> None:
         """Trigger passives specifically for damage taken events."""
@@ -91,6 +94,7 @@ class PassiveRegistry:
                 stacks = min(count, getattr(cls, "max_stacks", count))
                 for _ in range(stacks):
                     await passive_instance.on_damage_taken(target, attacker, damage)
+                    await asyncio.sleep(0.002)
 
             # Also trigger passives with explicit damage_taken trigger
             if _supports_event(cls, "damage_taken"):
@@ -103,6 +107,7 @@ class PassiveRegistry:
                             await passive_instance.apply(target, attacker=attacker, damage=damage)
                         except TypeError:
                             await passive_instance.apply(target)
+                    await asyncio.sleep(0.002)
 
     async def trigger_turn_end(self, target) -> None:
         """Trigger turn end events for passives that need end-of-turn processing."""
@@ -118,6 +123,7 @@ class PassiveRegistry:
                 stacks = min(count, getattr(cls, "max_stacks", count))
                 for _ in range(stacks):
                     await passive_instance.on_turn_end(target)
+                    await asyncio.sleep(0.002)
 
     async def trigger_defeat(self, target) -> None:
         """Trigger defeat events for passives that need cleanup on defeat."""
@@ -133,6 +139,7 @@ class PassiveRegistry:
                 stacks = min(count, getattr(cls, "max_stacks", count))
                 for _ in range(stacks):
                     await passive_instance.on_defeat(target)
+                    await asyncio.sleep(0.002)
 
     async def trigger_summon_defeat(self, target, **kwargs) -> None:
         """Trigger summon defeat events for relevant passives."""
@@ -149,6 +156,7 @@ class PassiveRegistry:
                         await passive_instance.on_summon_defeat(target, **kwargs)
                     except TypeError:
                         await passive_instance.on_summon_defeat(target)
+                    await asyncio.sleep(0.002)
 
     async def trigger_hit_landed(self, attacker, target, damage: int = 0, action_type: str = "attack", **kwargs) -> None:
         """Trigger passives when a hit successfully lands."""
@@ -165,6 +173,7 @@ class PassiveRegistry:
                 stacks = min(count, getattr(cls, "max_stacks", count))
                 for _ in range(stacks):
                     await passive_instance.on_hit_landed(attacker, target, damage, action_type, **kwargs)
+                    await asyncio.sleep(0.002)
 
             # Regular passive application with enhanced context
             stacks = min(count, getattr(cls, "max_stacks", count))
@@ -177,6 +186,7 @@ class PassiveRegistry:
                     except TypeError:
                         # Fall back to simple apply for existing passives
                         await passive_instance.apply(attacker)
+                await asyncio.sleep(0.002)
 
     async def trigger_turn_start(self, target, **kwargs) -> None:
         """Trigger turn start events for passives that need turn initialization."""
@@ -197,6 +207,7 @@ class PassiveRegistry:
                 stacks = min(count, getattr(cls, "max_stacks", count))
                 for _ in range(stacks):
                     await passive_instance.on_turn_start(target, **kwargs)
+                    await asyncio.sleep(0.002)
 
             # Regular passive application only for turn_start passives; be lenient with kwargs
             if supports_turn_start:
@@ -209,6 +220,7 @@ class PassiveRegistry:
                             await passive_instance.apply(target, **kwargs)
                         except TypeError:
                             await passive_instance.apply(target)
+                    await asyncio.sleep(0.002)
 
     async def trigger_level_up(self, target, **kwargs) -> None:
         """Trigger level up events for passives that respond to leveling."""
@@ -225,6 +237,7 @@ class PassiveRegistry:
                 stacks = min(count, getattr(cls, "max_stacks", count))
                 for _ in range(stacks):
                     await passive_instance.on_level_up(target, **kwargs)
+                    await asyncio.sleep(0.002)
 
             # Regular passive application
             stacks = min(count, getattr(cls, "max_stacks", count))
@@ -241,6 +254,7 @@ class PassiveRegistry:
                             log.warning(
                                 "Passive %s incompatible with level_up kwargs", pid
                             )
+                await asyncio.sleep(0.002)
 
     def describe(self, target) -> list[dict[str, Any]]:
         """Return structured information for a target's passives."""


### PR DESCRIPTION
## Summary
- ensure passive registry yields control after each passive call with a 0.002s delay

## Testing
- `uv tool run ruff check . --fix`
- `./run-tests.sh` *(fails: Stats.__init__ unexpected keyword 'max_hp', missing battle_logging module, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68c30e2b74cc832ca15c40a3bb82b3ee