### PR TITLE
[refactor] Extract battle progress snapshot helpers

### DIFF
--- a/backend/autofighter/rooms/battle/engine.py
+++ b/backend/autofighter/rooms/battle/engine.py
@@ -23,13 +23,13 @@ from ...party import Party
 from .events import handle_battle_end
 from .events import handle_battle_start
 from .pacing import _EXTRA_TURNS
+from .progress import build_action_queue_snapshot
+from .progress import collect_summon_snapshots
 from .resolution import resolve_rewards
 from .setup import BattleSetupResult
 from .turn_loop import run_turn_loop
 from .turn_loop.timeouts import TurnTimeoutError
 from .turns import EnrageState
-from .turns import build_action_queue_snapshot
-from .turns import collect_summon_snapshots
 from .turns import push_progress_update
 
 if TYPE_CHECKING:

--- a/backend/autofighter/rooms/battle/progress.py
+++ b/backend/autofighter/rooms/battle/progress.py
@@ -1,0 +1,188 @@
+"""Helpers for assembling battle progress payloads."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from typing import Iterable
+from typing import MutableMapping
+from typing import NotRequired
+from typing import Protocol
+from typing import Sequence
+from typing import TypedDict
+
+from autofighter.summons.base import Summon
+from autofighter.summons.manager import SummonManager
+
+from ...stats import Stats
+from ..utils import _serialize
+from . import snapshots as _snapshots
+
+
+class SupportsEnrageSnapshot(Protocol):
+    """Protocol describing the enrage payload interface."""
+
+    def as_payload(self) -> dict[str, Any]:
+        """Return a JSON serialisable enrage snapshot."""
+
+
+class ActionQueueEntry(TypedDict, total=False):
+    """Representation of a combatant in the visual action queue."""
+
+    id: str
+    action_gauge: int
+    action_value: float
+    base_action_value: float
+    bonus: NotRequired[bool]
+
+
+BattleEntityPayload = dict[str, Any]
+SummonSnapshotMap = dict[str, list[BattleEntityPayload]]
+
+
+class BattleProgressPayload(TypedDict, total=False):
+    """Payload broadcast to battle progress subscribers."""
+
+    result: str
+    party: list[BattleEntityPayload]
+    foes: list[BattleEntityPayload]
+    party_summons: SummonSnapshotMap
+    foe_summons: SummonSnapshotMap
+    enrage: dict[str, Any]
+    rdr: float
+    action_queue: list[ActionQueueEntry]
+    active_id: str | None
+    active_target_id: str | None
+    recent_events: list[dict[str, Any]]
+    status_phase: dict[str, Any]
+    ended: bool
+
+
+async def collect_summon_snapshots(entities: Iterable[Stats]) -> SummonSnapshotMap:
+    """Serialize active summons for the provided combatants."""
+
+    def _collect() -> SummonSnapshotMap:
+        snapshots: SummonSnapshotMap = {}
+        for ent in entities:
+            if isinstance(ent, Summon):
+                continue
+            sid = getattr(ent, "id", str(id(ent)))
+            for summon in SummonManager.get_summons(sid):
+                snap = _serialize(summon)
+                snap.setdefault(
+                    "instance_id",
+                    getattr(summon, "instance_id", getattr(summon, "id", None)),
+                )
+                snap["owner_id"] = sid
+                snapshots.setdefault(sid, []).append(snap)
+        return snapshots
+
+    return await asyncio.to_thread(_collect)
+
+
+async def build_action_queue_snapshot(
+    party_members: Sequence[Stats],
+    foes: Sequence[Stats],
+    extra_turns: MutableMapping[int, int],
+) -> list[ActionQueueEntry]:
+    """Capture the current visual action queue ordering."""
+
+    def _build() -> list[ActionQueueEntry]:
+        ordered = sorted(
+            list(party_members) + list(foes),
+            key=lambda combatant: getattr(combatant, "action_value", 0.0),
+        )
+        extras: list[ActionQueueEntry] = []
+        for ent in ordered:
+            turns = extra_turns.get(id(ent), 0)
+            for _ in range(turns):
+                extras.append(
+                    {
+                        "id": getattr(ent, "id", ""),
+                        "action_gauge": getattr(ent, "action_gauge", 0),
+                        "action_value": getattr(ent, "action_value", 0.0),
+                        "base_action_value": getattr(ent, "base_action_value", 0.0),
+                        "bonus": True,
+                    }
+                )
+        base_entries: list[ActionQueueEntry] = [
+            {
+                "id": getattr(combatant, "id", ""),
+                "action_gauge": getattr(combatant, "action_gauge", 0),
+                "action_value": getattr(combatant, "action_value", 0.0),
+                "base_action_value": getattr(combatant, "base_action_value", 0.0),
+            }
+            for combatant in ordered
+        ]
+        return extras + base_entries
+
+    return await asyncio.to_thread(_build)
+
+
+async def build_battle_progress_payload(
+    party_members: Sequence[Stats],
+    foes: Sequence[Stats],
+    enrage_state: SupportsEnrageSnapshot,
+    rdr: float,
+    extra_turns: MutableMapping[int, int],
+    *,
+    run_id: str | None,
+    active_id: str | None,
+    active_target_id: str | None,
+    include_summon_foes: bool = False,
+    ended: bool | None = None,
+) -> BattleProgressPayload:
+    """Assemble the payload dispatched to progress callbacks."""
+
+    party_data = await asyncio.to_thread(
+        lambda: [
+            _serialize(member)
+            for member in party_members
+            if not isinstance(member, Summon)
+        ]
+    )
+
+    def _serialize_foes() -> list[BattleEntityPayload]:
+        serialized: list[BattleEntityPayload] = []
+        for foe in foes:
+            if not include_summon_foes and isinstance(foe, Summon):
+                continue
+            serialized.append(_serialize(foe))
+        return serialized
+
+    foes_data = await asyncio.to_thread(_serialize_foes)
+    party_summons, foe_summons = await asyncio.gather(
+        collect_summon_snapshots(party_members),
+        collect_summon_snapshots(foes),
+    )
+    action_queue = await build_action_queue_snapshot(
+        party_members,
+        foes,
+        extra_turns,
+    )
+
+    payload: BattleProgressPayload = {
+        "result": "battle",
+        "party": party_data,
+        "foes": foes_data,
+        "party_summons": party_summons,
+        "foe_summons": foe_summons,
+        "enrage": enrage_state.as_payload(),
+        "rdr": rdr,
+        "action_queue": action_queue,
+        "active_id": active_id,
+        "active_target_id": active_target_id,
+    }
+
+    if run_id:
+        events = _snapshots.get_recent_events(run_id)
+        if events is not None:
+            payload["recent_events"] = events
+        status_phase = _snapshots.get_status_phase(run_id)
+        if status_phase is not None:
+            payload["status_phase"] = status_phase
+
+    if ended is not None:
+        payload["ended"] = ended
+
+    return payload

--- a/backend/tests/test_battle_progress_helpers.py
+++ b/backend/tests/test_battle_progress_helpers.py
@@ -1,0 +1,147 @@
+# ruff: noqa: E402
+
+
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from types import ModuleType
+
+writers_module = sys.modules.get("battle_logging.writers")
+if writers_module is None:
+    battle_logging_pkg = sys.modules.setdefault(
+        "battle_logging",
+        ModuleType("battle_logging"),
+    )
+    writers_module = ModuleType("battle_logging.writers")
+    setattr(battle_logging_pkg, "writers", writers_module)
+    sys.modules["battle_logging.writers"] = writers_module
+
+writers_module.end_run_logging = lambda *args, **kwargs: None  # noqa: E731
+writers_module.end_battle_logging = lambda *args, **kwargs: None  # noqa: E731
+writers_module.start_run_logging = lambda *args, **kwargs: None  # noqa: E731
+writers_module.start_battle_logging = lambda *args, **kwargs: None  # noqa: E731
+writers_module.get_current_run_logger = lambda: None  # noqa: E731
+
+tracking_module = sys.modules.setdefault("tracking", ModuleType("tracking"))
+tracking_module.log_play_session_end = lambda *args, **kwargs: None  # noqa: E731
+tracking_module.log_run_end = lambda *args, **kwargs: None  # noqa: E731
+
+
+from runs.lifecycle import battle_snapshots as run_snapshots
+
+from autofighter.rooms.battle import snapshots as battle_snapshots
+from autofighter.rooms.battle.progress import build_action_queue_snapshot
+from autofighter.rooms.battle.progress import build_battle_progress_payload
+from autofighter.rooms.battle.progress import collect_summon_snapshots
+from autofighter.rooms.battle.turns import EnrageState
+from autofighter.stats import Stats
+from autofighter.summons.manager import SummonManager
+
+
+@pytest.fixture(autouse=True)
+def cleanup_summons():
+    SummonManager.cleanup()
+    yield
+    SummonManager.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_collect_summon_snapshots_groups_by_owner():
+    summoner = Stats(hp=1_000)
+    summoner.id = "summoner"
+    summoner.ensure_permanent_summon_slots(1)
+    summon = SummonManager.create_summon(summoner, summon_type="test", source="unit_test")
+    assert summon is not None
+
+    snapshots = await collect_summon_snapshots([summoner])
+
+    assert list(snapshots.keys()) == ["summoner"]
+    [payload] = snapshots["summoner"]
+    assert payload["owner_id"] == "summoner"
+    assert payload["instance_id"] == summon.instance_id
+    assert payload["summon_type"] == "test"
+
+
+@pytest.mark.asyncio
+async def test_build_action_queue_snapshot_preserves_sorting_and_bonus_entries():
+    party_member = Stats(hp=1_000)
+    party_member.id = "party"
+    party_member.action_value = 2.0
+    party_member.action_gauge = 120
+    party_member.base_action_value = 1.8
+
+    foe = Stats(hp=1_000)
+    foe.id = "foe"
+    foe.action_value = 1.0
+    foe.action_gauge = 90
+    foe.base_action_value = 1.0
+
+    queue = await build_action_queue_snapshot(
+        [party_member],
+        [foe],
+        {id(party_member): 1},
+    )
+
+    assert queue[0]["bonus"] is True
+    assert queue[0]["id"] == "party"
+    assert [entry["id"] for entry in queue[1:]] == ["foe", "party"]
+    assert queue[1]["action_value"] <= queue[2]["action_value"]
+
+
+@pytest.mark.asyncio
+async def test_build_battle_progress_payload_includes_snapshots_and_events():
+    run_id = "progress-run"
+    party_member = Stats(hp=1_000)
+    party_member.id = "hero"
+    party_member.ensure_permanent_summon_slots(1)
+    hero_summon = SummonManager.create_summon(
+        party_member,
+        summon_type="sprite",
+        source="unit_test",
+    )
+    assert hero_summon is not None
+
+    foe = Stats(hp=900)
+    foe.id = "foe"
+    foe.ensure_permanent_summon_slots(1)
+    foe_summon = SummonManager.create_summon(
+        foe,
+        summon_type="minion",
+        source="unit_test",
+    )
+    assert foe_summon is not None
+
+    battle_snapshots.prepare_snapshot_overlay(run_id, [party_member, foe])
+    battle_snapshots.mutate_snapshot_overlay(run_id, event={"id": "evt"})
+    battle_snapshots.mutate_snapshot_overlay(run_id, status_phase={"phase": "hot"})
+
+    enrage_state = EnrageState(threshold=5)
+    enrage_state.active = True
+    enrage_state.stacks = 3
+
+    payload = await build_battle_progress_payload(
+        [party_member],
+        [foe],
+        enrage_state,
+        rdr=1.25,
+        extra_turns={},
+        run_id=run_id,
+        active_id=party_member.id,
+        active_target_id=foe.id,
+        ended=True,
+    )
+
+    assert payload["party"][0]["id"] == "hero"
+    assert payload["foes"][0]["id"] == "foe"
+    assert payload["party_summons"]["hero"][0]["instance_id"] == hero_summon.instance_id
+    assert payload["foe_summons"]["foe"][0]["instance_id"] == foe_summon.instance_id
+    assert payload["recent_events"] == [{"id": "evt"}]
+    assert payload["status_phase"] == {"phase": "hot"}
+    assert payload["enrage"]["stacks"] == 3
+    assert payload["ended"] is True
+
+    run_snapshots.pop(run_id, None)

--- a/backend/tests/test_status_phase_events.py
+++ b/backend/tests/test_status_phase_events.py
@@ -34,8 +34,8 @@ from runs.lifecycle import battle_snapshots
 from autofighter.effects import DamageOverTime
 from autofighter.effects import EffectManager
 from autofighter.effects import HealingOverTime
+from autofighter.rooms.battle.progress import build_battle_progress_payload
 from autofighter.rooms.battle.turns import EnrageState
-from autofighter.rooms.battle.turns import build_battle_progress_payload
 from autofighter.rooms.battle.turns import mutate_snapshot_overlay
 from autofighter.rooms.battle.turns import prepare_snapshot_overlay
 from autofighter.rooms.battle.turns import register_snapshot_entities


### PR DESCRIPTION
## Summary
- extract the battle progress helper functions into a dedicated `progress` module with typed payload structures
- update the turn handling and engine imports to use the new module
- add tests that cover the new helpers and adjust existing status phase tests

## Testing
- uv run pytest tests/test_battle_progress_helpers.py tests/test_status_phase_events.py

------
https://chatgpt.com/codex/tasks/task_b_68d24815a344832ca30d6e6397ebc343