### PR TITLE
[FIX] include aggro in player stats

### DIFF
--- a/backend/routes/players.py
+++ b/backend/routes/players.py
@@ -273,6 +273,7 @@ async def player_stats() -> tuple[str, int, dict[str, object]]:
             "damage_taken": player.damage_taken,
             "damage_dealt": player.damage_dealt,
             "kills": player.kills,
+            "aggro": player.aggro,
         },
         "status": {
             "passives": player.passives,


### PR DESCRIPTION
## Summary
- expose player's aggro value in advanced stats payload

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: Stats.__init__() got an unexpected keyword argument 'max_hp'; missing battle_logging module)*

------
https://chatgpt.com/codex/tasks/task_b_68c315a5c074832cbbd8d7822380cfb6