### PR TITLE
[FIX] avoid double counting damage-type aggro

### DIFF
--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -249,7 +249,6 @@ class Stats:
         modifier = (
             self.aggro_modifier
             + self._calculate_stat_modifier("aggro_modifier")
-            + float(getattr(getattr(self, "damage_type", None), "aggro", 0.0))
         )
         return self.base_aggro * (1 + modifier + defense_term)
 


### PR DESCRIPTION
## Summary
- remove duplicate damage type contribution in `Stats.aggro`

## Testing
- `uv tool run ruff check backend --fix`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging')*

------
https://chatgpt.com/codex/tasks/task_b_68c3451118a4832cbc4eca6255d00820