### PR TITLE
[FEAT] Rework Swift Footwork into speed buffs

### DIFF
--- a/backend/plugins/cards/swift_footwork.py
+++ b/backend/plugins/cards/swift_footwork.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
+from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.cards._base import CardBase
 
@@ -10,31 +12,48 @@ class SwiftFootwork(CardBase):
     id: str = "swift_footwork"
     name: str = "Swift Footwork"
     stars: int = 2
-    effects: dict[str, float] = field(default_factory=dict)
-    about: str = "+1 action per turn; first action each combat is free."
+    effects: dict[str, float] = field(default_factory=lambda: {"spd": 0.2})
+    about: str = (
+        "Permanent +20% SPD; on battle start gain +30% SPD for two turns."
+    )
 
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
-        for member in party.members:
-            member.actions_per_turn += 1
+        burst_id = f"{self.id}_spd_burst"
 
-        used: set[int] = set()
+        async def _battle_start(*_args) -> None:
+            for member in party.members:
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
 
-        def _battle_start(entity) -> None:
-            used.clear()
+                for mod in list(getattr(mgr, "mods", [])):
+                    if getattr(mod, "id", "") == burst_id:
+                        mod.remove()
+                        mgr.mods.remove(mod)
+                        if burst_id in getattr(member, "mods", []):
+                            member.mods.remove(burst_id)
 
-        async def _action_used(actor, *_args) -> None:
-            if actor not in party.members:
-                return
-
-            pid = id(actor)
-            if pid in used:
-                return
-
-            actor.action_points += 1
-            await BUS.emit_async("extra_turn", actor)
-            used.add(pid)
-            await BUS.emit_async("card_effect", self.id, actor, "free_action", 0, {})
+                burst = create_stat_buff(
+                    member,
+                    name=burst_id,
+                    turns=2,
+                    spd_mult=1.3,
+                )
+                mgr.add_modifier(burst)
+                await BUS.emit_async(
+                    "card_effect",
+                    self.id,
+                    member,
+                    "battle_start_spd_burst",
+                    30,
+                    {
+                        "stat_affected": "spd",
+                        "percentage_change": 30.0,
+                        "duration": 2,
+                    },
+                )
 
         BUS.subscribe("battle_start", _battle_start)
-        BUS.subscribe("action_used", _action_used)
+

--- a/backend/tests/test_multiple_actions_per_turn.py
+++ b/backend/tests/test_multiple_actions_per_turn.py
@@ -1,52 +1,44 @@
+import asyncio
+
 import pytest
 
 from autofighter.cards import apply_cards
 from autofighter.cards import award_card
-from autofighter.mapgen import MapNode
 from autofighter.party import Party
-from autofighter.rooms.battle.core import BattleRoom
 from autofighter.stats import BUS
-from plugins.foes._base import FoeBase
 from plugins.players import player as player_mod
 
 
-class DummyFoe(FoeBase):
-    id = "dummy"
-    name = "Dummy"
-
-
 @pytest.mark.asyncio
-async def test_swift_footwork_multiple_actions_and_queue(monkeypatch):
-    node = MapNode(room_id=0, room_type="battle", floor=1, index=1, loop=1, pressure=0)
-    room = BattleRoom(node)
+async def test_swift_footwork_speed_bonuses_and_no_extra_turns():
     player = player_mod.Player()
-    player.set_base_stat("atk", 50)
+    base_spd = player.spd
     party = Party(members=[player])
     award_card(party, "swift_footwork")
     await apply_cards(party)
+    await asyncio.sleep(0)
 
-    foe = DummyFoe()
-    foe.hp = 1000
-    monkeypatch.setattr("autofighter.rooms.utils._choose_foe", lambda p: foe)
-    monkeypatch.setattr("autofighter.rooms.utils._scale_stats", lambda *args, **kwargs: None)
+    # Permanent SPD boost is applied when cards are awarded
+    expected_permanent = int(base_spd * 1.2)
+    assert player.spd == expected_permanent
 
-    snapshots: list[dict] = []
-    async def collector(snap):
-        snapshots.append(snap)
+    extra_turns: list[object] = []
 
-    actions: list[int] = []
-    def _count(actor, *_):
-        if actor.id == player.id:
-            actions.append(1)
-    BUS.subscribe("action_used", _count)
+    def _on_extra_turn(actor, *_args):
+        extra_turns.append(actor)
 
-    await room.resolve(party, {}, progress=collector)
-    BUS.unsubscribe("action_used", _count)
+    BUS.subscribe("extra_turn", _on_extra_turn)
 
-    # Player should act three times (two from card and one free opener)
-    assert len(actions) == 3
+    await BUS.emit_async("battle_start")
+    await asyncio.sleep(0)
 
-    # Initial snapshot queue should show two upcoming turns for player (extra action)
-    queue = [q for q in snapshots[0]["action_queue"] if q["id"] == player.id]
-    assert len(queue) == 2
-    assert any(q.get("bonus") for q in queue)
+    # Opening burst further increases SPD without granting extra turns
+    expected_burst = int(base_spd * 1.5)
+    assert player.spd == expected_burst
+
+    await BUS.emit_async("action_used", player, None, 0)
+    await asyncio.sleep(0)
+
+    BUS.unsubscribe("extra_turn", _on_extra_turn)
+
+    assert not extra_turns


### PR DESCRIPTION
## Summary
- refocus Swift Footwork so it grants a permanent SPD multiplier and applies a short battle-start speed surge
- refresh Swift Footwork card metadata and backend tests to assert the new speed buffs instead of extra actions

## Testing
- [x] Backend tests (`uv run pytest backend/tests/test_multiple_actions_per_turn.py::test_swift_footwork_speed_bonuses_and_no_extra_turns backend/tests/test_card_rewards.py::test_swift_footwork_speed_burst`)
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68ccc9302de8832c964977a4c39bf455