### PR TITLE
fix: allow heal subscribers to accept source metadata

### DIFF
--- a/backend/plugins/relics/rusty_buckle.py
+++ b/backend/plugins/relics/rusty_buckle.py
@@ -107,7 +107,7 @@ class RustyBuckle(RelicBase):
                             foe = random.choice(state["foes"])
                             safe_async_task(Aftertaste(base_pot=dmg).apply(target, foe))
 
-            def _heal(target, healer, _amount) -> None:
+            def _heal(target, healer, _amount, *_args) -> None:
                 if target in party.members:
                     state["prev_hp"][id(target)] = target.hp
 

--- a/backend/tests/test_card_rewards.py
+++ b/backend/tests/test_card_rewards.py
@@ -250,7 +250,7 @@ async def test_vital_surge_low_hp_bonus():
     await BUS.emit_async("turn_start")
     assert member.atk == int(200 * 1.55)
     member.hp = member.max_hp
-    await BUS.emit_async("heal_received", member, member, 100)
+    await BUS.emit_async("heal_received", member, member, 100, None, None)
     assert member.atk == 200
 
 

--- a/backend/tests/test_rusty_buckle.py
+++ b/backend/tests/test_rusty_buckle.py
@@ -38,7 +38,7 @@ def bus(monkeypatch):
 
     async def simple_heal(self, amount, healer=None):
         self.hp = min(self.hp + int(amount), self.max_hp)
-        await bus.emit_async("heal_received", self, healer, amount)
+        await bus.emit_async("heal_received", self, healer, amount, None, None)
         return int(amount)
 
     monkeypatch.setattr(PlayerBase, "apply_damage", simple_damage)


### PR DESCRIPTION
## Summary
- allow Rusty Buckle's heal listener to absorb the newly added heal source metadata arguments
- update tests that manually emit `heal_received` to include the new source metadata parameters

## Testing
- `pytest tests/test_rusty_buckle.py tests/test_card_rewards.py -q` *(fails: ModuleNotFoundError: No module named 'autofighter')*


------
https://chatgpt.com/codex/tasks/task_b_68cba303d1d4832cb712b379af612b1f