### PR TITLE
[REFACTOR] Extract battle snapshot helpers

### DIFF
--- a/backend/autofighter/rooms/battle/snapshots.py
+++ b/backend/autofighter/rooms/battle/snapshots.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Any
+from typing import Iterable
+import weakref
+
+from autofighter.party import Party
+
+from ...stats import Stats
+
+__all__ = [
+    "register_snapshot_entities",
+    "prepare_snapshot_overlay",
+    "mutate_snapshot_overlay",
+    "resolve_run_id",
+    "get_recent_events",
+    "get_status_phase",
+]
+
+_MISSING = object()
+_RECENT_EVENT_LIMIT = 6
+
+_entity_run_ids: dict[int, str] = {}
+_entity_refs: dict[int, weakref.ref[Stats]] = {}
+_party_run_ids: dict[int, str] = {}
+_party_refs: dict[int, weakref.ref[Party]] = {}
+_recent_events: dict[str, deque[dict[str, Any]]] = {}
+_status_phases: dict[str, dict[str, Any] | None] = {}
+
+
+def resolve_run_id(*entities: Any) -> str | None:
+    for entity in entities:
+        if isinstance(entity, Stats):
+            run_id = _entity_run_ids.get(id(entity))
+            if run_id:
+                return run_id
+        if isinstance(entity, Party):
+            run_id = _party_run_ids.get(id(entity))
+            if run_id:
+                return run_id
+    return None
+
+
+def register_snapshot_entities(run_id: str | None, entities: Iterable[Any]) -> None:
+    if not run_id:
+        return
+    for entity in entities:
+        if isinstance(entity, Stats):
+            ident = id(entity)
+
+            def _cleanup(_ref: weakref.ref[Stats], *, key: int = ident) -> None:
+                _entity_run_ids.pop(key, None)
+                _entity_refs.pop(key, None)
+
+            _entity_run_ids[ident] = run_id
+            _entity_refs[ident] = weakref.ref(entity, _cleanup)
+        elif isinstance(entity, Party):
+            ident = id(entity)
+
+            def _cleanup(_ref: weakref.ref[Party], *, key: int = ident) -> None:
+                _party_run_ids.pop(key, None)
+                _party_refs.pop(key, None)
+
+            _party_run_ids[ident] = run_id
+            _party_refs[ident] = weakref.ref(entity, _cleanup)
+
+
+def prepare_snapshot_overlay(run_id: str | None, entities: Iterable[Any]) -> None:
+    if not run_id:
+        return
+    register_snapshot_entities(run_id, entities)
+    queue = _recent_events.get(run_id)
+    if queue is None:
+        queue = deque(maxlen=_RECENT_EVENT_LIMIT)
+        _recent_events[run_id] = queue
+    else:
+        queue.clear()
+    _status_phases.pop(run_id, None)
+    snapshot = _get_snapshot(run_id)
+    snapshot.setdefault("recent_events", [])
+    snapshot.pop("status_phase", None)
+
+
+def mutate_snapshot_overlay(
+    run_id: str | None,
+    *,
+    active_id: str | None | object = _MISSING,
+    active_target_id: str | None | object = _MISSING,
+    status_phase: dict[str, Any] | None | object = _MISSING,
+    event: dict[str, Any] | None = None,
+) -> None:
+    if not run_id:
+        return
+    snapshot = _get_snapshot(run_id)
+    if active_id is not _MISSING:
+        snapshot["active_id"] = active_id
+    if active_target_id is not _MISSING:
+        snapshot["active_target_id"] = active_target_id
+    if status_phase is not _MISSING:
+        _status_phases[run_id] = status_phase
+        snapshot["status_phase"] = status_phase
+    elif run_id in _status_phases:
+        snapshot["status_phase"] = _status_phases[run_id]
+    if event is not None:
+        queue = _ensure_event_queue(run_id)
+        queue.append(event)
+    queue = _recent_events.get(run_id)
+    if queue is not None:
+        snapshot["recent_events"] = list(queue)
+
+
+def get_recent_events(run_id: str | None) -> list[dict[str, Any]] | None:
+    if not run_id:
+        return None
+    queue = _recent_events.get(run_id)
+    if queue is None:
+        return None
+    return list(queue)
+
+
+def get_status_phase(run_id: str | None) -> dict[str, Any] | None:
+    if not run_id:
+        return None
+    return _status_phases.get(run_id)
+
+
+def _ensure_event_queue(run_id: str) -> deque[dict[str, Any]]:
+    queue = _recent_events.get(run_id)
+    if queue is None:
+        queue = deque(maxlen=_RECENT_EVENT_LIMIT)
+        _recent_events[run_id] = queue
+    return queue
+
+
+def _get_snapshot(run_id: str) -> dict[str, Any]:
+    from runs.lifecycle import battle_snapshots
+
+    snap = battle_snapshots.get(run_id)
+    if snap is None:
+        snap = {"result": "battle"}
+        battle_snapshots[run_id] = snap
+    return snap

