### PR TITLE
[FIX] Always unregister Thick Skin bleed listener on battle end

### DIFF
--- a/backend/plugins/cards/thick_skin.py
+++ b/backend/plugins/cards/thick_skin.py
@@ -42,9 +42,8 @@ class ThickSkin(CardBase):
         BUS.subscribe("effect_applied", _on_effect_applied)
 
         def _on_battle_end(entity) -> None:
-            if entity in party.members:
-                BUS.unsubscribe("effect_applied", _on_effect_applied)
-                BUS.unsubscribe("battle_end", _on_battle_end)
+            BUS.unsubscribe("effect_applied", _on_effect_applied)
+            BUS.unsubscribe("battle_end", _on_battle_end)
 
         BUS.subscribe("battle_end", _on_battle_end)
 


### PR DESCRIPTION
## Summary
- ensure Thick Skin card removes its bleed listener on any `battle_end` event so effects don't stack across battles

## Testing
- `uv run ruff check . --fix`
- `./run-tests.sh` *(fails: timed out tests and missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_68c310d2a458832c9fca55b7713540eb