### PR TITLE
feat: extract foe selection helpers

### DIFF
--- a/backend/autofighter/rooms/foes/selector.py
+++ b/backend/autofighter/rooms/foes/selector.py
@@ -1,0 +1,225 @@
+"""Helper utilities for selecting foe spawn templates."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from collections.abc import Mapping
+import random
+from typing import Any
+
+from autofighter.mapgen import MapNode
+from autofighter.party import Party
+from autofighter.rooms.foes import SpawnTemplate
+
+
+def _weight_for_template(
+    template: SpawnTemplate,
+    *,
+    node: MapNode,
+    party_ids: Collection[str],
+    recent_ids: Collection[str] | None,
+    boss: bool,
+) -> float:
+    """Return a selection weight for the given template."""
+
+    hook = template.weight_hook
+    if not callable(hook):
+        return 1.0
+    try:
+        weight = hook(
+            node=node,
+            party_ids=party_ids,
+            recent_ids=recent_ids,
+            boss=boss,
+        )
+    except Exception:
+        return 1.0
+    try:
+        return float(weight)
+    except Exception:
+        return 1.0
+
+
+def _adjust_recent_weight(
+    weight: float,
+    template_id: str,
+    recent_ids: Collection[str] | None,
+    config: Mapping[str, Any] | None,
+) -> float:
+    if not recent_ids or template_id not in recent_ids:
+        return weight
+
+    factor = 1.0
+    minimum = 0.0
+    if config is not None:
+        try:
+            factor = float(config.get("recent_weight_factor", 1.0))
+        except Exception:
+            factor = 1.0
+        try:
+            minimum = float(config.get("recent_weight_min", 0.0))
+        except Exception:
+            minimum = 0.0
+    adjusted = weight * factor
+    if adjusted <= 0.0:
+        return max(minimum, 0.0)
+    return max(adjusted, minimum)
+
+
+def _sample_templates(
+    count: int,
+    *,
+    templates: Mapping[str, SpawnTemplate],
+    node: MapNode,
+    party_ids: Collection[str],
+    recent_ids: Collection[str] | None = None,
+    config: Mapping[str, Any] | None = None,
+    rng: random.Random | None = None,
+) -> list[SpawnTemplate]:
+    """Sample encounter templates while respecting recent foe history."""
+
+    rng = rng or random
+    pool: list[SpawnTemplate] = [
+        template for template in templates.values() if template.id not in party_ids
+    ]
+    if not pool:
+        return []
+
+    unique: dict[str, SpawnTemplate] = {}
+    for template in pool:
+        unique.setdefault(template.id, template)
+    candidates = list(unique.values())
+
+    weights: list[float] = []
+    for template in candidates:
+        weight = _weight_for_template(
+            template,
+            node=node,
+            party_ids=party_ids,
+            recent_ids=recent_ids,
+            boss=False,
+        )
+        if weight > 0.0:
+            weight = _adjust_recent_weight(weight, template.id, recent_ids, config)
+        weights.append(max(weight, 0.0))
+
+    selected: list[SpawnTemplate] = []
+    candidate_weights = weights[:]
+    limit = min(count, len(candidates))
+    for _ in range(limit):
+        if not candidates:
+            break
+        if not any(weight > 0.0 for weight in candidate_weights):
+            candidate_weights = [1.0 for _ in candidates]
+        choice = rng.choices(candidates, weights=candidate_weights, k=1)[0]
+        selected.append(choice)
+        idx = candidates.index(choice)
+        candidates.pop(idx)
+        candidate_weights.pop(idx)
+    return selected
+
+
+def _choose_template(
+    *,
+    templates: Mapping[str, SpawnTemplate],
+    node: MapNode,
+    party_ids: Collection[str],
+    recent_ids: Collection[str] | None,
+    boss: bool,
+    rng: random.Random | None = None,
+) -> SpawnTemplate | None:
+    """Choose a single template for encounters such as boss rooms."""
+
+    rng = rng or random
+    candidates = [
+        template for template in templates.values() if template.id not in party_ids
+    ]
+    if not candidates:
+        return None
+
+    weights = [
+        max(
+            _weight_for_template(
+                template,
+                node=node,
+                party_ids=party_ids,
+                recent_ids=recent_ids,
+                boss=boss,
+            ),
+            0.0,
+        )
+        for template in candidates
+    ]
+    if not any(weight > 0.0 for weight in weights):
+        weights = [1.0 for _ in candidates]
+    return rng.choices(candidates, weights=weights, k=1)[0]
+
+
+def _desired_count(
+    node: MapNode,
+    party: Party,
+    *,
+    config: Mapping[str, Any],
+    rng: random.Random | None = None,
+) -> int:
+    """Calculate the number of foes to spawn for the encounter."""
+
+    rng = rng or random
+
+    try:
+        base_cap = int(config.get("base_spawn_cap", 1))
+    except Exception:
+        base_cap = 1
+    try:
+        pressure_base = int(config.get("pressure_spawn_base", 0))
+    except Exception:
+        pressure_base = 0
+    try:
+        pressure_step = int(config.get("pressure_spawn_step", 1))
+    except Exception:
+        pressure_step = 1
+
+    try:
+        pressure = int(getattr(node, "pressure", 0))
+    except Exception:
+        pressure = 0
+
+    effective_step = pressure_step if pressure_step > 0 else 1
+    base = min(base_cap, pressure_base + max(pressure, 0) // effective_step)
+
+    extras = 0
+    members_obj = getattr(party, "members", [])
+    if isinstance(members_obj, Collection):
+        size = len(members_obj)
+    else:
+        try:
+            materialized = list(members_obj)
+        except Exception:
+            materialized = []
+        size = len(materialized)
+    max_extra = max(size - 1, 0)
+    if max_extra:
+        try:
+            full_chance = float(config.get("party_extra_full_chance", 0.0))
+        except Exception:
+            full_chance = 0.0
+        try:
+            step_chance = float(config.get("party_extra_step_chance", 0.0))
+        except Exception:
+            step_chance = 0.0
+        if rng.random() < full_chance:
+            extras = max_extra
+        else:
+            for tier in range(max_extra - 1, 0, -1):
+                if rng.random() < step_chance:
+                    extras = tier
+                    break
+    return min(base_cap, base + extras)
+
+
+__all__ = [
+    "_weight_for_template",
+    "_sample_templates",
+    "_choose_template",
+    "_desired_count",
+]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,114 @@
+"""Test configuration for backend suite."""
+
+import sys
+import types
+
+
+def _ensure_battle_logging_stub() -> None:
+    if "battle_logging.writers" in sys.modules:
+        return
+
+    battle_logging = sys.modules.get("battle_logging")
+    if battle_logging is None:
+        battle_logging = types.ModuleType("battle_logging")
+        sys.modules["battle_logging"] = battle_logging
+
+    writers = types.ModuleType("battle_logging.writers")
+    writers.end_battle_logging = lambda *args, **kwargs: None  # noqa: E731
+
+    class BattleLogger:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs) -> None:  # noqa: D401, ANN001
+            return
+
+        def start(self, *args, **kwargs) -> None:  # noqa: D401, ANN001
+            return
+
+        def stop(self, *args, **kwargs) -> None:  # noqa: D401, ANN001
+            return
+
+    writers.BattleLogger = BattleLogger  # type: ignore[attr-defined]
+    writers.start_battle_logging = lambda *args, **kwargs: BattleLogger()  # noqa: E731
+    writers.get_current_run_logger = lambda: BattleLogger()  # noqa: E731
+    sys.modules["battle_logging.writers"] = writers
+    setattr(battle_logging, "writers", writers)
+
+
+def _ensure_user_level_stub() -> None:
+    if "services.user_level_service" in sys.modules:
+        return
+
+    services_pkg = sys.modules.get("services")
+    if services_pkg is None:
+        services_pkg = types.ModuleType("services")
+        sys.modules["services"] = services_pkg
+
+    user_level = types.ModuleType("services.user_level_service")
+    user_level.gain_user_exp = lambda *args, **kwargs: None  # noqa: E731
+    user_level.get_user_level = lambda *args, **kwargs: 1  # noqa: E731
+    sys.modules["services.user_level_service"] = user_level
+    setattr(services_pkg, "user_level_service", user_level)
+
+
+def _ensure_tracking_stub() -> None:
+    if "tracking" in sys.modules:
+        return
+
+    tracking = types.ModuleType("tracking")
+    tracking.log_battle_summary = lambda *args, **kwargs: None  # noqa: E731
+    tracking.log_game_action = lambda *args, **kwargs: None  # noqa: E731
+    sys.modules["tracking"] = tracking
+
+
+def _ensure_options_stub() -> None:
+    if "options" in sys.modules:
+        return
+
+    options = types.ModuleType("options")
+
+    class OptionKey(str):
+        pass
+
+    def get_option(*_args, default=None, **_kwargs):  # noqa: ANN001, D401 - simple stub
+        return default
+
+    options.OptionKey = OptionKey  # type: ignore[attr-defined]
+    options.get_option = get_option  # type: ignore[attr-defined]
+    sys.modules["options"] = options
+
+
+def _ensure_llm_stub() -> None:
+    if "llms.loader" in sys.modules:
+        return
+
+    llms = sys.modules.get("llms")
+    if llms is None:
+        llms = types.ModuleType("llms")
+        sys.modules["llms"] = llms
+
+    loader = types.ModuleType("llms.loader")
+
+    class ModelName(str):
+        pass
+
+    loader.ModelName = ModelName  # type: ignore[attr-defined]
+    loader.pipeline = lambda *args, **kwargs: None  # noqa: E731
+    loader.load_llm = lambda *args, **kwargs: None  # noqa: E731
+    sys.modules["llms.loader"] = loader
+    setattr(llms, "loader", loader)
+
+
+def _ensure_tts_stub() -> None:
+    if "tts" in sys.modules:
+        return
+
+    tts = types.ModuleType("tts")
+    tts.generate_voice = lambda *args, **kwargs: None  # noqa: E731
+    sys.modules["tts"] = tts
+
+
+_ensure_battle_logging_stub()
+_ensure_user_level_stub()
+_ensure_tracking_stub()
+_ensure_options_stub()
+_ensure_llm_stub()
+_ensure_tts_stub()

--- a/backend/tests/test_foe_selector.py
+++ b/backend/tests/test_foe_selector.py
@@ -1,0 +1,218 @@
+from dataclasses import dataclass
+import types
+from typing import Callable
+
+import pytest
+
+from autofighter.rooms.foes.selector import _choose_template
+from autofighter.rooms.foes.selector import _desired_count
+from autofighter.rooms.foes.selector import _sample_templates
+from autofighter.rooms.foes.selector import _weight_for_template
+
+
+@dataclass(frozen=True)
+class Template:
+    id: str
+    cls: type
+    tags: frozenset[str] = frozenset()
+    weight_hook: Callable[..., float] | None = None
+    base_rank: str = "normal"
+    apply_adjective: bool = False
+
+
+class DummyFoe:
+    plugin_type = "foe"
+
+
+class DummyNode:
+    def __init__(self, *, pressure: int = 0) -> None:
+        self.pressure = pressure
+
+
+class DummyParty:
+    def __init__(self, members: list[types.SimpleNamespace]) -> None:
+        self.members = members
+
+
+class DeterministicRng:
+    """Deterministic helper that prefers highest-weight options."""
+
+    def __init__(self, values: list[float] | None = None) -> None:
+        self._values = list(values or [])
+        self._index = 0
+
+    def random(self) -> float:
+        if self._index < len(self._values):
+            value = self._values[self._index]
+            self._index += 1
+            return value
+        return 0.0
+
+    def choices(self, population, weights=None, k=1):  # noqa: D401 - matches random API
+        if weights and any(weight > 0 for weight in weights):
+            max_weight = max(weights)
+            index = weights.index(max_weight)
+        else:
+            index = 0
+        return [population[index] for _ in range(k)]
+
+
+def make_template(identifier: str, weight: float = 1.0, *, tags: frozenset[str] | None = None):
+    calls: list[dict[str, object]] = []
+
+    def hook(**kwargs):
+        calls.append(kwargs)
+        return weight
+
+    template = Template(
+        id=identifier,
+        cls=DummyFoe,
+        tags=tags or frozenset(),
+        weight_hook=hook,
+    )
+    hook.calls = calls  # type: ignore[attr-defined]
+    return template
+
+
+def test_weight_for_template_defaults_without_hook():
+    template = Template(id="plain", cls=DummyFoe)
+    node = DummyNode()
+    weight = _weight_for_template(
+        template,
+        node=node,
+        party_ids=set(),
+        recent_ids=None,
+        boss=False,
+    )
+    assert weight == pytest.approx(1.0)
+
+
+def test_sample_templates_prioritises_non_recent_ids():
+    fresh = make_template("fresh", weight=1.0)
+    recent = make_template("recent", weight=1.0)
+    templates = {"fresh": fresh, "recent": recent}
+    node = DummyNode()
+    rng = DeterministicRng()
+
+    selected = _sample_templates(
+        1,
+        templates=templates,
+        node=node,
+        party_ids=set(),
+        recent_ids={"recent"},
+        config={
+            "recent_weight_factor": 0.25,
+            "recent_weight_min": 0.1,
+        },
+        rng=rng,
+    )
+
+    assert [template.id for template in selected] == ["fresh"]
+    assert fresh.weight_hook.calls[0]["boss"] is False
+
+
+def test_sample_templates_ignores_party_members():
+    ally = make_template("ally", weight=10.0)
+    other = make_template("other", weight=1.0)
+    templates = {"ally": ally, "other": other}
+    node = DummyNode()
+    rng = DeterministicRng()
+
+    selected = _sample_templates(
+        1,
+        templates=templates,
+        node=node,
+        party_ids={"ally"},
+        recent_ids=set(),
+        config={},
+        rng=rng,
+    )
+
+    assert [template.id for template in selected] == ["other"]
+
+
+def test_sample_templates_falls_back_when_all_weights_zero():
+    zero = make_template("zero", weight=0.0)
+    templates = {"zero": zero}
+    node = DummyNode()
+
+    selected = _sample_templates(
+        1,
+        templates=templates,
+        node=node,
+        party_ids=set(),
+        recent_ids=set(),
+        config={},
+        rng=DeterministicRng(),
+    )
+
+    assert [template.id for template in selected] == ["zero"]
+
+
+def test_choose_template_passes_boss_flag():
+    recorded: list[bool] = []
+
+    def hook(**kwargs):
+        recorded.append(bool(kwargs.get("boss")))
+        return 5.0
+
+    template = Template(
+        id="bossy",
+        cls=DummyFoe,
+        weight_hook=hook,
+    )
+    result = _choose_template(
+        templates={"bossy": template},
+        node=DummyNode(),
+        party_ids=set(),
+        recent_ids=None,
+        boss=True,
+        rng=DeterministicRng(),
+    )
+
+    assert result is template
+    assert recorded == [True]
+
+
+def test_desired_count_uses_full_party_bonus():
+    node = DummyNode(pressure=10)
+    members = [types.SimpleNamespace(id=str(idx)) for idx in range(4)]
+    party = DummyParty(members)
+    rng = DeterministicRng([0.2])  # triggers full bonus
+
+    result = _desired_count(
+        node,
+        party,
+        config={
+            "base_spawn_cap": 10,
+            "pressure_spawn_base": 1,
+            "pressure_spawn_step": 5,
+            "party_extra_full_chance": 0.35,
+            "party_extra_step_chance": 0.75,
+        },
+        rng=rng,
+    )
+
+    assert result == 6
+
+
+def test_desired_count_partial_bonus_steps():
+    node = DummyNode(pressure=5)
+    members = [types.SimpleNamespace(id=str(idx)) for idx in range(5)]
+    party = DummyParty(members)
+    rng = DeterministicRng([0.9, 0.4])  # skip full bonus, apply tier bonus
+
+    result = _desired_count(
+        node,
+        party,
+        config={
+            "base_spawn_cap": 10,
+            "pressure_spawn_base": 1,
+            "pressure_spawn_step": 5,
+            "party_extra_full_chance": 0.35,
+            "party_extra_step_chance": 0.75,
+        },
+        rng=rng,
+    )
+
+    assert result == 5


### PR DESCRIPTION
## Summary
- add `autofighter.rooms.foes.selector` to host helper functions for foe selection
- refactor `FoeFactory` to rely on the helper module instead of direct configuration access
- add pytest coverage for selector scenarios with supporting stubs in `tests/conftest.py`

## Testing
- ./run-tests.sh (fails: existing suite depends on unavailable optional modules)
- uv run pytest tests/test_foe_selector.py

------
https://chatgpt.com/codex/tasks/task_b_68d212a0bfc0832c9f6daeee76e6e600