### PR TITLE
Fix slime base stats scaling before room scaling

### DIFF
--- a/backend/plugins/foes/slime.py
+++ b/backend/plugins/foes/slime.py
@@ -18,8 +18,6 @@ class Slime(FoeBase):
     min_defense_override: int = 0
 
     def __post_init__(self) -> None:
-        super().__post_init__()
-
         scale = 0.1
         base_stats = {
             "max_hp",
@@ -35,7 +33,10 @@ class Slime(FoeBase):
             "vitality",
         }
 
-        for dataclass_field in fields(FoeBase):
+        scaled_numeric: dict[str, int | float] = {}
+        scaled_base_stats: dict[str, int | float] = {}
+
+        for dataclass_field in fields(type(self)):
             name = dataclass_field.name
             if name.startswith("_base_"):
                 continue
@@ -45,17 +46,20 @@ class Slime(FoeBase):
                 continue
 
             scaled_value = type(value)(value * scale)
+            scaled_numeric[name] = scaled_value
 
             if name in base_stats:
-                self.set_base_stat(name, scaled_value)
+                scaled_base_stats[name] = scaled_value
 
+        super().__post_init__()
+
+        for stat_name, scaled_value in scaled_base_stats.items():
+            self.set_base_stat(stat_name, scaled_value)
+
+        for name, scaled_value in scaled_numeric.items():
             setattr(self, name, scaled_value)
 
-        if isinstance(getattr(self, "max_hp", None), (int, float)):
-            self.hp = type(self.hp)(getattr(self, "max_hp"))
-
-        defense_base = self.get_base_stat("defense")
-        if isinstance(defense_base, (int, float)):
-            reduced_defense = int(defense_base * scale)
-            self.set_base_stat("defense", reduced_defense)
-            setattr(self, "defense", reduced_defense)
+        max_hp_value = getattr(self, "max_hp", None)
+        if isinstance(max_hp_value, (int, float)):
+            current_hp = getattr(self, "hp", max_hp_value)
+            setattr(self, "hp", type(current_hp)(max_hp_value))

--- a/backend/tests/test_slime_scaling.py
+++ b/backend/tests/test_slime_scaling.py
@@ -1,0 +1,34 @@
+import random
+
+from autofighter.mapgen import MapNode
+from autofighter.rooms.utils import _scale_stats
+from plugins.foes.slime import Slime
+
+
+def test_slime_scaling_uses_reduced_base_stats() -> None:
+    random.seed(0)
+
+    slime = Slime()
+
+    assert slime.max_hp == 100
+    assert slime.atk == 10
+    assert slime.defense == 5
+
+    assert slime.get_base_stat("max_hp") == 100
+    assert slime.get_base_stat("atk") == 10
+    assert slime.get_base_stat("defense") == 5
+
+    node = MapNode(
+        room_id=1,
+        room_type="battle-normal",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+
+    _scale_stats(slime, node)
+
+    assert slime.max_hp == 50
+    assert slime.atk == 5
+    assert slime.defense == 0


### PR DESCRIPTION
## Summary
- ensure the slime foe seeds its reduced base stats prior to room scaling so `_scale_stats` operates on the lowered values
- add a regression test that verifies slime stats stay reduced after scaling on a default map node

## Testing
- `uv run --project backend pytest backend/tests` *(fails: existing SyntaxError in test_event_bus_performance.py due to top-level await, also affects test_spiked_shield.py)*

------
https://chatgpt.com/codex/tasks/task_b_68cc2971bad8832ca486bedcb5df6d54