### PR TITLE
Color-coded action queue entries with HP filtering

### DIFF
--- a/frontend/src/lib/battle/ActionQueue.svelte
+++ b/frontend/src/lib/battle/ActionQueue.svelte
@@ -11,27 +11,29 @@
       return combatants.find((c) => c.id === id) || { id };
     }
 
-    $: activeIndex = queue.findIndex((e) => !e.bonus);
+    $: displayQueue = queue.filter((e) => {
+      const fighter = findCombatant(e.id);
+      return fighter.hp >= 1;
+    });
+    $: activeIndex = displayQueue.findIndex((e) => !e.bonus);
   </script>
 
 <div class="action-queue" data-testid="action-queue">
-  {#each queue as entry, i (entry.bonus ? `b-${entry.id}-${i}` : entry.id)}
+  {#each displayQueue as entry, i (entry.bonus ? `b-${entry.id}-${i}` : entry.id)}
     {@const fighter = findCombatant(entry.id)}
-    {#if fighter.hp >= 1}
-      {@const elColor = getElementColor(fighter.element)}
-      <div
-        class="entry"
-        class:active={i === activeIndex}
-        class:bonus={entry.bonus}
-        style="--element-color: {elColor}"
-        animate:flip={{ duration: reducedMotion ? 0 : 220 }}
-      >
-        <img src={getCharacterImage(fighter.summon_type || fighter.id)} alt="" class="portrait" />
-        {#if showActionValues}
-          <div class="av">{Math.round(entry.action_value)}</div>
-        {/if}
-      </div>
-    {/if} <!-- filter out defeated fighters so revived ones return -->
+    {@const elColor = getElementColor(fighter.element)}
+    <div
+      class="entry"
+      class:active={i === activeIndex}
+      class:bonus={entry.bonus}
+      style="--element-color: {elColor}"
+      animate:flip={{ duration: reducedMotion ? 0 : 220 }}
+    >
+      <img src={getCharacterImage(fighter.summon_type || fighter.id)} alt="" class="portrait" />
+      {#if showActionValues}
+        <div class="av">{Math.round(entry.action_value)}</div>
+      {/if}
+    </div>
   {/each}
 </div>
 


### PR DESCRIPTION
## Summary
- color queue entries by fighter element and enlarge to rectangles
- hide defeated fighters until revived
- restyle action value badge with element-tinted design

## Testing
- `bun run lint:fix`
- `./run-tests.sh` *(fails: ENOENT for card placeholder, expectation mismatch in battle polling, vi.mock undefined, missing Pull 1 string)*

------
https://chatgpt.com/codex/tasks/task_b_68c47eeff2b0832cbf25c43d53ca27f3