### PR TITLE
feat: add quick link actions to main menu

### DIFF
--- a/frontend/src/lib/components/MainMenu.svelte
+++ b/frontend/src/lib/components/MainMenu.svelte
@@ -1,22 +1,54 @@
 <script>
   export let items = [];
+
+  $: primaryItems = items.filter((item) => item?.group !== 'quick-link');
+  $: quickLinks = items.filter((item) => item?.group === 'quick-link');
 </script>
 
 <div class="stained-glass-side">
-  {#each items as item}
-    <button class="icon-btn" title={item.label} on:click={item.action} disabled={item.disabled}>
-      <div class="btn-content">
-        {#if item.icon}
-          <div class="icon">
-            <svelte:component this={item.icon} size={24} color="#fff" />
-          </div>
-          <span class="label">{item.label}</span>
-        {:else}
-          <span class="label">{item.label}</span>
-        {/if}
-      </div>
-    </button>
-  {/each}
+  <div class="primary-items">
+    {#each primaryItems as item}
+      <button
+        type="button"
+        class="icon-btn"
+        title={item.label}
+        aria-label={item.label}
+        on:click={item.action}
+        disabled={item.disabled}
+      >
+        <div class="btn-content">
+          {#if item.icon}
+            <div class="icon">
+              <svelte:component this={item.icon} size={24} color="#fff" />
+            </div>
+            <span class="label">{item.label}</span>
+          {:else}
+            <span class="label">{item.label}</span>
+          {/if}
+        </div>
+      </button>
+    {/each}
+  </div>
+
+  {#if quickLinks.length}
+    <div class="quick-links">
+      {#each quickLinks as item}
+        <button
+          type="button"
+          class="quick-link-btn"
+          title={item.label}
+          aria-label={item.label}
+          on:click={item.action}
+          disabled={item.disabled}
+        >
+          {#if item.icon}
+            <svelte:component this={item.icon} size={22} color="#fff" />
+          {/if}
+          <span class="tooltip" aria-hidden="true">{item.label}</span>
+        </button>
+      {/each}
+    </div>
+  {/if}
 </div>
 
 <style>
@@ -38,6 +70,13 @@
     overflow: auto;
     align-items: center;
     min-width: 140px;
+  }
+  .primary-items {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    width: 100%;
+    align-items: center;
   }
   .icon-btn {
     background: rgba(255,255,255,0.10);
@@ -82,5 +121,59 @@
   .icon-btn:disabled {
     opacity: 0.5;
     cursor: default;
+  }
+  .quick-links {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    width: 100%;
+  }
+  .quick-link-btn {
+    background: rgba(255,255,255,0.10);
+    border: none;
+    border-radius: 999px;
+    width: 2.75rem;
+    height: 2.75rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: background 0.18s, box-shadow 0.18s;
+    box-shadow: 0 1px 4px 0 rgba(0,40,120,0.10);
+    position: relative;
+  }
+  .quick-link-btn:hover,
+  .quick-link-btn:focus-visible {
+    background: rgba(120,180,255,0.22);
+    outline: none;
+  }
+  .quick-link-btn:active {
+    background: rgba(80,140,220,0.28);
+  }
+  .quick-link-btn:disabled {
+    opacity: 0.5;
+    cursor: default;
+  }
+  .quick-link-btn .tooltip {
+    position: absolute;
+    bottom: calc(100% + 0.4rem);
+    left: 50%;
+    transform: translate(-50%, 0.2rem);
+    background: rgba(20,30,60,0.92);
+    color: #fff;
+    padding: 0.2rem 0.5rem;
+    border-radius: 0.35rem;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.18s ease, transform 0.18s ease;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.4);
+  }
+  .quick-link-btn:hover .tooltip,
+  .quick-link-btn:focus-visible .tooltip {
+    opacity: 1;
+    transform: translate(-50%, 0);
   }
 </style>

--- a/frontend/src/lib/components/RunButtons.svelte
+++ b/frontend/src/lib/components/RunButtons.svelte
@@ -11,20 +11,36 @@
    * - Consider a contextual entry that jumps to the Party Picker with the
    *   player pre-selected once the per-character upgrade flow is ready.
    */
-  import { Play, Users, PackageOpen, Settings, MessageSquare, Package, Book } from 'lucide-svelte';
+  import {
+    Play,
+    Users,
+    PackageOpen,
+    Settings,
+    MessageSquare,
+    MessageCircle,
+    Globe,
+    Package,
+    Book
+  } from 'lucide-svelte';
 
   // Build the run menu items array. Handlers are functions for each action.
   export function buildRunMenu(handlers, battleActive) {
-    return [
+    const primaryItems = [
       { icon: Play, label: 'Run', action: handlers.openRun, disabled: false },
       { icon: Users, label: 'Party', action: handlers.handleParty, disabled: battleActive },
       // Player Editor removed from main menu per design
       { icon: PackageOpen, label: 'Warp', action: handlers.openPulls, disabled: battleActive },
       { icon: Package, label: 'Inventory', action: handlers.openInventory, disabled: false },
       { icon: Book, label: 'Guidebook', action: handlers.openGuidebook, disabled: false },
-      { icon: Settings, label: 'Settings', action: handlers.openSettings, disabled: false },
-      { icon: MessageSquare, label: 'Feedback', action: handlers.openFeedback, disabled: false },
-      // Inventory moved to in-run NavBar; remove from main menu
+      { icon: Settings, label: 'Settings', action: handlers.openSettings, disabled: false }
     ];
+
+    const quickLinks = [
+      { icon: MessageSquare, label: 'Feedback', action: handlers.openFeedback, disabled: false, group: 'quick-link' },
+      { icon: MessageCircle, label: 'Discord', action: handlers.openDiscord, disabled: false, group: 'quick-link' },
+      { icon: Globe, label: 'Website', action: handlers.openWebsite, disabled: false, group: 'quick-link' }
+    ];
+
+    return [...primaryItems, ...quickLinks];
   }
 </script>

--- a/frontend/src/lib/index.js
+++ b/frontend/src/lib/index.js
@@ -68,5 +68,7 @@ export {
 
 // Export constants
 export {
-  FEEDBACK_URL
+  FEEDBACK_URL,
+  DISCORD_URL,
+  WEBSITE_URL
 } from './systems/constants.js';

--- a/frontend/src/lib/systems/constants.js
+++ b/frontend/src/lib/systems/constants.js
@@ -1,1 +1,4 @@
-export const FEEDBACK_URL = 'https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/new';
+export const FEEDBACK_URL =
+  'https://github.com/Midori-AI-OSS/Midori-AI-AutoFighter/issues/new/choose';
+export const DISCORD_URL = 'https://discord.gg/xdgCx3VyHU';
+export const WEBSITE_URL = 'https://io.midori-ai.xyz/';

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -19,6 +19,8 @@
     saveRunState,
     clearRunState,
     FEEDBACK_URL,
+    DISCORD_URL,
+    WEBSITE_URL,
     openOverlay,
     backOverlay,
     homeOverlay
@@ -506,6 +508,14 @@
 
   function openFeedback() {
     window.open(FEEDBACK_URL, '_blank', 'noopener');
+  }
+
+  function openDiscord() {
+    window.open(DISCORD_URL, '_blank', 'noopener');
+  }
+
+  function openWebsite() {
+    window.open(WEBSITE_URL, '_blank', 'noopener');
   }
 
   async function openInventory() {
@@ -1269,6 +1279,8 @@
       handleParty,
       openPulls,
       openFeedback,
+      openDiscord,
+      openWebsite,
       openInventory,
       openSettings: () => openOverlay('settings'),
       openGuidebook: () => openOverlay('guidebook')


### PR DESCRIPTION
## Summary
- add discord and website constants alongside the updated feedback link
- expose new quick link handlers in the run menu and main page
- split the main menu into primary actions and an icon-only quick link row

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68cd64692e50832cbb4ef5b8f6dab76f