### PR TITLE
feat(backend): extract foe catalog loader

### DIFF
--- a/backend/autofighter/rooms/foe_factory.py
+++ b/backend/autofighter/rooms/foe_factory.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from dataclasses import field
 from dataclasses import fields
-from pathlib import Path
 import random
 from typing import Any
-from typing import Callable
 from typing import Collection
 from typing import Iterable
 from typing import Mapping
@@ -17,21 +14,10 @@ from autofighter.effects import get_current_stat_value
 from autofighter.mapgen import MapGenerator
 from autofighter.mapgen import MapNode
 from autofighter.party import Party
+from autofighter.rooms.foes import SpawnTemplate
+from autofighter.rooms.foes.catalog import load_catalog
 from autofighter.stats import Stats
 from plugins.foes._base import FoeBase
-from plugins.plugin_loader import PluginLoader
-
-
-@dataclass(frozen=True)
-class SpawnTemplate:
-    """Metadata describing a foe spawn template."""
-
-    id: str
-    cls: type[FoeBase]
-    tags: frozenset[str] = field(default_factory=frozenset)
-    weight_hook: Callable[[MapNode, Collection[str], Collection[str] | None, bool], float] | None = None
-    base_rank: str = "normal"
-    apply_adjective: bool = False
 
 
 @dataclass
@@ -64,10 +50,6 @@ ROOM_BALANCE_CONFIG: dict[str, Any] = {
     "scaling_modifier_id": "foe_room_scaling",
     "pressure_modifier_id": "foe_pressure_scaling",
 }
-
-
-def _plugin_root() -> Path:
-    return Path(__file__).resolve().parents[2] / "plugins"
 
 
 def _ensure_pending(stats: Stats, modifier: StatModifier) -> None:
@@ -161,67 +143,11 @@ class FoeFactory:
         self.config = dict(ROOM_BALANCE_CONFIG)
         if config:
             self.config.update(config)
-        loader = PluginLoader()
-        root = _plugin_root()
-        for category in ("foes", "players", "themedadj"):
-            loader.discover(str(root / category))
-        try:
-            foes = loader.get_plugins("foe")
-        except Exception:
-            foes = {}
-        try:
-            players = loader.get_plugins("player")
-        except Exception:
-            players = {}
-        try:
-            adjectives = loader.get_plugins("themedadj")
-        except Exception:
-            adjectives = {}
-        self._adjectives: list[type] = list(adjectives.values())
-        self._templates: dict[str, SpawnTemplate] = {}
-        for foe_cls in foes.values():
-            ident = getattr(foe_cls, "id", foe_cls.__name__)
-            tags = frozenset(getattr(foe_cls, "spawn_tags", ()) or ())
-            hook = getattr(foe_cls, "get_spawn_weight", None)
-            self._templates[ident] = SpawnTemplate(
-                id=ident,
-                cls=foe_cls,
-                tags=tags,
-                weight_hook=hook,
-                base_rank=getattr(foe_cls, "rank", "normal"),
-            )
-        self._player_templates: dict[str, SpawnTemplate] = {}
-        for player_cls in players.values():
-            ident = getattr(player_cls, "id", player_cls.__name__)
-            if ident in self._templates:
-                continue
-            wrapper = self._wrap_player(player_cls)
-            hook = getattr(player_cls, "get_spawn_weight", None)
-            template = SpawnTemplate(
-                id=ident,
-                cls=wrapper,
-                tags=frozenset({"player_template"}),
-                weight_hook=hook,
-                base_rank=getattr(wrapper, "rank", "normal"),
-                apply_adjective=True,
-            )
-            self._templates[ident] = template
-            self._player_templates[ident] = template
-
-    def _wrap_player(self, cls: type) -> type[FoeBase]:
-        base_rank = getattr(cls, "rank", "normal")
-
-        class Wrapped(cls, FoeBase):  # type: ignore[misc, valid-type]
-            plugin_type = "foe"
-            rank = base_rank
-
-            def __post_init__(self) -> None:  # noqa: D401 - thin wrapper
-                getattr(cls, "__post_init__", lambda self: None)(self)
-                FoeBase.__post_init__(self)
-                self.plugin_type = "foe"
-
-        Wrapped.__name__ = f"{cls.__name__}Foe"
-        return Wrapped
+        (
+            self._templates,
+            self._player_templates,
+            self._adjectives,
+        ) = load_catalog()
 
     @property
     def templates(self) -> Mapping[str, SpawnTemplate]:

