### PR TITLE
Fix warp info pity description

### DIFF
--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -254,7 +254,10 @@
         </p>
         <ul class="warp-info-list">
           <li>Single pulls cost 1 ticket, while ×5 and ×10 options spend 5 or 10 at once.</li>
-          <li>Pity carries across banners of the same type and resets only after a 6★ reward.</li>
+          <li>
+            Pity carries across all banners and resets after any 5★ or 6★ reward, whichever comes
+            first.
+          </li>
           <li>Duplicate characters grant upgrade materials instead of extra copies.</li>
         </ul>
         <p class="warp-info-note">


### PR DESCRIPTION
## Summary
- correct the warp info overlay text to match actual pity reset behavior

## Testing
- not run (text-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cc400a8ff0832c87cbb058981b856c