### PR TITLE
Ensure progress snapshots keep active fighter first

### DIFF
--- a/backend/.codex/implementation/battle-snapshots.md
+++ b/backend/.codex/implementation/battle-snapshots.md
@@ -22,6 +22,9 @@ poll for results:
 - Progress snapshots now include `active_id`, the id of the combatant whose
   action produced the snapshot, so user interfaces can highlight the active
   fighter for both party and foe turns.
+- The action queue advances **after** progress snapshots are dispatched so the
+  active combatant remains at the head of the queue until user interfaces
+  receive and render the update.
 
 - Foe snapshots include a `rank` field describing encounter difficulty.
   Supported ranks are `"normal"`, `"prime"`, `"glitched prime"`, `"boss"`, and

--- a/backend/autofighter/rooms/battle.py
+++ b/backend/autofighter/rooms/battle.py
@@ -703,7 +703,6 @@ class BattleRoom(Room):
                         await asyncio.sleep(0.001)
                         continue
                     if progress is not None:
-                        _advance_queue(member)
                         await progress(
                             {
                                 "result": "battle",
@@ -725,6 +724,7 @@ class BattleRoom(Room):
                                 "active_id": member.id,
                             }
                         )
+                        _advance_queue(member)
                     await _pace(action_start)
                     if tgt_foe.hp <= 0:
                         await _credit_if_dead(tgt_foe)
@@ -831,7 +831,6 @@ class BattleRoom(Room):
                             await _pace(action_start)
                             continue
                         if progress is not None:
-                            _advance_queue(acting_foe)
                             await progress(
                                 {
                                     "result": "battle",
@@ -857,6 +856,7 @@ class BattleRoom(Room):
                                     "active_id": acting_foe.id,
                                 }
                             )
+                            _advance_queue(acting_foe)
                         await _pace(action_start)
                         await asyncio.sleep(0.001)
                         break
@@ -913,7 +913,6 @@ class BattleRoom(Room):
                         await asyncio.sleep(0.001)
                         continue
                     if progress is not None:
-                        _advance_queue(acting_foe)
                         await progress(
                             {
                                 "result": "battle",
@@ -939,6 +938,7 @@ class BattleRoom(Room):
                                 "active_id": acting_foe.id,
                             }
                         )
+                        _advance_queue(acting_foe)
                     await _pace(action_start)
                     await asyncio.sleep(0.001)
                     break


### PR DESCRIPTION
## Summary
- emit progress updates before moving to the next actor so snapshots show the current combatant at the front of the queue
- document that the action queue advances only after dispatching progress snapshots

## Testing
- `./run-tests.sh` *(fails: tests timed out or failed)*

------
https://chatgpt.com/codex/tasks/task_b_68c511905ecc832cbebfdfc33bcd1667