### PR TITLE
chore: fix docker fallback in test runner

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -66,7 +66,6 @@ yay -S --noconfirm uv bun-bin || true
 
 echo "[docker][install] prepare finished"
 EOF
-  fi
 
   # If fallback requested, prepare local env now
   LOCAL_PYTHON_CMD=""


### PR DESCRIPTION
## Summary
- keep Docker setup block open by removing early `fi`
- keep fallback prep and `else` branch inside Docker availability check

## Testing
- [ ] Backend tests (failing: numerous missing modules)
- [ ] Frontend tests (not run)
- [x] Linting
- [ ] Doc sync updates (N/A)


------
https://chatgpt.com/codex/tasks/task_b_68c82fbb7a3c832c8c953882ceb56ff3