### PR TITLE
feat: add repeatable stat upgrades

### DIFF
--- a/frontend/src/lib/components/PlayerPreview.svelte
+++ b/frontend/src/lib/components/PlayerPreview.svelte
@@ -24,6 +24,8 @@
   export let reducedMotion = false;
 
   const dispatch = createEventDispatcher();
+  const REPEAT_OPTIONS = [1, 5, 10];
+  let upgradeRepeat = 1;
   const ELEMENTS = ['Light','Fire','Ice','Lightning','Wind','Dark'];
   async function chooseElement(name) {
     const s = String(name || '');
@@ -338,7 +340,7 @@
 
   function requestUpgrade(stat) {
     if (!selected || !stat || pendingAction) return;
-    dispatch('request-upgrade', { id: selected.id, stat });
+    dispatch('request-upgrade', { id: selected.id, stat, repeats: upgradeRepeat });
   }
 
   function convertFourStar() {
@@ -518,6 +520,21 @@
               {/if}
               <span class="points">Points: {formatPoints(upgradePointsValue)}</span>
             </div>
+            <div class="repeat-controls" aria-label="Upgrade repeats" on:click|stopPropagation>
+              {#each REPEAT_OPTIONS as option}
+                {#key option}
+                  <button
+                    type="button"
+                    class="repeat-btn"
+                    class:active={upgradeRepeat === option}
+                    aria-pressed={upgradeRepeat === option ? 'true' : 'false'}
+                    on:click={() => upgradeRepeat = option}
+                  >
+                    {option}×
+                  </button>
+                {/key}
+              {/each}
+            </div>
             <div class="row row2">
               <button type="button" class="convert4-btn" on:click={convertFourStar} disabled={!canConvert4}>
                 Convert 4★ into 5 points
@@ -628,6 +645,35 @@
     align-items: center;
     gap: 0.6rem;
     flex-wrap: wrap;
+  }
+  .upgrade-bottom .repeat-controls {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.4rem;
+    margin: 0.35rem 0 0.25rem;
+    padding-right: 0.2rem;
+  }
+  .upgrade-bottom .repeat-btn {
+    background: rgba(0,0,0,0.45);
+    border: 1px solid rgba(255,255,255,0.35);
+    color: #fff;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    padding: 0.25rem 0.6rem;
+    cursor: pointer;
+    transition: background 140ms ease, border-color 140ms ease, color 140ms ease;
+  }
+  .upgrade-bottom .repeat-btn:hover,
+  .upgrade-bottom .repeat-btn:focus-visible {
+    background: rgba(255,255,255,0.12);
+    border-color: rgba(255,255,255,0.6);
+    outline: none;
+  }
+  .upgrade-bottom .repeat-btn.active {
+    background: rgba(255,255,255,0.22);
+    border-color: rgba(255,255,255,0.75);
+    color: #fff;
+    font-weight: 600;
   }
   .upgrade-bottom .row1 { justify-content: space-between; }
   .upgrade-bottom .row2 { justify-content: flex-start; }

--- a/frontend/src/lib/systems/api.js
+++ b/frontend/src/lib/systems/api.js
@@ -147,8 +147,20 @@ export async function upgradeCharacter(id, starLevel, itemCount = 1) {
 }
 
 // Spend upgrade points on a specific stat for the given character
-export async function upgradeStat(id, statName) {
-  return httpPost(`/players/${id}/upgrade-stat`, {
-    stat_name: statName
-  });
+export async function upgradeStat(id, statName, options = {}) {
+  const payload = { stat_name: statName };
+  if (options && typeof options === 'object') {
+    if (options.points != null) {
+      payload.points = options.points;
+    }
+    const repeatValue = options.repeat ?? options.repeats;
+    if (repeatValue != null) {
+      payload.repeat = repeatValue;
+    }
+    const totalPointsValue = options.totalPoints ?? options.total_points;
+    if (totalPointsValue != null) {
+      payload.total_points = totalPointsValue;
+    }
+  }
+  return httpPost(`/players/${id}/upgrade-stat`, payload);
 }


### PR DESCRIPTION
## Summary
- add repeat controls to the upgrade sheet and propagate repeat counts through the party picker
- extend the frontend API and backend upgrade handler to support repeated stat upgrades and optional budgets
- cover multi-step upgrade flows with backend tests

## Testing
- uv run pytest backend/tests/test_new_upgrade_system.py
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68cfcf636ff4832c9bad6a363e918844