### PR TITLE
Fix deal sound volume handling

### DIFF
--- a/frontend/src/lib/components/PullResultsOverlay.svelte
+++ b/frontend/src/lib/components/PullResultsOverlay.svelte
@@ -70,7 +70,15 @@
 
   function playDeal() {
     if (reducedMotion || !dealSfx) return;
-    try { dealSfx.cloneNode().play(); } catch {}
+    try {
+      const node = dealSfx.paused ? dealSfx : dealSfx.cloneNode(true);
+      if (node === dealSfx) {
+        dealSfx.currentTime = 0;
+      } else {
+        node.volume = dealSfx.volume;
+      }
+      node.play();
+    } catch {}
   }
 
   function dealNext() {

--- a/frontend/src/lib/systems/sfx.js
+++ b/frontend/src/lib/systems/sfx.js
@@ -58,12 +58,15 @@ function generateBeepWav(freq = 880, duration = 0.12, sampleRate = 44100) {
   return `data:audio/wav;base64,${base64}`;
 }
 
-export function createDealSfx(volumePercent = 5) {
+export function createDealSfx(volumeSteps = 5) {
   try {
     const url = generateBeepWav(880, 0.12);
     const a = new Audio(url);
-    const v = Math.max(0, Math.min(1, Number(volumePercent) / 100));
-    a.volume = v;
+    const numericVolume = Number(volumeSteps);
+    const clamped = Number.isFinite(numericVolume)
+      ? Math.max(0, Math.min(10, numericVolume))
+      : 0;
+    a.volume = clamped / 10;
     return a;
   } catch {
     return null;


### PR DESCRIPTION
## Summary
- ensure the pull overlay reuses the deal SFX element when possible and copies its volume onto any clones
- normalize the deal SFX helper to clamp the 0–10 slider value and convert it to the Audio element volume range

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68cd7265c7f4832c9e0507e0ee52f711