### PR TITLE
fix: enforce mezzy siphon max hp floor

### DIFF
--- a/backend/plugins/passives/normal/mezzy_gluttonous_bulwark.py
+++ b/backend/plugins/passives/normal/mezzy_gluttonous_bulwark.py
@@ -4,6 +4,8 @@ from typing import ClassVar
 
 from autofighter.stat_effect import StatEffect
 
+SAFE_MAX_HP_FLOOR = 1
+
 if TYPE_CHECKING:
     from autofighter.stats import Stats
 
@@ -69,29 +71,41 @@ class MezzyGluttonousBulwark:
                 # Return half of previously siphoned stats if ally falls below threshold
                 if ally_id in self._siphoned_stats:
                     returned_stats = self._siphoned_stats[ally_id]
+                    remaining_stats: dict[str, int] = {}
                     for stat, amount in returned_stats.items():
-                        return_amount = amount // 2
+                        if amount <= 0:
+                            ally.remove_effect_by_name(f"{self.id}_siphon_{stat}")
+                            mezzy.remove_effect_by_name(f"{self.id}_gain_{stat}")
+                            continue
 
-                        # Return stats to ally
-                        return_effect = StatEffect(
-                            name=f"{self.id}_return_{stat}",
-                            stat_modifiers={stat: return_amount},
-                            duration=-1,  # Permanent return
-                            source=f"{self.id}_return",
-                        )
-                        ally.add_effect(return_effect)
+                        remaining = amount - (amount // 2)
 
-                        # Remove from Mezzy
-                        remove_effect = StatEffect(
-                            name=f"{self.id}_remove_{stat}",
-                            stat_modifiers={stat: -return_amount},
-                            duration=-1,  # Permanent removal
-                            source=f"{self.id}_remove",
-                        )
-                        mezzy.add_effect(remove_effect)
+                        if remaining > 0:
+                            remaining_stats[stat] = remaining
+                            ally.add_effect(
+                                StatEffect(
+                                    name=f"{self.id}_siphon_{stat}",
+                                    stat_modifiers={stat: -remaining},
+                                    duration=-1,
+                                    source=f"{self.id}_siphon",
+                                )
+                            )
+                            mezzy.add_effect(
+                                StatEffect(
+                                    name=f"{self.id}_gain_{stat}",
+                                    stat_modifiers={stat: remaining},
+                                    duration=-1,
+                                    source=f"{self.id}_gain",
+                                )
+                            )
+                        else:
+                            ally.remove_effect_by_name(f"{self.id}_siphon_{stat}")
+                            mezzy.remove_effect_by_name(f"{self.id}_gain_{stat}")
 
-                    # Clear siphoned tracking
-                    del self._siphoned_stats[ally_id]
+                    if remaining_stats:
+                        self._siphoned_stats[ally_id] = remaining_stats
+                    else:
+                        del self._siphoned_stats[ally_id]
                 continue
 
             # Siphon 1% of attack, defense, and max HP
@@ -104,15 +118,24 @@ class MezzyGluttonousBulwark:
                 base_value = getattr(ally, stat, 0)
                 siphon_amount = max(1, int(base_value * 0.01))  # 1% minimum 1
 
+                if stat == "max_hp":
+                    if base_value <= SAFE_MAX_HP_FLOOR:
+                        continue
+                    max_reducible = base_value - SAFE_MAX_HP_FLOOR
+                    if max_reducible <= 0:
+                        continue
+                    siphon_amount = min(siphon_amount, max_reducible)
+
                 # Track total siphoned
                 if stat not in self._siphoned_stats[ally_id]:
                     self._siphoned_stats[ally_id][stat] = 0
-                self._siphoned_stats[ally_id][stat] += siphon_amount
+                new_total = self._siphoned_stats[ally_id][stat] + siphon_amount
+                self._siphoned_stats[ally_id][stat] = new_total
 
                 # Apply debuff to ally
                 ally_debuff = StatEffect(
                     name=f"{self.id}_siphon_{stat}",
-                    stat_modifiers={stat: -siphon_amount},
+                    stat_modifiers={stat: -new_total},
                     duration=-1,  # Permanent until returned
                     source=f"{self.id}_siphon",
                 )
@@ -121,11 +144,14 @@ class MezzyGluttonousBulwark:
                 # Apply buff to Mezzy
                 mezzy_buff = StatEffect(
                     name=f"{self.id}_gain_{stat}",
-                    stat_modifiers={stat: siphon_amount},
+                    stat_modifiers={stat: new_total},
                     duration=-1,  # Permanent
                     source=f"{self.id}_gain",
                 )
                 mezzy.add_effect(mezzy_buff)
+
+            if not self._siphoned_stats[ally_id]:
+                del self._siphoned_stats[ally_id]
 
     @classmethod
     def get_description(cls) -> str:

--- a/backend/tests/test_mezzy_gluttonous_bulwark.py
+++ b/backend/tests/test_mezzy_gluttonous_bulwark.py
@@ -1,0 +1,26 @@
+import pytest
+
+from autofighter.stats import Stats
+from plugins.passives.normal.mezzy_gluttonous_bulwark import SAFE_MAX_HP_FLOOR
+from plugins.passives.normal.mezzy_gluttonous_bulwark import MezzyGluttonousBulwark
+
+
+@pytest.mark.asyncio
+async def test_mezzy_gluttonous_bulwark_respects_max_hp_floor() -> None:
+    MezzyGluttonousBulwark._siphoned_stats.clear()
+    passive = MezzyGluttonousBulwark()
+    mezzy = Stats()
+    ally = Stats()
+
+    initial_max_hp = ally.max_hp
+    iterations = initial_max_hp * 2
+
+    for _ in range(iterations):
+        await passive.siphon_from_allies(mezzy, [ally])
+        assert ally.max_hp >= SAFE_MAX_HP_FLOOR
+
+    ally_id = id(ally)
+    tracked_max_hp = passive._siphoned_stats.get(ally_id, {}).get("max_hp", 0)
+
+    assert ally.max_hp == SAFE_MAX_HP_FLOOR
+    assert tracked_max_hp == initial_max_hp - ally.max_hp


### PR DESCRIPTION
## Summary
- add a safe max HP floor to Mezzy's Gluttonous Bulwark siphon routine and clamp siphoned amounts before applying effects
- update stat tracking/return logic so siphon totals stay in sync with the new floor-aware behaviour
- add a regression test covering repeated siphon ticks to ensure allies never fall below the floor

## Testing
- `uv run pytest tests/test_mezzy_gluttonous_bulwark.py`
- `uv run pytest tests` *(fails: existing tests contain syntax errors outside this change)*

------
https://chatgpt.com/codex/tasks/task_b_68d13bee5fc0832c8f553248d1d1a5d5