### PR TITLE
[TASK] Plan daily login reward system

### DIFF
--- a/.codex/tasks/0cc586c2-login-reward-panel-ui.md
+++ b/.codex/tasks/0cc586c2-login-reward-panel-ui.md
@@ -1,0 +1,14 @@
+Coder, add a main menu panel that displays daily login rewards using left-to-right chevrons.
+
+## Requirements
+- Place the panel in the centered banner space described in `.codex/instructions/main-menu.md`.
+- Show a row of chevrons representing each day in the current streak.
+- Highlight today's chevron and list the reward items beneath it.
+- Display a countdown timer to the 2am PT reset.
+- Clear the UI and restart at day 1 if the player misses a day.
+- Fetch streak data and rewards from the new backend endpoints.
+- Ensure the panel adapts to desktop/tablet/phone breakpoints.
+
+## Notes
+- Follow existing main menu styling conventions and Lucide icon usage.
+- Include tooltip or hover text summarizing reward contents.

--- a/.codex/tasks/3c35cdc7-login-reward-api.md
+++ b/.codex/tasks/3c35cdc7-login-reward-api.md
@@ -1,0 +1,12 @@
+Coder, expose login reward progress and claiming through backend APIs.
+
+## Requirements
+- Create an endpoint to fetch current streak length, today's reward items, and time until next reset.
+- Provide an endpoint to claim the day's reward once eligible.
+- Enforce the 3-room completion requirement before allowing claims.
+- Reset streak and rewards if claim occurs after daily deadline.
+- Return reward details for frontend display (item names, star ratings, damage types).
+
+## Notes
+- Ensure endpoints integrate with authentication and existing backend framework.
+- Use PT for reset timers to match backend streak logic.

--- a/.codex/tasks/dfeacf56-login-reward-backend.md
+++ b/.codex/tasks/dfeacf56-login-reward-backend.md
@@ -1,0 +1,15 @@
+Coder, implement a backend system to grant daily login rewards that scale with consecutive play.
+
+## Requirements
+- Track per-account login streaks and last login timestamps.
+- Reset streak at 2am Pacific Time if the user misses a day.
+- Daily reward becomes available after the player completes 3 rooms in a calendar day.
+- Base reward: 1 random 1★ damage-type item each day.
+- Every 7-day streak adds +1 additional random 1★ damage-type item.
+- Every 100-day streak adds +1 random 2★ damage-type item to the daily reward.
+- Support duplicated items; no uniqueness enforcement.
+- Persist streak data in the existing player profile storage.
+
+## Notes
+- Ensure time zone handling uses PT regardless of server location.
+- Provide clear hooks to expose reward data via API.

--- a/.codex/tasks/e4b31156-login-reward-docs.md
+++ b/.codex/tasks/e4b31156-login-reward-docs.md
@@ -1,0 +1,10 @@
+Coder, document the daily login reward system and main menu panel.
+
+## Requirements
+- Add a new section to `.codex/implementation` detailing streak rules, reward scaling, and reset timing.
+- Update `.codex/instructions/main-menu.md` with notes about the login reward panel placement and behavior.
+- Mention the feature in `README.md` or other user-facing docs if appropriate.
+- Include screenshots or diagrams in `.codex/docs` after UI implementation.
+
+## Notes
+- Keep documentation under 300 lines per file and follow existing style guidelines.


### PR DESCRIPTION
## Summary
- add backend task for daily login reward streaks with 2am PT reset
- add API task for claiming and displaying rewards
- add UI task for main-menu chevron panel and countdown
- add documentation task for streak rules and panel instructions

## Testing
- `uvx ruff check . --fix`


------
https://chatgpt.com/codex/tasks/task_b_68c4382413ac832c9bf612a1d8dbbf42