### PR TITLE
Update inventory subcomponent tests to match component markup

### DIFF
--- a/frontend/tests/inventory-subcomponents.test.js
+++ b/frontend/tests/inventory-subcomponents.test.js
@@ -8,10 +8,10 @@ const materialsPanel = readFileSync(join(import.meta.dir, '../src/lib/components
 
 describe('inventory subcomponents', () => {
   test('CardView lists cards', () => {
-    expect(cardView).toContain('card-view');
+    expect(cardView).toContain('cards-grid');
   });
   test('RelicView lists relics', () => {
-    expect(relicView).toContain('relic-view');
+    expect(relicView).toContain('relics-grid');
   });
   test('MaterialsPanel shows materials grid', () => {
     expect(materialsPanel).toContain('materials-grid');


### PR DESCRIPTION
## Summary
- adjust inventory subcomponent tests to look for `cards-grid` and `relics-grid`

## Testing
- `bun run lint`
- `bun test` *(fails: party persistence, state polling, asset placeholders, inventory subcomponents)*

------
https://chatgpt.com/codex/tasks/task_b_68c81d7acc64832ca6411773625da5f9