### PR TITLE
Fix Supercell hit landed hook

### DIFF
--- a/backend/plugins/passives/lady_storm_supercell.py
+++ b/backend/plugins/passives/lady_storm_supercell.py
@@ -163,7 +163,14 @@ class LadyStormSupercell:
 
         self._storm_phase[entity_id] = "wind"
 
-    async def on_hit_target(self, attacker: "Stats", target_hit: "Stats") -> None:
+    async def on_hit_landed(
+        self,
+        attacker: "Stats",
+        target_hit: "Stats",
+        damage: int = 0,
+        action_type: str = "attack",
+        **_: object,
+    ) -> None:
         """Detonate stored lightning charges when Lady Storm connects a strike."""
 
         attacker_id = id(attacker)


### PR DESCRIPTION
## Summary
- rename Lady Storm's lightning detonation hook to `on_hit_landed` so the dispatcher invokes it
- accept the full dispatcher signature while ignoring unused context to keep Supercell charge effects firing

## Testing
- uv run pytest tests/test_advanced_passive_behaviors.py *(fails: ModuleNotFoundError: No module named 'battle_logging')*

------
https://chatgpt.com/codex/tasks/task_b_68cc31de4d04832cb96d13c479e4cfc3