### PR TITLE
[FIX] add aggro field to damage types

### DIFF
--- a/backend/plugins/damage_types/_base.py
+++ b/backend/plugins/damage_types/_base.py
@@ -21,6 +21,7 @@ class DamageTypeBase:
     id: str = "Generic"
     weakness: str = "none"
     color: tuple[int, int, int] = (255, 255, 255)
+    aggro: float = 0.1
 
     def is_weak(self, type_check: str) -> bool:
         return type_check == self.weakness


### PR DESCRIPTION
## Summary
- add aggro attribute with default value to DamageTypeBase so all damage type plugins share it

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: test_event_bus_batching_performance, test_many_dots_performance, test_accelerate_missing_error, more)*

------
https://chatgpt.com/codex/tasks/task_b_68c3159c517c832ca1e3b559a970ff35