### PR TITLE
[FIX] modularize battle room logic - guard lightning aftertaste scheduling

### DIFF
--- a/backend/plugins/damage_types/lightning.py
+++ b/backend/plugins/damage_types/lightning.py
@@ -61,15 +61,17 @@ class Lightning(DamageTypeBase):
         actor._lightning_aftertaste_stacks = stacks
 
         if not hasattr(actor, "_lightning_aftertaste_handler"):
-            def _hit(atk, tgt, amount, *_args) -> None:
-                if atk is actor:
-                    from plugins.effects.aftertaste import Aftertaste
+            async def _hit(atk, tgt, amount, *_args) -> None:
+                if atk is not actor:
+                    return
 
-                    asyncio.create_task(
-                        Aftertaste(
-                            hits=getattr(actor, "_lightning_aftertaste_stacks", 0)
-                        ).apply(atk, tgt)
-                    )
+                hits = getattr(actor, "_lightning_aftertaste_stacks", 0)
+                if hits <= 0:
+                    return
+
+                from plugins.effects.aftertaste import Aftertaste
+
+                await Aftertaste(hits=hits).apply(atk, tgt)
 
             def _clear(_):
                 BUS.unsubscribe("hit_landed", _hit)


### PR DESCRIPTION
## Summary
- split battle logic into dedicated modules and expose them via a new `autofighter.rooms.battle` package
- document combat log utilities, pacing helpers, and reward helpers
- update room imports and sync docs with new module paths
- run the lightning Aftertaste hit subscriber as a coroutine so it executes on the battle loop instead of spawning a task when no event loop exists

## Testing
- `uv run ruff check backend`
- `uv run pytest tests/test_lightning_ultimate.py` *(fails: `BUS.emit` smoke check assumes immediate batch processing; unchanged from main)*

------
https://chatgpt.com/codex/tasks/task_b_68c84062afe0832caf5648e4eb08937b