### PR TITLE
test: align party picker tests with repeat upgrades

### DIFF
--- a/frontend/tests/__snapshots__/partypicker.test.js.snap
+++ b/frontend/tests/__snapshots__/partypicker.test.js.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+// Bun Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PartyPicker component roster layout snapshot 1`] = `
 "<script>
@@ -168,8 +168,8 @@ exports[`PartyPicker component roster layout snapshot 1`] = `
         class:reduced={reducedMotion}
         animate:flip={{ duration: reducedMotion ? 0 : 300 }}
         on:click={(e) => select(char.id, e)}
-        on:dblclick={() => toggle(char.id)}
-        on:pointerdown={(e) => onPointerDown(char.id, e)}
+        on:dblclick={() => !char.is_player && toggle(char.id)}
+        on:pointerdown={(e) => !char.is_player && onPointerDown(char.id, e)}
         on:pointerup={onPointerUp}
         on:pointerleave={onPointerUp}
         on:introstart={(e) => onIntroStart(char.id, e)}
@@ -202,8 +202,8 @@ exports[`PartyPicker component roster layout snapshot 1`] = `
       class:reduced={reducedMotion}
       animate:flip={{ duration: reducedMotion ? 0 : 300 }}
       on:click={(e) => select(char.id, e)}
-      on:dblclick={() => toggle(char.id)}
-      on:pointerdown={(e) => onPointerDown(char.id, e)}
+      on:dblclick={() => !char.is_player && toggle(char.id)}
+      on:pointerdown={(e) => !char.is_player && onPointerDown(char.id, e)}
       on:pointerup={onPointerUp}
       on:pointerleave={onPointerUp}
       on:introstart={(e) => onIntroStart(char.id, e)}
@@ -245,6 +245,8 @@ exports[`PartyPicker component roster layout snapshot 1`] = `
   gap: 0.25rem;
   align-items: center;
 }
+
+/* No explicit "Required" chip; the remove button conveys it. */
 
 .sort-dir {
   background: transparent;

--- a/frontend/tests/partypicker.test.js
+++ b/frontend/tests/partypicker.test.js
@@ -85,8 +85,8 @@ describe('PartyPicker component', () => {
 
   test('wires upgrade requests to the API', () => {
     const content = readFileSync(join(import.meta.dir, '../src/lib/components/PartyPicker.svelte'), 'utf8');
-    expect(content).toContain('import { getPlayers, upgradeStat }');
-    expect(content).toContain('await upgradeStat(id, stat);');
+    expect(content).toContain('import { getPlayers, getUpgrade, upgradeCharacter, upgradeStat }');
+    expect(content).toContain('await upgradeStat(id, stat, { repeat: requestRepeats });');
     expect(content).toContain('upgradeContext?.pendingStat');
   });
 });


### PR DESCRIPTION
## Summary
- update the PartyPicker wiring test to expect the expanded API import and repeat-aware upgrade call
- refresh the PartyRoster snapshot so the layout assertion matches the current component markup

## Testing
- bun test tests/partypicker.test.js

------
https://chatgpt.com/codex/tasks/task_b_68cfd460d698832c84aa921736c476fe