--- a/backend/tests/test_battle_snapshots_module.py
+++ b/backend/tests/test_battle_snapshots_module.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from autofighter.stats import Stats
+
+
+@pytest.fixture()
+def snapshot_env(monkeypatch: pytest.MonkeyPatch):
+    created_stub = False
+    try:
+        lifecycle = importlib.import_module("runs.lifecycle")
+    except ImportError:
+        lifecycle = types.ModuleType("runs.lifecycle")
+        lifecycle.battle_snapshots = {}
+        runs_module = types.ModuleType("runs")
+        runs_module.lifecycle = lifecycle
+        monkeypatch.setitem(sys.modules, "runs", runs_module)
+        monkeypatch.setitem(sys.modules, "runs.lifecycle", lifecycle)
+        created_stub = True
+    else:
+        lifecycle.battle_snapshots.clear()
+
+    snapshots_module = importlib.import_module("autofighter.rooms.battle.snapshots")
+    snapshots_module = importlib.reload(snapshots_module)
+    try:
+        yield snapshots_module, lifecycle.battle_snapshots
+    finally:
+        lifecycle.battle_snapshots.clear()
+        if created_stub:
+            monkeypatch.delitem(sys.modules, "runs", raising=False)
+            monkeypatch.delitem(sys.modules, "runs.lifecycle", raising=False)
+
+
+def test_prepare_snapshot_overlay_initializes_state(snapshot_env) -> None:
+    snapshots_module, battle_snapshots = snapshot_env
+    run_id = "snapshot-init"
+
+    combatant = Stats()
+    combatant.id = "hero"
+
+    snapshots_module.prepare_snapshot_overlay(run_id, [combatant])
+
+    assert run_id in battle_snapshots
+    snapshot = battle_snapshots[run_id]
+    assert snapshot["result"] == "battle"
+    assert snapshot.get("recent_events") == []
+    assert snapshots_module.resolve_run_id(combatant) == run_id
+
+    snapshots_module.mutate_snapshot_overlay(run_id, event={"type": "seed"})
+    assert snapshots_module.get_recent_events(run_id) == [{"type": "seed"}]
+
+    snapshots_module.prepare_snapshot_overlay(run_id, [combatant])
+    assert snapshots_module.get_recent_events(run_id) == []
+    assert "status_phase" not in battle_snapshots[run_id]
+
+
+def test_mutate_snapshot_overlay_updates_snapshot_fields(snapshot_env) -> None:
+    snapshots_module, battle_snapshots = snapshot_env
+    run_id = "snapshot-mutate"
+
+    attacker = Stats()
+    attacker.id = "attacker"
+
+    snapshots_module.prepare_snapshot_overlay(run_id, [attacker])
+
+    status_payload = {"phase": "dot", "state": "start"}
+    event_payload = {"type": "hit_landed", "amount": 5}
+
+    snapshots_module.mutate_snapshot_overlay(
+        run_id,
+        active_id=attacker.id,
+        active_target_id="target",
+        status_phase=status_payload,
+        event=event_payload,
+    )
+
+    snapshot = battle_snapshots[run_id]
+    assert snapshot["active_id"] == attacker.id
+    assert snapshot["active_target_id"] == "target"
+    assert snapshot["status_phase"] == status_payload
+    assert snapshot["recent_events"] == [event_payload]
+
+    events_copy = snapshots_module.get_recent_events(run_id)
+    assert events_copy == [event_payload]
+    events_copy.append({"type": "other"})
+    assert snapshot["recent_events"] == [event_payload]
+
+    assert snapshots_module.get_status_phase(run_id) == status_payload

--- a/backend/tests/test_status_phase_events.py
+++ b/backend/tests/test_status_phase_events.py
@@ -252,7 +252,7 @@ async def test_status_phase_events_update_snapshot_queue(monkeypatch):
     target.passives = [STUB_PASSIVE_ID]
 
     monkeypatch.setattr(
-        "autofighter.rooms.battle.turns._RECENT_EVENT_LIMIT",
+        "autofighter.rooms.battle.snapshots._RECENT_EVENT_LIMIT",
         20,
         raising=False,
     )


### PR DESCRIPTION
## Summary
- introduce `snapshots.py` to hold battle snapshot state, run/entity tracking, and overlay helpers
- update `turns.py` to delegate snapshot access to the new module while keeping existing public APIs intact
- add targeted tests covering snapshot initialization/mutation and adjust status phase tests to patch the new constant location

## Testing
- uvx ruff check backend/autofighter/rooms/battle/snapshots.py backend/autofighter/rooms/battle/turns.py backend/tests/test_battle_snapshots_module.py backend/tests/test_status_phase_events.py --fix
- uv run pytest tests/test_battle_snapshots_module.py -vv
- uv run pytest tests/test_status_phase_events.py::test_target_acquired_event_records_recent_events -vv *(fails: ImportError: cannot import name 'end_run_logging' from 'battle_logging.writers')*


------
https://chatgpt.com/codex/tasks/task_b_68d236b30484832c80d2be5f68988238