### PR TITLE
[FEATURE] Refactor enrage helpers

### DIFF
--- a/backend/autofighter/rooms/battle/enrage.py
+++ b/backend/autofighter/rooms/battle/enrage.py
@@ -1,16 +1,46 @@
-"""Enrage threshold helpers for battle rooms."""
+"""Enrage helpers for battle rooms."""
 
 from __future__ import annotations
 
 import asyncio
+from dataclasses import dataclass
+import logging
 from types import ModuleType
 from typing import TYPE_CHECKING
+from typing import Any
+from typing import Callable
+from typing import MutableSequence
+from typing import Sequence
 
 ENRAGE_TURNS_NORMAL = 100
 ENRAGE_TURNS_BOSS = 500
 
+log = logging.getLogger(__name__)
+
 if TYPE_CHECKING:
+    from autofighter.effects import EffectManager
+
+    from ...stats import Stats
     from .. import Room
+
+
+@dataclass(slots=True)
+class EnrageState:
+    """Track enrage progression for a battle."""
+
+    threshold: int
+    active: bool = False
+    stacks: int = 0
+    bleed_applies: int = 0
+
+    def as_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable snapshot of the current enrage state."""
+
+        return {
+            "active": self.active,
+            "stacks": self.stacks,
+            "turns": self.stacks,
+        }
 
 
 def _resolve_overrides(
@@ -56,8 +86,125 @@ async def compute_enrage_threshold(room: Room) -> int:
     return base_boss if isinstance(room, boss_type) else base_normal
 
 
+async def update_enrage_state(
+    turn: int,
+    state: EnrageState,
+    foes: Sequence[Stats],
+    foe_effects: Sequence["EffectManager"],
+    enrage_mods: MutableSequence[Any],
+    party_members: Sequence[Stats],
+    *,
+    set_enrage_percent: Callable[[float], Any],
+    create_stat_buff: Callable[..., Any],
+    catastrophic_turn_threshold: int = 1000,
+    catastrophic_damage: int = 100,
+) -> dict[str, Any] | None:
+    """Update enrage modifiers and catastrophic damage thresholds."""
+
+    previous_active = state.active
+    previous_stacks = state.stacks
+
+    if turn > state.threshold:
+        if not state.active:
+            state.active = True
+            for foe in foes:
+                try:
+                    foe.passives.append("Enraged")
+                except Exception:
+                    pass
+            log.info("Enrage activated")
+        new_stacks = turn - state.threshold
+        await asyncio.to_thread(set_enrage_percent, 1.35 * max(new_stacks, 0))
+        mult = 1 + 2.0 * new_stacks
+        for idx, (foe_obj, mgr) in enumerate(zip(foes, foe_effects, strict=False)):
+            existing = enrage_mods[idx]
+            if existing is not None:
+                existing.remove()
+                try:
+                    mgr.mods.remove(existing)
+                    if existing.id in foe_obj.mods:
+                        foe_obj.mods.remove(existing.id)
+                except ValueError:
+                    pass
+            mod = create_stat_buff(
+                foe_obj,
+                name="enrage_atk",
+                atk_mult=mult,
+                turns=9999,
+            )
+            mgr.add_modifier(mod)
+            enrage_mods[idx] = mod
+        state.stacks = new_stacks
+        if turn > catastrophic_turn_threshold:
+            extra_damage = catastrophic_damage * max(state.stacks, 0)
+            if extra_damage > 0:
+                for member in party_members:
+                    if getattr(member, "hp", 0) > 0:
+                        await member.apply_damage(extra_damage)
+                for foe_obj in foes:
+                    if getattr(foe_obj, "hp", 0) > 0:
+                        await foe_obj.apply_damage(extra_damage)
+    else:
+        await asyncio.to_thread(set_enrage_percent, 0.0)
+
+    if state.active != previous_active or state.stacks != previous_stacks:
+        return state.as_payload()
+    return None
+
+
+async def apply_enrage_bleed(
+    state: EnrageState,
+    party_members: Sequence[Stats],
+    foes: Sequence[Stats],
+    foe_effects: Sequence["EffectManager"],
+    *,
+    damage_over_time_factory: Callable[[str, int, int, str], Any],
+    party_bleed_ratio: float = 0.5,
+    foe_bleed_ratio: float = 0.25,
+) -> None:
+    """Apply stacking bleed to both sides while enrage remains active."""
+
+    if not state.active:
+        return
+    turns_since_enrage = max(state.stacks, 0)
+    next_trigger = (state.bleed_applies + 1) * 10
+    if turns_since_enrage < next_trigger:
+        return
+    stacks_to_add = 1 + state.bleed_applies
+
+    for member in party_members:
+        mgr = member.effect_manager
+        max_hp = max(getattr(mgr.stats, "max_hp", 1), 1)
+        for _ in range(stacks_to_add):
+            dmg_per_tick = int(max_hp * party_bleed_ratio)
+            mgr.add_dot(
+                damage_over_time_factory(
+                    "Enrage Bleed",
+                    dmg_per_tick,
+                    10,
+                    "enrage_bleed",
+                )
+            )
+    for mgr, foe_obj in zip(foe_effects, foes, strict=False):
+        max_hp = max(getattr(foe_obj, "max_hp", 1), 1)
+        for _ in range(stacks_to_add):
+            dmg_per_tick = int(max_hp * foe_bleed_ratio)
+            mgr.add_dot(
+                damage_over_time_factory(
+                    "Enrage Bleed",
+                    dmg_per_tick,
+                    10,
+                    "enrage_bleed",
+                )
+            )
+    state.bleed_applies += 1
+
+
 __all__ = [
     "ENRAGE_TURNS_NORMAL",
     "ENRAGE_TURNS_BOSS",
+    "EnrageState",
+    "apply_enrage_bleed",
     "compute_enrage_threshold",
+    "update_enrage_state",
 ]

--- a/backend/tests/backend/rooms/battle/test_enrage.py
+++ b/backend/tests/backend/rooms/battle/test_enrage.py
@@ -1,0 +1,135 @@
+"""Unit tests for enrage helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from autofighter.rooms.battle.enrage import EnrageState
+from autofighter.rooms.battle.enrage import apply_enrage_bleed
+from autofighter.rooms.battle.enrage import update_enrage_state
+
+
+class DummyMod:
+    """Simple modifier stub used by tests."""
+
+    def __init__(self, atk_mult: float) -> None:
+        self.id = "enrage_atk"
+        self.atk_mult = atk_mult
+        self.removed = False
+
+    def remove(self) -> None:
+        self.removed = True
+
+
+class DummyEffectManager:
+    """Minimal effect manager stub."""
+
+    def __init__(self, stats: Any | None = None) -> None:
+        self.stats = stats or SimpleNamespace(max_hp=1)
+        self.mods: list[Any] = []
+        self.dots: list[Any] = []
+
+    def add_modifier(self, mod: Any) -> None:
+        self.mods.append(mod)
+
+    def add_dot(self, dot: Any) -> None:
+        self.dots.append(dot)
+
+
+class DummyCombatant:
+    """Stats-like object for both party members and foes."""
+
+    def __init__(self, max_hp: int = 1000) -> None:
+        self.hp = max_hp
+        self.max_hp = max_hp
+        self.passives: list[str] = []
+        self.mods: list[str] = []
+        self.effect_manager = DummyEffectManager(self)
+        self.received_damage: list[int] = []
+
+    async def apply_damage(self, amount: int) -> None:
+        self.received_damage.append(amount)
+
+
+@pytest.mark.asyncio()
+async def test_update_enrage_state_activates_and_adds_modifier() -> None:
+    """Cross-turn enrage activation should add modifiers via dependency hooks."""
+
+    state = EnrageState(threshold=5)
+    foe = DummyCombatant(max_hp=800)
+    foe_effect = DummyEffectManager()
+    enrage_mods: list[Any | None] = [None]
+    party_members = [DummyCombatant(max_hp=900)]
+
+    set_calls: list[float] = []
+
+    def fake_set_enrage(value: float) -> None:
+        set_calls.append(value)
+
+    created_mods: list[DummyMod] = []
+
+    def fake_create_stat_buff(*_args: Any, atk_mult: float, **_kwargs: Any) -> DummyMod:
+        mod = DummyMod(atk_mult=atk_mult)
+        created_mods.append(mod)
+        return mod
+
+    payload = await update_enrage_state(
+        turn=8,
+        state=state,
+        foes=[foe],
+        foe_effects=[foe_effect],
+        enrage_mods=enrage_mods,
+        party_members=party_members,
+        set_enrage_percent=fake_set_enrage,
+        create_stat_buff=fake_create_stat_buff,
+    )
+
+    assert payload == {"active": True, "stacks": 3, "turns": 3}
+    assert state.active is True
+    assert state.stacks == 3
+    assert set_calls and set_calls[0] == pytest.approx(4.05)
+    assert enrage_mods[0] is created_mods[0]
+    assert created_mods[0].atk_mult == pytest.approx(7.0)
+    assert foe_effect.mods == created_mods
+    assert "Enraged" in foe.passives
+
+
+@pytest.mark.asyncio()
+async def test_apply_enrage_bleed_stacks_for_both_sides() -> None:
+    """Bleed application should respect provided DoT factory and ratios."""
+
+    state = EnrageState(threshold=0, active=True, stacks=10)
+    party_member = DummyCombatant(max_hp=1200)
+    foe = DummyCombatant(max_hp=600)
+    foe_effect = DummyEffectManager(SimpleNamespace(max_hp=foe.max_hp))
+
+    created_effects: list[tuple[str, int, int, str]] = []
+
+    def fake_damage_over_time(name: str, dmg: int, turns: int, key: str) -> dict[str, Any]:
+        created_effects.append((name, dmg, turns, key))
+        return {"name": name, "damage": dmg, "turns": turns, "key": key}
+
+    await apply_enrage_bleed(
+        state,
+        party_members=[party_member],
+        foes=[foe],
+        foe_effects=[foe_effect],
+        damage_over_time_factory=fake_damage_over_time,
+        party_bleed_ratio=0.5,
+        foe_bleed_ratio=0.25,
+    )
+
+    assert state.bleed_applies == 1
+    assert party_member.effect_manager.dots == [
+        {"name": "Enrage Bleed", "damage": 600, "turns": 10, "key": "enrage_bleed"}
+    ]
+    assert foe_effect.dots == [
+        {"name": "Enrage Bleed", "damage": 150, "turns": 10, "key": "enrage_bleed"}
+    ]
+    assert created_effects == [
+        ("Enrage Bleed", 600, 10, "enrage_bleed"),
+        ("Enrage Bleed", 150, 10, "enrage_bleed"),
+    ]


### PR DESCRIPTION
## Summary
- extract the enrage state container and helper routines into `autofighter.rooms.battle.enrage`
- adjust the turn orchestration module to delegate enrage updates and bleed application to the new helpers
- add unit coverage for enrage activation and bleed stacking behaviour

## Testing
- [x] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68d24c030da8832c820da2b283387837