### PR TITLE
[FIX] clear summons on defeat and battle reset

### DIFF
--- a/.codex/implementation/battle-room.md
+++ b/.codex/implementation/battle-room.md
@@ -4,8 +4,9 @@
 
 The room deep-copies the run's party for combat. When the fight ends, remaining
 HP and accumulated experience are synced back so level-ups and damage persist
-into subsequent rooms. All summons and related tracking are cleared to prevent
-them from leaking into later encounters.
+into subsequent rooms. `SummonManager.reset_all()` runs at battle start so all
+summons and related tracking are cleared, preventing leftovers from leaking
+into later encounters.
 
 ## Action Queue Flow
 

--- a/.codex/implementation/summons-system.md
+++ b/.codex/implementation/summons-system.md
@@ -41,6 +41,8 @@ The Midori AI AutoFighter now has a unified summons system that provides a consi
 - Battle event integration for cleanup
 - Turn-based expiration for temporary summons
 - Summoner defeat cleanup
+- `SummonManager.reset_all()` runs at the start of each battle to remove any
+  leftover summons from previous encounters
 
 ## Usage Examples
 
@@ -115,7 +117,8 @@ The summons system integrates with the existing event bus:
 - `battle_start`: Resets temporary tracking
 - `battle_end`: Cleans up temporary summons
 - `turn_start`: Processes turn expiration
-- `entity_defeat`: Removes summoner's summons
+- `entity_defeat`: Emitted automatically when an entity's HP reaches zero and
+  again during battle cleanup; removes the summoner's active summons
 
 ## Testing
 

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -647,9 +647,18 @@ class Stats:
         if amount > 0:
             self.hp = max(self.hp - amount, 0)
 
-        # Emit kill event if this damage killed the target - async for better performance
-        if old_hp > 0 and self.hp <= 0 and attacker is not None:
-            await BUS.emit_async("entity_killed", self, attacker, original_amount, "death", {"killer_id": getattr(attacker, "id", "unknown")})
+        # Emit defeat/kill events if this damage reduced HP to zero
+        if old_hp > 0 and self.hp <= 0:
+            if attacker is not None:
+                await BUS.emit_async(
+                    "entity_killed",
+                    self,
+                    attacker,
+                    original_amount,
+                    "death",
+                    {"killer_id": getattr(attacker, "id", "unknown")},
+                )
+            await BUS.emit_async("entity_defeat", self)
 
         # Trigger passive registry for damage taken events
         if original_amount > 0:


### PR DESCRIPTION
## Summary
- emit defeat events when entities reach 0 HP and at battle cleanup
- reset SummonManager before battles to prevent leftover summons
- test summon cleanup on defeat and at battle start

## Testing
- `ruff check . --fix`
- `uv run pytest tests/test_summons_system.py::test_summon_defeat_cleanup tests/test_summons_system.py::test_summons_reset_before_new_battle -q`


------
https://chatgpt.com/codex/tasks/task_b_68c5bb49d2f0832c8be2c13b52ea2524