### PR TITLE
Refactor party upgrades to use material-based costs

### DIFF
--- a/frontend/src/lib/components/upgradeCacheUtils.js
+++ b/frontend/src/lib/components/upgradeCacheUtils.js
@@ -12,18 +12,37 @@ export function mergeUpgradePayload(previousData, result) {
     base.items = {};
   }
 
-  if (result && Object.prototype.hasOwnProperty.call(result, 'total_points')) {
-    base.total_points = result.total_points;
-  } else if (previousData && Object.prototype.hasOwnProperty.call(previousData, 'total_points')) {
-    base.total_points = previousData.total_points;
+  const payloadMaps = [
+    ['stat_totals', {}],
+    ['stat_counts', {}],
+    ['next_costs', {}],
+    ['stat_upgrades', []],
+  ];
+
+  for (const [key, fallback] of payloadMaps) {
+    if (result && Object.prototype.hasOwnProperty.call(result, key)) {
+      base[key] = result[key] ?? fallback;
+    } else if (previousData && Object.prototype.hasOwnProperty.call(previousData, key)) {
+      base[key] = previousData[key];
+    } else if (!Object.prototype.hasOwnProperty.call(base, key)) {
+      base[key] = Array.isArray(fallback) ? [] : { ...fallback };
+    }
   }
 
-  if (result && Object.prototype.hasOwnProperty.call(result, 'upgrade_points')) {
-    base.upgrade_points = result.upgrade_points;
-  } else if (previousData && Object.prototype.hasOwnProperty.call(previousData, 'upgrade_points')) {
-    base.upgrade_points = previousData.upgrade_points;
-  } else if (base.total_points != null && !Object.prototype.hasOwnProperty.call(base, 'upgrade_points')) {
-    base.upgrade_points = base.total_points;
+  if (result && Object.prototype.hasOwnProperty.call(result, 'element')) {
+    base.element = result.element;
+  } else if (previousData && Object.prototype.hasOwnProperty.call(previousData, 'element')) {
+    base.element = previousData.element;
+  }
+
+  if (result && Object.prototype.hasOwnProperty.call(result, 'materials_remaining')) {
+    const elementKey = String(result.element || base.element || '').toLowerCase();
+    if (elementKey) {
+      const materialKey = `${elementKey}_1`;
+      base.items = { ...(base.items || {}) };
+      base.items[materialKey] = result.materials_remaining;
+    }
+    base.materials_remaining = result.materials_remaining;
   }
 
   return base;

--- a/frontend/src/lib/systems/api.js
+++ b/frontend/src/lib/systems/api.js
@@ -138,29 +138,36 @@ export async function getUpgrade(id) {
   return httpGet(`/players/${id}/upgrade`, { cache: 'no-store' });
 }
 
-// New upgrade API: requires star_level (1-4) and item_count (>=1)
-export async function upgradeCharacter(id, starLevel, itemCount = 1) {
-  return httpPost(`/players/${id}/upgrade`, { 
-    star_level: starLevel, 
-    item_count: itemCount 
-  });
-}
-
-// Spend upgrade points on a specific stat for the given character
+// Spend upgrade materials on a specific stat for the given character
 export async function upgradeStat(id, statName, options = {}) {
   const payload = { stat_name: statName };
+
   if (options && typeof options === 'object') {
-    if (options.points != null) {
-      payload.points = options.points;
+    const materialInput =
+      options.materials ??
+      options.points ??
+      options.expectedMaterials ??
+      options.expected_materials;
+    if (materialInput != null) {
+      payload.materials = materialInput;
     }
+
     const repeatValue = options.repeat ?? options.repeats;
     if (repeatValue != null) {
       payload.repeat = repeatValue;
     }
-    const totalPointsValue = options.totalPoints ?? options.total_points;
-    if (totalPointsValue != null) {
-      payload.total_points = totalPointsValue;
+
+    const totalMaterialsValue =
+      options.total_materials ??
+      options.totalMaterials ??
+      options.total_points ??
+      options.totalPoints ??
+      options.materialBudget ??
+      options.budget;
+    if (totalMaterialsValue != null) {
+      payload.total_materials = totalMaterialsValue;
     }
   }
+
   return httpPost(`/players/${id}/upgrade-stat`, payload);
 }

--- a/frontend/src/lib/utils/upgradeFormatting.js
+++ b/frontend/src/lib/utils/upgradeFormatting.js
@@ -1,12 +1,43 @@
-export function formatPoints(value) {
-  const num = Number(value);
-  if (!Number.isFinite(num)) return '—';
-  return Math.max(0, Math.round(num)).toLocaleString();
+function normalizeMaterialId(value) {
+  if (!value) return '';
+  return String(value).trim().toLowerCase();
 }
 
-export function formatCost(value) {
-  const points = formatPoints(value);
-  return points === '—' ? '—' : `${points} pts`;
+function titleCase(text) {
+  if (!text) return '';
+  return text.replace(/\b([a-z])/g, (m) => m.toUpperCase());
+}
+
+export function formatMaterialName(materialId) {
+  const normalized = normalizeMaterialId(materialId);
+  if (!normalized) return 'Unknown material';
+  const [elementRaw, starRaw] = normalized.split('_');
+  const element = titleCase(elementRaw || '');
+  if (!starRaw) return element || 'Unknown material';
+  const starValue = starRaw.replace(/[^0-9]/g, '');
+  const starLabel = starValue ? `${Number(starValue)}★` : `${starRaw}★`;
+  return `${element} ${starLabel}`.trim();
+}
+
+export function formatMaterialQuantity(count, materialId) {
+  const num = Number(count);
+  if (!Number.isFinite(num)) return '—';
+  const prettyCount = Math.max(0, Math.round(num)).toLocaleString();
+  const label = materialId ? formatMaterialName(materialId) : 'materials';
+  return `${prettyCount}× ${label}`;
+}
+
+export function formatCost(cost) {
+  if (cost == null) return '—';
+  if (typeof cost === 'number') {
+    return formatMaterialQuantity(cost, null);
+  }
+  if (typeof cost === 'object') {
+    const { count, item, material, id } = cost;
+    const materialId = item ?? material ?? id ?? null;
+    return formatMaterialQuantity(count, materialId);
+  }
+  return String(cost);
 }
 
 export function formatPercent(value) {

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -6,7 +6,6 @@ import {
   getGacha,
   pullGacha,
   getUpgrade,
-  upgradeCharacter,
   upgradeStat,
   wipeData,
   getLrmConfig,
@@ -152,24 +151,18 @@ describe('api calls', () => {
     expect(result).toEqual({ level: 2, items: { fire_1: 3 } });
   });
 
-  test('upgradeCharacter posts upgrade', async () => {
-    global.fetch = createFetch({ level: 1, items: {} });
-    const result = await upgradeCharacter('player');
-    expect(result).toEqual({ level: 1, items: {} });
-  });
-
-  test('upgradeStat spends points', async () => {
+  test('upgradeStat spends materials', async () => {
     const fetchMock = mock(async (url, options) => {
       expect(url).toBe('http://backend.test/players/player/upgrade-stat');
-      expect(JSON.parse(options.body)).toEqual({ stat_name: 'atk' });
+      expect(JSON.parse(options.body)).toEqual({ stat_name: 'atk', materials: 2, repeat: 3, total_materials: 12 });
       return {
         ok: true,
         status: 200,
-        json: async () => ({ stat_upgraded: 'atk', points_spent: 1 })
+        json: async () => ({ stat_upgraded: 'atk', materials_spent: 5, completed_upgrades: 3 })
       };
     });
     global.fetch = fetchMock;
-    const result = await upgradeStat('player', 'atk');
-    expect(result).toEqual({ stat_upgraded: 'atk', points_spent: 1 });
+    const result = await upgradeStat('player', 'atk', { repeat: 3, expectedMaterials: 2, totalMaterials: 12 });
+    expect(result).toEqual({ stat_upgraded: 'atk', materials_spent: 5, completed_upgrades: 3 });
   });
 });

--- a/frontend/tests/partypicker.test.js
+++ b/frontend/tests/partypicker.test.js
@@ -85,9 +85,10 @@ describe('PartyPicker component', () => {
 
   test('wires upgrade requests to the API', () => {
     const content = readFileSync(join(import.meta.dir, '../src/lib/components/PartyPicker.svelte'), 'utf8');
-    expect(content).toContain('import { getPlayers, getUpgrade, upgradeCharacter, upgradeStat }');
-    expect(content).toContain('await upgradeStat(id, stat, { repeat: requestRepeats });');
-    expect(content).toContain('upgradeContext?.pendingStat');
+    expect(content).toContain('import { getPlayers, getUpgrade, upgradeStat }');
+    expect(content).toContain('const options = { repeat: repeats };');
+    expect(content).toContain('options.materials = expectedMaterials;');
+    expect(content).toContain('await upgradeStat(id, stat, options);');
   });
 });
 

--- a/frontend/tests/playerpreview.test.js
+++ b/frontend/tests/playerpreview.test.js
@@ -18,14 +18,15 @@ describe('PlayerPreview component', () => {
     expect(content).toContain("dispatch('open-upgrade'");
     expect(content).toContain("dispatch('close-upgrade'");
     expect(content).toContain("dispatch('request-upgrade'");
-    expect(content).toContain('Upgrade stats');
-    expect(content).toContain('class="stat-button"');
+    expect(content).toContain('class="stat-icon-btn"');
+    expect(content).toContain("Level ${statLevel('max_hp')}");
+    expect(content).toContain('formatMaterialQuantity(availableMaterials, upgradeMaterialKey)');
   });
 
   test('renders upgrade feedback status', () => {
     const content = readFileSync(file, 'utf8');
-    expect(content).toContain('class="upgrade-feedback"');
-    expect(content).toContain('aria-busy={pendingStat ? \'true\' : undefined}');
-    expect(content).toContain('pendingStat || upgradeContext?.stat');
+    expect(content).toContain('class="upgrade-bottom"');
+    expect(content).toContain('Level {activeStatLevel}');
+    expect(content).toContain('Next {activeStatLabel || \'upgrade\'}: {formatCost(activeNextCost)}');
   });
 });

--- a/frontend/tests/upgradepanel.test.js
+++ b/frontend/tests/upgradepanel.test.js
@@ -7,8 +7,8 @@ describe('UpgradePanel component', () => {
     // Note: file path reflects the component location in src/lib/components
     const content = readFileSync(join(import.meta.dir, '../src/lib/components/UpgradePanel.svelte'), 'utf8');
     expect(content).toContain('data-testid="upgrade-panel"');
-    expect(content).toContain('Convert items'); // section label
-    expect(content).toContain('Convert to Points'); // unified button text
-    expect(content).toContain('Spend points'); // stat spend UI
+    expect(content).toContain('Spend materials');
+    expect(content).toContain('formatMaterialQuantity(availableMaterials, materialKey)');
+    expect(content).toContain('Next {formatLabel(spendStat)} cost');
   });
 });


### PR DESCRIPTION
## Summary
- update the frontend upgrade API helpers and cache merger to support material budgets and stat count payloads
- refresh the upgrade panel, player preview, and party picker UIs to surface material availability, stat levels, and multi-upgrade messaging
- adjust material formatting utilities and front-end tests for the material-centric workflow

## Testing
- bun run lint
- bun test *(fails: battlepolling stat error and stat-tabs expectation still outstanding)*

------
https://chatgpt.com/codex/tasks/task_b_68d00935e384832cbc62dfc26dffda97