### PR TITLE
[FIX] Reuse MimicPlayerCopy event listener for unsubscription

### DIFF
--- a/backend/plugins/passives/mimic_player_copy.py
+++ b/backend/plugins/passives/mimic_player_copy.py
@@ -45,10 +45,11 @@ class MimicPlayerCopy:
                 target.remove_effect_by_name(effect.name)
 
         # Subscribe to effect application events to block future buffs
-        BUS.subscribe("effect_applied", self._on_effect_applied)
+        effect_listener = self._on_effect_applied
+        BUS.subscribe("effect_applied", effect_listener)
 
         def _on_battle_end(entity) -> None:
-            BUS.unsubscribe("effect_applied", self._on_effect_applied)
+            BUS.unsubscribe("effect_applied", effect_listener)
             BUS.unsubscribe("battle_end", _on_battle_end)
 
         BUS.subscribe("battle_end", _on_battle_end)


### PR DESCRIPTION
## Summary
- reuse stored event listener in MimicPlayerCopy to allow proper unsubscription

## Testing
- `uv run ruff check . --fix`
- `./run-tests.sh` *(fails: missing frontend modules, timed out backend tests)*

------
https://chatgpt.com/codex/tasks/task_b_68c3184faf94832c83868cfb958969c2