### PR TITLE
Add shield soak and overkill reporting to damage events

### DIFF
--- a/backend/autofighter/rooms/battle/turns.py
+++ b/backend/autofighter/rooms/battle/turns.py
@@ -335,18 +335,19 @@ def _on_damage_taken(
     post_damage_hp: int | None = None,
     is_critical: bool | None = None,
     action_name: str | None = None,
+    details: dict[str, Any] | None = None,
     *_: Any,
 ) -> None:
     run_id = _resolve_run_id(target, attacker)
     if not run_id:
         return
-    metadata: dict[str, Any] = {}
+    metadata: dict[str, Any] = dict(details) if isinstance(details, dict) else {}
     damage_type_id = _resolve_damage_type_id(attacker)
-    if damage_type_id:
+    if damage_type_id and "damage_type_id" not in metadata:
         metadata["damage_type_id"] = damage_type_id
-    if is_critical is not None:
+    if is_critical is not None and "is_critical" not in metadata:
         metadata["is_critical"] = bool(is_critical)
-    if action_name:
+    if action_name and "action_name" not in metadata:
         metadata["action_name"] = str(action_name)
     metadata_payload = metadata or None
     _record_event(

--- a/backend/plugins/cards/a_micro_blade.py
+++ b/backend/plugins/cards/a_micro_blade.py
@@ -26,7 +26,7 @@ class MicroBlade(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        async def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name):
+        async def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name, details=None):
             # Check if attacker is one of our party members and this is an attack
             if attacker in party.members and action_name == "attack":
                 # 6% chance to deal +8% bonus damage aligned with the attacker

--- a/backend/plugins/cards/honed_point.py
+++ b/backend/plugins/cards/honed_point.py
@@ -22,7 +22,7 @@ class HonedPoint(CardBase):
 
         marked_enemies: dict[int, set[int]] = {}
 
-        async def _on_damage_dealt(attacker, target, damage, _damage_type, source, source_action, action_name):
+        async def _on_damage_dealt(attacker, target, damage, _damage_type, source, source_action, action_name, details=None):
             if attacker in party.members and action_name == "attack":
                 attacker_id = id(attacker)
                 target_id = id(target)

--- a/backend/plugins/cards/steel_bangles.py
+++ b/backend/plugins/cards/steel_bangles.py
@@ -19,7 +19,7 @@ class SteelBangles(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        async def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name):
+        async def _on_damage_dealt(attacker, target, damage, damage_type, source, source_action, action_name, details=None):
             # Check if attacker is one of our party members and this is an attack
             if attacker in party.members and action_name == "attack":
                 # 5% chance to reduce target's next attack damage by 3%

--- a/backend/tests/test_cost_damage.py
+++ b/backend/tests/test_cost_damage.py
@@ -49,10 +49,14 @@ async def test_normal_attack_respects_defense_and_shields(bus):
     s.shields = 200
     start_hp = s.hp
     attacker = stats.Stats()
+    attacker._base_crit_rate = 0
+    s._base_dodge_odds = 0
     await s.apply_damage(150, attacker=attacker)
     assert s.hp == start_hp
     assert s.shields == 199
-    assert s.damage_taken == 1
+    assert s.damage_taken == 0
+    assert s.last_shield_absorbed == 1
+    assert s.last_overkill == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- track shield absorption and overkill in `Stats.apply_damage`, clamp recorded damage, and emit detailed metadata with damage and kill events
- update battle logging, battle turn tracking, and card damage listeners to consume the optional damage details payload
- cover overkill logging and shield absorption in tests, adjusting shield-heavy cost damage expectations

## Testing
- `PYTHONPATH=. uv run pytest tests/test_battle_logging.py tests/test_cost_damage.py`
- `uv run ruff check autofighter/stats.py battle_logging/writers.py autofighter/rooms/battle/turns.py plugins/cards/a_micro_blade.py plugins/cards/steel_bangles.py plugins/cards/honed_point.py tests/test_battle_logging.py tests/test_cost_damage.py`


------
https://chatgpt.com/codex/tasks/task_b_68cfbf842918832c925d780d98acb391