### PR TITLE
docs: clarify character plugin boundaries

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,6 +23,13 @@ The script will automatically detect available tools and use the best option:
 - With `uv` and `bun`: Fast, modern tooling (same as CI)
 - Without `uv`/`bun`: Falls back to `python3`/`pip3` and `npm`
 
+### Character Plugin Boundaries
+- Read the plugin boundary reminder in
+  [`.codex/instructions/plugin-system.md`](.codex/instructions/plugin-system.md)
+  before touching combat helpers. All spawn weighting, boss behaviours, and
+  passive effects must live in the relevant plugin modules so shared battle
+  utilities remain character-agnostic.
+
 ### Building the Application
 ```bash
 ./build.sh [variant] [platform]


### PR DESCRIPTION
## Summary
- add an explicit character-behaviour boundary section to the plugin system guide so combat logic stays inside plugins, with Luna sword and spawn weighting examples
- cross-reference the new reminder from DEVELOPMENT.md so contributors see it during onboarding

## Testing
- ./run-tests.sh *(fails: accelerate patch expects llms.loader._IMPORT_ERROR and battle logging modules are absent in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ccecddcdfc832cae000a51780f657c