### PR TITLE
Refactor frontend into modular components

### DIFF
--- a/frontend/src/lib/components/Inventory.svelte
+++ b/frontend/src/lib/components/Inventory.svelte
@@ -79,19 +79,27 @@
   $: relicEntries = count(relics || []);
   $: materialEntries = Object.entries(materials || {}); // [key, qty]
 
-  $: sortedCards = [...cardEntries].sort((a, b) => {
+  $: sortedCardEntries = [...cardEntries].sort((a, b) => {
     const [idA] = a; const [idB] = b;
     const s = cardStars(idB) - cardStars(idA);
     if (s !== 0) return s;
     return cardName(idA).localeCompare(cardName(idB));
   });
+  $: sortedCards = sortedCardEntries.map(([id, qty]) => [
+    { id, name: cardName(id), stars: cardStars(id), about: cardDesc(id) },
+    qty
+  ]);
 
-  $: sortedRelics = [...relicEntries].sort((a, b) => {
+  $: sortedRelicEntries = [...relicEntries].sort((a, b) => {
     const [idA] = a; const [idB] = b;
     const s = relicStars(idB) - relicStars(idA);
     if (s !== 0) return s;
     return relicName(idA).localeCompare(relicName(idB));
   });
+  $: sortedRelics = sortedRelicEntries.map(([id, qty]) => [
+    { id, name: relicName(id), stars: relicStars(id), about: relicDesc(id) },
+    qty
+  ]);
 
   // Get total counts
   $: cardCount = cards?.length || 0;
@@ -151,11 +159,11 @@
   // Set initial selection when data loads
   $: if (metaReady && !selectedItem) {
     if (activeTab === 'cards' && sortedCards.length > 0) {
-      const [id, qty] = sortedCards[0];
-      selectItem(id, 'card', qty);
+      const [entry, qty] = sortedCards[0];
+      selectItem(entry.id, 'card', qty);
     } else if (activeTab === 'relics' && sortedRelics.length > 0) {
-      const [id, qty] = sortedRelics[0];
-      selectItem(id, 'relic', qty);
+      const [entry, qty] = sortedRelics[0];
+      selectItem(entry.id, 'relic', qty);
     } else if (activeTab === 'materials' && materialEntries.length > 0) {
       const [id, qty] = materialEntries[0];
       selectItem(id, 'material', qty);
@@ -168,11 +176,11 @@
     selectedItem = null;
     // Auto-select first item in new tab
     if (tab === 'cards' && sortedCards.length > 0) {
-      const [id, qty] = sortedCards[0];
-      selectItem(id, 'card', qty);
+      const [entry, qty] = sortedCards[0];
+      selectItem(entry.id, 'card', qty);
     } else if (tab === 'relics' && sortedRelics.length > 0) {
-      const [id, qty] = sortedRelics[0];
-      selectItem(id, 'relic', qty);
+      const [entry, qty] = sortedRelics[0];
+      selectItem(entry.id, 'relic', qty);
     } else if (tab === 'materials' && materialEntries.length > 0) {
       const [id, qty] = materialEntries[0];
       selectItem(id, 'material', qty);

--- a/frontend/src/lib/components/battle-review/RewardList.svelte
+++ b/frontend/src/lib/components/battle-review/RewardList.svelte
@@ -1,22 +1,27 @@
 <script>
   import RewardCard from '../RewardCard.svelte';
   import CurioChoice from '../CurioChoice.svelte';
+  import { createEventDispatcher } from 'svelte';
   export let cards = [];
   export let relics = [];
+  const dispatch = createEventDispatcher();
+  function forward(e) {
+    dispatch('select', e.detail);
+  }
 </script>
 
 <div class="reward-list">
   {#if cards.length}
     <div class="cards">
       {#each cards as card}
-        <RewardCard {card} />
+        <RewardCard entry={card} on:select={forward} />
       {/each}
     </div>
   {/if}
   {#if relics.length}
     <div class="relics">
       {#each relics as relic}
-        <CurioChoice {relic} />
+        <CurioChoice entry={relic} on:select={forward} />
       {/each}
     </div>
   {/if}

--- a/frontend/src/lib/components/inventory/CardView.svelte
+++ b/frontend/src/lib/components/inventory/CardView.svelte
@@ -5,9 +5,9 @@
 </script>
 
 <div class="card-view">
-  {#each cards as [id, qty]}
-    <div class="card-item" on:click={() => select(id, 'card', qty)}>
-      <CardArt id={id} stars={1} />
+  {#each cards as [entry, qty]}
+    <div class="card-item" on:click={() => select(entry.id, 'card', qty)}>
+      <CardArt {entry} type="card" />
       <span class="qty">{qty}</span>
     </div>
   {/each}

--- a/frontend/src/lib/components/inventory/RelicView.svelte
+++ b/frontend/src/lib/components/inventory/RelicView.svelte
@@ -5,9 +5,9 @@
 </script>
 
 <div class="relic-view">
-  {#each relics as [id, qty]}
-    <div class="relic-item" on:click={() => select(id, 'relic', qty)}>
-      <CurioChoice id={id} />
+  {#each relics as [entry, qty]}
+    <div class="relic-item" on:click={() => select(entry.id, 'relic', qty)}>
+      <CurioChoice entry={entry} />
       <span class="qty">{qty}</span>
     </div>
   {/each}


### PR DESCRIPTION
## Summary
- Pass reward entries and forward select events in RewardList
- Render inventory cards and relics via entry props and metadata

## Testing
- `bun run lint`
- `bun test` *(fails: Party persistence, state polling, asset placeholders)*

------
https://chatgpt.com/codex/tasks/task_b_68c7fe94cc60832c82de61f281a81839