--- a/backend/autofighter/rooms/foes/__init__.py
+++ b/backend/autofighter/rooms/foes/__init__.py
@@ -1,0 +1,6 @@
+"""Foe catalog utilities and plugin helpers."""
+
+from .catalog import SpawnTemplate
+from .catalog import load_catalog
+
+__all__ = ["SpawnTemplate", "load_catalog"]

--- a/backend/autofighter/rooms/foes/catalog.py
+++ b/backend/autofighter/rooms/foes/catalog.py
@@ -1,0 +1,104 @@
+"""Plugin discovery helpers for foe spawn templates."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field
+from pathlib import Path
+from typing import TYPE_CHECKING
+from typing import Callable
+from typing import Collection
+from typing import Iterable
+
+from plugins.foes._base import FoeBase
+from plugins.plugin_loader import PluginLoader
+
+if TYPE_CHECKING:
+    from autofighter.mapgen import MapNode
+
+
+@dataclass(frozen=True)
+class SpawnTemplate:
+    """Metadata describing a foe spawn template."""
+
+    id: str
+    cls: type[FoeBase]
+    tags: frozenset[str] = field(default_factory=frozenset)
+    weight_hook: Callable[[MapNode, Collection[str], Collection[str] | None, bool], float] | None = None
+    base_rank: str = "normal"
+    apply_adjective: bool = False
+
+
+def _plugin_root() -> Path:
+    return Path(__file__).resolve().parents[3] / "plugins"
+
+
+def _safe_get_plugins(loader: PluginLoader, category: str) -> dict[str, type]:
+    try:
+        return loader.get_plugins(category)
+    except Exception:
+        return {}
+
+
+def _wrap_player(cls: type) -> type[FoeBase]:
+    base_rank = getattr(cls, "rank", "normal")
+
+    class Wrapped(cls, FoeBase):  # type: ignore[misc, valid-type]
+        plugin_type = "foe"
+        rank = base_rank
+
+        def __post_init__(self) -> None:  # noqa: D401 - thin wrapper
+            getattr(cls, "__post_init__", lambda self: None)(self)
+            FoeBase.__post_init__(self)
+            self.plugin_type = "foe"
+
+    Wrapped.__name__ = f"{cls.__name__}Foe"
+    return Wrapped
+
+
+def load_catalog() -> tuple[dict[str, SpawnTemplate], dict[str, SpawnTemplate], list[type]]:
+    """Discover foe, player, and adjective plugins and build spawn templates."""
+
+    loader = PluginLoader()
+    root = _plugin_root()
+    for category in ("foes", "players", "themedadj"):
+        loader.discover(str(root / category))
+
+    foes = _safe_get_plugins(loader, "foe")
+    players = _safe_get_plugins(loader, "player")
+    adjectives = _safe_get_plugins(loader, "themedadj")
+
+    templates: dict[str, SpawnTemplate] = {}
+    player_templates: dict[str, SpawnTemplate] = {}
+
+    for foe_cls in foes.values():
+        ident = getattr(foe_cls, "id", foe_cls.__name__)
+        tags: Iterable[str] = getattr(foe_cls, "spawn_tags", ()) or ()
+        hook = getattr(foe_cls, "get_spawn_weight", None)
+        templates[ident] = SpawnTemplate(
+            id=ident,
+            cls=foe_cls,
+            tags=frozenset(tags),
+            weight_hook=hook,
+            base_rank=getattr(foe_cls, "rank", "normal"),
+        )
+
+    for player_cls in players.values():
+        ident = getattr(player_cls, "id", player_cls.__name__)
+        if ident in templates:
+            continue
+        wrapper = _wrap_player(player_cls)
+        hook = getattr(player_cls, "get_spawn_weight", None)
+        template = SpawnTemplate(
+            id=ident,
+            cls=wrapper,
+            tags=frozenset({"player_template"}),
+            weight_hook=hook,
+            base_rank=getattr(wrapper, "rank", "normal"),
+            apply_adjective=True,
+        )
+        templates[ident] = template
+        player_templates[ident] = template
+
+    adjective_types = list(adjectives.values())
+    return templates, player_templates, adjective_types

--- a/backend/tests/rooms/foes/test_catalog.py
+++ b/backend/tests/rooms/foes/test_catalog.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import types
+
+logging_module = types.ModuleType("battle_logging")
+writers_module = types.ModuleType("battle_logging.writers")
+writers_module.start_battle_logging = lambda *_, **__: None
+writers_module.end_battle_logging = lambda *_, **__: None
+writers_module.BattleLogger = type("BattleLogger", (), {})
+writers_module.get_current_run_logger = lambda *_, **__: None
+logging_module.writers = writers_module
+sys.modules.setdefault("battle_logging", logging_module)
+sys.modules.setdefault("battle_logging.writers", writers_module)
+sys.modules.setdefault("services", types.ModuleType("services"))
+user_level_module = types.ModuleType("services.user_level_service")
+user_level_module.gain_user_exp = lambda *_, **__: None
+user_level_module.get_user_level = lambda *_, **__: 1
+sys.modules.setdefault("services.user_level_service", user_level_module)
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from autofighter.rooms.foes import SpawnTemplate  # noqa: E402
+from autofighter.rooms.foes import load_catalog  # noqa: E402
+from plugins.foes._base import FoeBase  # noqa: E402
+from plugins.foes.slime import Slime  # noqa: E402
+from plugins.players.player import Player  # noqa: E402
+
+
+def test_catalog_exposes_spawn_templates_for_foes_and_players() -> None:
+    templates, player_templates, adjectives = load_catalog()
+
+    assert "slime" in templates
+    slime_template = templates["slime"]
+    assert isinstance(slime_template, SpawnTemplate)
+    assert issubclass(slime_template.cls, FoeBase)
+    assert slime_template.cls.__name__ == Slime.__name__
+    assert slime_template.tags == frozenset(getattr(Slime, "spawn_tags", ()) or ())
+    assert slime_template.apply_adjective is False
+
+    assert "player" in player_templates
+    player_template = player_templates["player"]
+    assert player_template is templates["player"]
+    assert isinstance(player_template, SpawnTemplate)
+    assert player_template.tags == frozenset({"player_template"})
+    assert issubclass(player_template.cls, FoeBase)
+    assert player_template.cls is not Player
+    assert player_template.apply_adjective is True
+
+    assert adjectives
+    assert all(isinstance(adjective, type) for adjective in adjectives)
+    assert any(getattr(adjective, "id", "") == "evil" for adjective in adjectives)

--- a/backend/tests/test_foe_factory.py
+++ b/backend/tests/test_foe_factory.py
@@ -9,6 +9,7 @@ writers_module = types.ModuleType("battle_logging.writers")
 writers_module.start_battle_logging = lambda *_, **__: None
 writers_module.end_battle_logging = lambda *_, **__: None
 writers_module.BattleLogger = type("BattleLogger", (), {})
+writers_module.get_current_run_logger = lambda *_, **__: None
 logging_module.writers = writers_module
 sys.modules.setdefault("battle_logging", logging_module)
 sys.modules.setdefault("battle_logging.writers", writers_module)


### PR DESCRIPTION
## Summary
- move plugin discovery and spawn template creation into a dedicated `autofighter.rooms.foes.catalog` helper
- update `FoeFactory` to load foe, player, and adjective templates from the new catalog module
- add regression coverage for catalog discovery and extend the foe factory test shim

## Testing
- [x] Backend tests (`uv run pytest tests/rooms/foes/test_catalog.py`)
- [ ] Backend tests (`uv run pytest tests/test_foe_factory.py`) *(fails in current mainline: high-stat scaling expectation is unmet)*
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68d20d201ae8832c9da80b3d37249dcc