### PR TITLE
Add Luna-specific boss scaling multipliers

### DIFF
--- a/backend/autofighter/rooms/utils.py
+++ b/backend/autofighter/rooms/utils.py
@@ -141,6 +141,17 @@ def _scale_stats(obj: Stats, node: MapNode, strength: float = 1.0) -> None:
             setattr(obj, field.name, type(value)(total))
 
     try:
+        from plugins.players._base import PlayerBase as _PlayerBase
+    except Exception:
+        _PlayerBase = None
+
+    if _PlayerBase is not None and isinstance(obj, _PlayerBase):
+        try:
+            obj.apply_boss_scaling()
+        except Exception:
+            pass
+
+    try:
         room_num = max(int(cumulative_rooms), 1)
         desired = max(1, math.ceil(room_num / 2))
         obj.level = int(max(getattr(obj, "level", 1), desired))

--- a/backend/plugins/players/_base.py
+++ b/backend/plugins/players/_base.py
@@ -5,11 +5,11 @@ from dataclasses import dataclass
 from dataclasses import field
 from dataclasses import fields
 import logging
-from typing import Collection
 from typing import TYPE_CHECKING
+from typing import Collection
 
-from autofighter.mapgen import MapNode
 from autofighter.character import CharacterType
+from autofighter.mapgen import MapNode
 from autofighter.stats import BUS
 from autofighter.stats import Stats
 from plugins.damage_types import random_damage_type
@@ -183,6 +183,9 @@ class PlayerBase(Stats):
         registry: "PassiveRegistry",
     ) -> None:
         """Hook for subclasses to adjust state prior to entering battle."""
+
+    def apply_boss_scaling(self) -> None:
+        """Hook for subclasses to tweak scaled stats when treated as bosses."""
 
     async def use_ultimate(self) -> bool:
         """Consume charge and emit an event when firing the ultimate."""

--- a/backend/plugins/players/luna.py
+++ b/backend/plugins/players/luna.py
@@ -245,3 +245,23 @@ class Luna(PlayerBase):
 
         helper.sync_actions_per_turn()
         self._luna_sword_helper = helper
+
+    def apply_boss_scaling(self) -> None:
+        rank = str(getattr(self, "rank", ""))
+        lowered = rank.lower()
+        if "boss" not in lowered:
+            return
+
+        multiplier = 11 if "glitched" in lowered else 4
+        for stat in ("max_hp", "atk", "defense"):
+            base_value = self.get_base_stat(stat)
+            try:
+                scaled = type(base_value)(base_value * multiplier)
+            except Exception:
+                continue
+            self.set_base_stat(stat, scaled)
+
+        try:
+            self.hp = int(self.max_hp)
+        except Exception:
+            self.hp = self.max_hp

--- a/backend/tests/test_luna_boss_scaling.py
+++ b/backend/tests/test_luna_boss_scaling.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+import random
+import sys
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.append(str(_PROJECT_ROOT))
+
+from autofighter.mapgen import MapNode  # noqa: E402
+from autofighter.rooms.utils import _scale_stats  # noqa: E402
+from plugins.players.bubbles import Bubbles  # noqa: E402
+from plugins.players.luna import Luna  # noqa: E402
+
+
+def _scale_player(cls, rank: str, seed: int):
+    random.seed(seed)
+    node = MapNode(
+        room_id=1,
+        room_type="battle-boss",
+        floor=1,
+        index=1,
+        loop=1,
+        pressure=0,
+    )
+
+    player = cls()
+    player.rank = rank
+    _scale_stats(player, node)
+    return player
+
+
+def test_luna_boss_scaling_multiplier_applied() -> None:
+    normal = _scale_player(Luna, "normal", seed=123)
+    boss = _scale_player(Luna, "boss", seed=123)
+
+    assert boss.get_base_stat("max_hp") == normal.get_base_stat("max_hp") * 4
+    assert boss.get_base_stat("atk") == normal.get_base_stat("atk") * 4
+    assert boss.get_base_stat("defense") == normal.get_base_stat("defense") * 4
+    assert boss.hp == boss.max_hp
+
+
+def test_luna_glitched_boss_scaling_multiplier_applied() -> None:
+    normal = _scale_player(Luna, "normal", seed=456)
+    glitched = _scale_player(Luna, "glitched boss", seed=456)
+
+    assert glitched.get_base_stat("max_hp") == normal.get_base_stat("max_hp") * 11
+    assert glitched.get_base_stat("atk") == normal.get_base_stat("atk") * 11
+    assert glitched.get_base_stat("defense") == normal.get_base_stat("defense") * 11
+    assert glitched.hp == glitched.max_hp
+
+
+def test_other_player_boss_rank_unscaled() -> None:
+    normal = _scale_player(Bubbles, "normal", seed=789)
+    boss = _scale_player(Bubbles, "boss", seed=789)
+
+    assert boss.get_base_stat("max_hp") == normal.get_base_stat("max_hp")
+    assert boss.get_base_stat("atk") == normal.get_base_stat("atk")
+    assert boss.get_base_stat("defense") == normal.get_base_stat("defense")


### PR DESCRIPTION
## Summary
- add an overridable `apply_boss_scaling` hook on `PlayerBase` and invoke it from the generic stat scaler
- implement Luna's boss/glitched boss multipliers while keeping her health synced to the new max
- cover Luna and non-Luna scaling behaviour with focused tests

## Testing
- uv run pytest tests/test_luna_boss_scaling.py

------
https://chatgpt.com/codex/tasks/task_b_68cce4857f20832cb555bd1072723ab1