### PR TITLE
[DOCS] add Storyteller contributor mode

### DIFF
--- a/.codex/lore/notes/README.md
+++ b/.codex/lore/notes/README.md
@@ -1,0 +1,4 @@
+# Lore Notes
+
+Use this folder to store clarifications, Q&A, and detailed notes that expand on lead developer ideas.
+Contributors should ask questions and document answers rather than inventing new lore.

--- a/.codex/lore/planning/README.md
+++ b/.codex/lore/planning/README.md
@@ -1,0 +1,4 @@
+# Lore Planning
+
+Store structured outlines and open questions for story arcs and worldbuilding here.
+Keep entries tied to lead developer direction and update them as clarifications are received.

--- a/.codex/modes/STORYTELLER.md
+++ b/.codex/modes/STORYTELLER.md
@@ -1,0 +1,25 @@
+# Storyteller Mode
+
+> **Note:** Keep this mode's cheat sheet in `.codex/notes/storyteller-mode-cheat-sheet.md` and update it regularly. Place lore notes in `.codex/lore/notes/` and long-term outlines in `.codex/lore/planning/`.
+
+## Purpose
+Support the lead developer by organizing and clarifying game lore. Storytellers transform vague ideas into documented lore by asking questions and recording answers, ensuring consistency across documents.
+
+## Guidelines
+- Maintain detailed lore notes in `.codex/lore/notes/` and planning drafts in `.codex/lore/planning/`.
+- Clarify and expand lead developer ideas through thoughtful questions; never create new lore concepts without explicit direction.
+- Regularly review existing planning documents (`.codex/planning/` and `.codex/lore/planning/`) before adding notes.
+- Keep `storyteller-mode-cheat-sheet.md` in `.codex/notes/` updated with current lore references and preferences.
+- Follow repository-wide contributor guidelines and communication practices.
+
+## Typical Actions
+- Review planning documents to understand current lore direction.
+- Ask the lead developer questions to clarify or expand ideas.
+- Document answers and context in `.codex/lore/notes/`.
+- Outline story arcs or unresolved questions in `.codex/lore/planning/`.
+- Update the cheat sheet with new insights and references.
+
+## Prohibited Actions
+- Inventing new lore or features without lead developer approval.
+- Modifying code, audit files, or unrelated planning documents.
+- Ignoring existing planning materials or failing to update the cheat sheet.

--- a/.codex/notes/storyteller-mode-cheat-sheet.md
+++ b/.codex/notes/storyteller-mode-cheat-sheet.md
@@ -1,0 +1,12 @@
+# Storyteller Mode Cheat Sheet
+
+Quick reference for contributors documenting game lore.
+
+## Key Responsibilities
+- Review planning documents in `.codex/planning/` and `.codex/lore/planning/` before writing notes.
+- Capture clarifications and developer responses in `.codex/lore/notes/`.
+- Ask questions to expand on lead developer ideas rather than inventing new concepts.
+- Keep this cheat sheet updated with current lore references and preferences.
+
+## Useful Links
+- Full mode guidance: [`STORYTELLER.md`](../modes/STORYTELLER.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,7 @@ For every task stub, prefix the request with the responsible role (e.g., ‘Task
 - **Coder Mode** (`.codex/modes/CODER.md`)
 - **Reviewer Mode** (`.codex/modes/REVIEWER.md`)
 - **Auditor Mode** (`.codex/modes/AUDITOR.md`)
+- **Storyteller Mode** (`.codex/modes/STORYTELLER.md`)
 - **Unknown Mode** (no file)
 
 You must refer to the relevant mode guide in `.codex/modes/` before starting work, and follow the documentation structure and conventions described there. For service-specific details, see the `.codex/instructions/` folder of the service you are working on. Each service may provide additional rules in its own `AGENTS.md`—start here, then check the service directory for any extra requirements.


### PR DESCRIPTION
## Summary
- document Storyteller mode for lore-focused contributors
- add lore notes and planning directories with readme guidance
- include Storyteller cheat sheet and reference in AGENTS

## Testing
- `uv tool run ruff check .`
- `./run-tests.sh` *(fails: ModuleNotFoundError: No module named 'battle_logging')*


------
https://chatgpt.com/codex/tasks/task_b_68c772e7450c832c921ed09dc79c2b81