### PR TITLE
feat: extract battle setup helpers

### DIFF
--- a/backend/.codex/implementation/battle-logging.md
+++ b/backend/.codex/implementation/battle-logging.md
@@ -6,6 +6,7 @@ The battle logging system provides structured, organized logging for battles wit
 - `battle_logging/summary.py` – dataclasses representing events and battle summaries.
 - `battle_logging/writers.py` – high level run and battle log writers.
 - `rooms/battle/logging.py` – combat-log queue utilities.
+- `rooms/battle/setup.py` – prepares parties/foes and starts battle logging once participants are known.
 
 ## Folder Structure
 
@@ -154,6 +155,7 @@ Total Events: 45
 - Logs are organized by run ID and battle index for easy navigation
 - Each battle gets its own logger instance to prevent interference
 - Call `start_battle_logging()` only once per battle after participants are set; additional calls finalize the previous battle as "interrupted"
+- `rooms/battle/setup.py` performs that participant preparation asynchronously before `BattleRoom.resolve` emits any events, ensuring the logger captures the correct party and foe state.
 
 ## Battle Review API
 

--- a/backend/autofighter/rooms/battle/pacing.py
+++ b/backend/autofighter/rooms/battle/pacing.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 
-from ..action_queue import ActionQueue
-from ..stats import BUS
-from ..stats import Stats
+from autofighter.action_queue import ActionQueue
+from autofighter.stats import BUS
+from autofighter.stats import Stats
 
 TURN_PACING = 0.5
 

--- a/backend/autofighter/rooms/battle/setup.py
+++ b/backend/autofighter/rooms/battle/setup.py
@@ -1,0 +1,132 @@
+"""Battle setup helpers for :mod:`autofighter.rooms.battle`."""
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from typing import Sequence
+
+from battle_logging.writers import BattleLogger
+from battle_logging.writers import start_battle_logging
+
+from autofighter.action_queue import ActionQueue
+from autofighter.cards import apply_cards
+from autofighter.effects import EffectManager
+from autofighter.effects import StatModifier
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.passives import PassiveRegistry
+from autofighter.relics import apply_relics
+from autofighter.stats import Stats
+from autofighter.summons.manager import SummonManager
+
+from ..utils import _build_foes
+from ..utils import _scale_stats
+from .pacing import set_visual_queue
+
+
+@dataclass(slots=True)
+class BattleSetupResult:
+    """Container for data produced during battle setup."""
+
+    registry: PassiveRegistry
+    combat_party: Party
+    foes: list[Stats]
+    foe_effects: list[EffectManager]
+    enrage_mods: list[StatModifier | None]
+    visual_queue: ActionQueue | None
+    battle_logger: BattleLogger | None
+
+
+async def _clone_members(members: Sequence[Stats]) -> list[Stats]:
+    """Create deep copies of party members for combat."""
+
+    return [copy.deepcopy(member) for member in members]
+
+
+async def _apply_relics_async(party: Party) -> None:
+    """Asynchronously apply relic effects to a party."""
+
+    apply_relics(party)
+
+
+async def setup_battle(
+    node: MapNode,
+    party: Party,
+    *,
+    foe: Stats | list[Stats] | None = None,
+    strength: float = 1.0,
+) -> BattleSetupResult:
+    """Prepare combatants and battle state before a fight begins."""
+
+    registry = PassiveRegistry()
+    SummonManager.reset_all()
+
+    if foe is None:
+        foes = _build_foes(node, party)
+    else:
+        foes = foe if isinstance(foe, list) else [foe]
+
+    for stats in foes:
+        _scale_stats(stats, node, strength)
+
+    members = await _clone_members(party.members)
+    combat_party = Party(
+        members=members,
+        gold=party.gold,
+        relics=party.relics,
+        cards=party.cards,
+        rdr=party.rdr,
+    )
+
+    await apply_cards(combat_party)
+    await _apply_relics_async(combat_party)
+    party.rdr = combat_party.rdr
+
+    foe_effects: list[EffectManager] = []
+    for stats in foes:
+        manager = EffectManager(stats)
+        stats.effect_manager = manager
+        foe_effects.append(manager)
+
+    enrage_mods: list[StatModifier | None] = [None for _ in foes]
+
+    try:
+        from autofighter.stats import set_battle_active
+
+        set_battle_active(True)
+    except Exception:
+        pass
+
+    for member in combat_party.members:
+        manager = EffectManager(member)
+        member.effect_manager = manager
+
+    try:
+        entities = list(combat_party.members) + list(foes)
+        visual_queue: ActionQueue | None = ActionQueue(entities)
+    except Exception:
+        visual_queue = None
+
+    set_visual_queue(visual_queue)
+
+    battle_logger = start_battle_logging()
+    try:
+        if battle_logger is not None:
+            battle_logger.summary.party_members = [m.id for m in combat_party.members]
+            battle_logger.summary.foes = [f.id for f in foes]
+            relic_counts: dict[str, int] = {}
+            for relic_id in combat_party.relics:
+                relic_counts[relic_id] = relic_counts.get(relic_id, 0) + 1
+            battle_logger.summary.party_relics = relic_counts
+    except Exception:
+        pass
+
+    return BattleSetupResult(
+        registry=registry,
+        combat_party=combat_party,
+        foes=foes,
+        foe_effects=foe_effects,
+        enrage_mods=enrage_mods,
+        visual_queue=visual_queue,
+        battle_logger=battle_logger,
+    )

--- a/backend/tests/test_battle_setup.py
+++ b/backend/tests/test_battle_setup.py
@@ -1,0 +1,36 @@
+import pytest
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms.battle.setup import setup_battle
+from autofighter.stats import Stats
+
+
+@pytest.mark.asyncio
+async def test_setup_battle_prepares_combat_state():
+    node = MapNode(room_id=0, room_type="battle-normal", floor=1, index=1, loop=1, pressure=0)
+
+    member = Stats()
+    member.id = "hero"
+    member.hp = member.max_hp
+
+    foe = Stats()
+    foe.id = "foe"
+    foe.hp = foe.max_hp
+
+    party = Party(members=[member], gold=25, relics=[], cards=[], rdr=1.0)
+
+    result = await setup_battle(node, party, foe=foe)
+
+    assert result.registry is not None
+    assert result.combat_party is not party
+    assert len(result.combat_party.members) == 1
+    prepared_member = result.combat_party.members[0]
+    assert prepared_member is not member
+    assert prepared_member.effect_manager is not None
+    assert result.foes == [foe]
+    assert foe.effect_manager is not None
+    assert len(result.enrage_mods) == len(result.foes)
+    assert result.visual_queue is not None
+    assert party.rdr == result.combat_party.rdr
+    assert result.battle_logger is None


### PR DESCRIPTION
## Summary
- extract the battle preparation logic into `rooms/battle/setup.py` and expose an awaitable `setup_battle` helper
- refactor `BattleRoom.resolve` to call the new helper and rely on awaitable helpers instead of `asyncio.to_thread`
- switch battle pacing imports to absolute paths, document the setup helper, and add a unit test that exercises `setup_battle`

## Testing
- `uv run ruff check . --fix`
- `uv run pytest` *(fails: large number of pre-existing test failures in the backend suite)*
- `PYTHONPATH=. uv run pytest tests/test_battle_setup.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68c8423df298832c90a19cfdbc24c430