### PR TITLE
Update progress stubs to accept turn argument

### DIFF
--- a/backend/tests/test_enrage_progress_updates.py
+++ b/backend/tests/test_enrage_progress_updates.py
@@ -153,6 +153,7 @@ async def test_player_phase_emits_snapshot_on_enrage(monkeypatch: pytest.MonkeyP
         enrage_state,
         rdr,
         extra_turns,
+        turn,
         *,
         run_id,
         active_id,
@@ -169,6 +170,7 @@ async def test_player_phase_emits_snapshot_on_enrage(monkeypatch: pytest.MonkeyP
                 "active_target_id": active_target_id,
                 "include_summon_foes": include_summon_foes,
                 "ended": ended,
+                "turn": turn,
             }
         )
 

--- a/backend/tests/test_turn_loop_summon_updates.py
+++ b/backend/tests/test_turn_loop_summon_updates.py
@@ -104,6 +104,7 @@ def _setup_common_player_patches(monkeypatch: pytest.MonkeyPatch, module) -> lis
         enrage_state,
         rdr,
         extra_turns,
+        turn,
         *,
         run_id,
         active_id,
@@ -118,6 +119,7 @@ def _setup_common_player_patches(monkeypatch: pytest.MonkeyPatch, module) -> lis
                 "include_summon_foes": include_summon_foes,
                 "active_id": active_id,
                 "active_target_id": active_target_id,
+                "turn": turn,
             }
         )
         if progress_cb is not None:


### PR DESCRIPTION
## Summary
- include a `turn` field in the battle progress payload and require callers to supply it when building updates
- propagate the active turn counter through the progress update helpers and turn loop so every emission carries the battle turn value
- seed newly created battle and boss snapshots with a default turn of 0 and adjust related backend tests to expect the updated shape
- update the battle progress test stubs to accept the new `turn` positional argument

## Testing
- `ruff check backend/autofighter/rooms/battle/engine.py backend/autofighter/rooms/battle/progress.py backend/autofighter/rooms/battle/turn_loop/foe_turn.py backend/autofighter/rooms/battle/turn_loop/initialization.py backend/autofighter/rooms/battle/turn_loop/player_turn.py backend/autofighter/rooms/battle/turn_loop/turn_end.py backend/autofighter/rooms/battle/turns.py backend/services/room_service.py backend/tests/test_battle_progress_helpers.py backend/tests/test_battle_room_awaiting_next.py backend/tests/test_recent_foe_cooldown.py backend/tests/test_status_phase_events.py --fix`
- `uv run pytest` *(fails: repository tests rely on optional packages and modules that are not available in this environment, raising multiple import errors during collection)*
- `uv run pytest backend/tests/test_enrage_progress_updates.py backend/tests/test_turn_loop_summon_updates.py` *(fails: ModuleNotFoundError: No module named 'rich' when importing optional plugins)*

------
https://chatgpt.com/codex/tasks/task_b_68d2a141af54832c92e76b4281a72726