### PR TITLE
Improve battle setup async helpers

### DIFF
--- a/backend/autofighter/rooms/battle/setup.py
+++ b/backend/autofighter/rooms/battle/setup.py
@@ -50,7 +50,14 @@ async def _clone_members(members: Sequence[Stats]) -> list[Stats]:
 async def _apply_relics_async(party: Party) -> None:
     """Asynchronously apply relic effects to a party."""
 
-    await asyncio.to_thread(apply_relics, party)
+    # `apply_relics` relies on `safe_async_task` to schedule follow-up coroutine
+    # work on the running event loop. When executed inside ``asyncio.to_thread``
+    # there is no active loop, so the helper falls back to spinning up a
+    # temporary loop via ``asyncio.run``. That temporary loop is torn down as
+    # soon as the coroutine returns, cancelling any batched bus emissions (for
+    # example, healing notifications). Keep the call on the main loop so that
+    # relic effects continue to dispatch their async side effects.
+    apply_relics(party)
 
 
 async def setup_battle(


### PR DESCRIPTION
## Summary
- offload party cloning in battle setup to `asyncio.to_thread`
- keep relic application on the main loop so async side effects continue to dispatch
- document the non-blocking battle setup behavior in backend `.codex`

## Testing
- `uv run ruff check backend/autofighter/rooms/battle/setup.py`
- `uv run pytest` *(fails: known missing accelerate features and other pre-existing test failures; run interrupted after several minutes)*

------
https://chatgpt.com/codex/tasks/task_b_68c9351b30ec832ca8de40a140c260b3