### PR TITLE
[DOCS] Document aggro stat

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -29,8 +29,8 @@ The LLM system is fully optional - players and foes function normally without LL
 All legacy characters from the Pygame version have been ported as plugins.
 Each entry notes the character's `CharacterType` and starting damage type.
 Players currently share placeholder stats of 1000 HP, 100 attack, 50 defense,
-5% crit rate, 2× crit damage, 1% effect hit, 100 mitigation, 0 dodge, and 1
-for remaining values.
+5% crit rate, 2× crit damage, 1% effect hit, 100 mitigation, 0 dodge, 0.1 aggro,
+and 1 for remaining values. Aggro defaults to `0.1` for both players and foes.
 
 Player plugins also include a `gacha_rarity` field so the gacha system can
 automatically discover 5★ and 6★ recruits.

--- a/.codex/implementation/stats-and-effects.md
+++ b/.codex/implementation/stats-and-effects.md
@@ -8,7 +8,7 @@ The `Stats` dataclass stores core attributes for both players and foes:
 - **Core:** `hp`, `max_hp`, `exp`, `level`, `exp_multiplier`, `actions_per_turn`
 - **Offense:** `atk`, `crit_rate`, `crit_damage`, `effect_hit_rate`, `damage_type`
 - **Defense:** `defense`, `mitigation`, `regain`, `dodge_odds`, `effect_resistance`
-- **Vitality & Advanced:** `vitality`, `action_points`, `damage_taken`, `damage_dealt`, `kills`
+- **Vitality & Advanced:** `vitality`, `action_points`, `damage_taken`, `damage_dealt`, `kills`, `aggro` (default `0.1`)
 - **Status Lists:** `passives`, `dots`, `hots`, `relics`
 - **Party:** `gold`, `rdr` – run-wide currency and rare drop rate multiplier applied to gold, upgrade item counts, relic odds, pull ticket chances, and (at extreme values) can roll to raise relic and card star ranks
 - **Ultimate:** `ultimate_charge`, `ultimate_ready` – charge builds with actions to power character ultimates. Ice characters gain additional charge whenever an ally acts via `handle_ally_action`.


### PR DESCRIPTION
## Summary
- document aggro stat with default 0.1 in stats overview
- mention aggro default for players and foes

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: missing modules, many failing tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c315ab1a24832c982df0fd152f4d16