### PR TITLE
Refactor enrage threshold computation

### DIFF
--- a/backend/autofighter/rooms/__init__.py
+++ b/backend/autofighter/rooms/__init__.py
@@ -17,9 +17,9 @@ class Room:
         raise NotImplementedError
 
 
-from .battle.core import ENRAGE_TURNS_BOSS  # noqa: E402
-from .battle.core import ENRAGE_TURNS_NORMAL  # noqa: E402
 from .battle.core import BattleRoom  # noqa: E402
+from .battle.enrage import ENRAGE_TURNS_BOSS  # noqa: E402
+from .battle.enrage import ENRAGE_TURNS_NORMAL  # noqa: E402
 from .boss import BossRoom  # noqa: E402
 from .chat import ChatRoom  # noqa: E402
 from .shop import ShopRoom  # noqa: E402

--- a/backend/autofighter/rooms/battle/core.py
+++ b/backend/autofighter/rooms/battle/core.py
@@ -12,10 +12,10 @@ from autofighter.mapgen import MapNode
 from ...party import Party
 from .. import Room
 from .engine import run_battle
+from .enrage import ENRAGE_TURNS_BOSS
+from .enrage import ENRAGE_TURNS_NORMAL
+from .enrage import compute_enrage_threshold
 from .setup import setup_battle
-
-ENRAGE_TURNS_NORMAL = 100
-ENRAGE_TURNS_BOSS = 500
 
 
 @dataclass
@@ -45,18 +45,7 @@ class BattleRoom(Room):
             foe=foe,
             strength=self.strength,
         )
-        try:
-            from autofighter import rooms as rooms_module
-        except Exception:
-            rooms_module = None
-
-        base_normal = ENRAGE_TURNS_NORMAL
-        base_boss = ENRAGE_TURNS_BOSS
-        if rooms_module is not None:
-            base_normal = getattr(rooms_module, "ENRAGE_TURNS_NORMAL", base_normal)
-            base_boss = getattr(rooms_module, "ENRAGE_TURNS_BOSS", base_boss)
-
-        threshold = base_boss if isinstance(self, BossRoom) else base_normal
+        threshold = await compute_enrage_threshold(self)
 
         return await run_battle(
             self,
@@ -72,7 +61,6 @@ class BattleRoom(Room):
 
 
 from ...stats import Stats  # noqa: E402  # imported for type annotations
-from ..boss import BossRoom  # noqa: E402  # imported for isinstance checks
 
 __all__ = [
     "BattleRoom",

--- a/backend/autofighter/rooms/battle/enrage.py
+++ b/backend/autofighter/rooms/battle/enrage.py
@@ -1,0 +1,63 @@
+"""Enrage threshold helpers for battle rooms."""
+
+from __future__ import annotations
+
+import asyncio
+from types import ModuleType
+from typing import TYPE_CHECKING
+
+ENRAGE_TURNS_NORMAL = 100
+ENRAGE_TURNS_BOSS = 500
+
+if TYPE_CHECKING:
+    from .. import Room
+
+
+def _resolve_overrides(
+    rooms_module: ModuleType,
+    default_normal: int,
+    default_boss: int,
+) -> tuple[int, int]:
+    """Extract enrage overrides from the rooms module."""
+
+    normal = getattr(rooms_module, "ENRAGE_TURNS_NORMAL", default_normal)
+    boss = getattr(rooms_module, "ENRAGE_TURNS_BOSS", default_boss)
+    return normal, boss
+
+
+async def compute_enrage_threshold(room: Room) -> int:
+    """Compute the enrage threshold for the given room."""
+
+    base_normal = ENRAGE_TURNS_NORMAL
+    base_boss = ENRAGE_TURNS_BOSS
+
+    try:
+        from autofighter import rooms as rooms_module
+    except Exception:  # pragma: no cover - defensive against dynamic loaders
+        rooms_module = None
+
+    if rooms_module is not None:
+        base_normal, base_boss = await asyncio.to_thread(
+            _resolve_overrides,
+            rooms_module,
+            base_normal,
+            base_boss,
+        )
+
+    boss_type = None
+    if rooms_module is not None:
+        boss_type = getattr(rooms_module, "BossRoom", None)
+
+    if boss_type is None:
+        from ..boss import BossRoom  # imported lazily to avoid circular imports
+
+        boss_type = BossRoom
+
+    return base_boss if isinstance(room, boss_type) else base_normal
+
+
+__all__ = [
+    "ENRAGE_TURNS_NORMAL",
+    "ENRAGE_TURNS_BOSS",
+    "compute_enrage_threshold",
+]


### PR DESCRIPTION
## Summary
- add a dedicated `enrage` helper module that owns the enrage constants and async threshold computation
- update the battle room core logic to use the helper and keep constants re-exported for callers
- wire the rooms package to source enrage constants from the new helper module

## Testing
- `uv run ruff check backend`
- `cd backend && PYTHONPATH=$PWD uv run pytest tests/test_enrage_stacking.py`


------
https://chatgpt.com/codex/tasks/task_b_68c8d1926598832c846a042f3bf97642