### PR TITLE
fix: track action turns separately

### DIFF
--- a/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
@@ -106,6 +106,9 @@ async def _run_foe_turn_iteration(
         await pace_sleep(YIELD_MULTIPLIER)
         return FoeTurnIterationResult(repeat=False, battle_over=False)
 
+    context.action_turn += 1
+    actor_turn_index = context.action_turn
+
     alive_targets = [
         (index, target)
         for index, target in enumerate(context.combat_party.members)
@@ -134,7 +137,7 @@ async def _run_foe_turn_iteration(
         getattr(acting_foe, "id", acting_foe),
         getattr(target, "id", target),
     )
-    await acting_foe.maybe_regain(context.turn)
+    await acting_foe.maybe_regain(actor_turn_index)
 
     damage_type = getattr(acting_foe, "damage_type", None)
     await foe_manager.tick(target_effect)

--- a/backend/autofighter/rooms/battle/turn_loop/initialization.py
+++ b/backend/autofighter/rooms/battle/turn_loop/initialization.py
@@ -45,7 +45,8 @@ class TurnLoopContext:
     battle_tasks: dict[str, Task[Any]]
     abort: Callable[[str], None]
     credited_foe_ids: set[str]
-    turn: int
+    turn: int = 0
+    action_turn: int = 0
 
     @property
     def credit_kwargs(self) -> dict[str, Any]:
@@ -95,6 +96,7 @@ async def initialize_turn_loop(
         abort=abort,
         credited_foe_ids=set(),
         turn=0,
+        action_turn=0,
     )
 
     prepare_snapshot_overlay(

--- a/backend/autofighter/rooms/battle/turn_loop/player_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/player_turn.py
@@ -106,6 +106,9 @@ async def _run_player_turn_iteration(
         await pace_sleep(YIELD_MULTIPLIER)
         return PlayerTurnIterationResult(repeat=False, battle_over=False)
 
+    context.action_turn += 1
+    actor_turn_index = context.action_turn
+
     enrage_update = await update_enrage_state(
         context.turn,
         context.enrage_state,
@@ -141,7 +144,7 @@ async def _run_player_turn_iteration(
     )
     await BUS.emit_async("turn_start", member)
     log.debug("%s turn start", getattr(member, "id", member))
-    await member.maybe_regain(context.turn)
+    await member.maybe_regain(actor_turn_index)
 
     if not _any_foes_alive(context.foes):
         await finish_turn(


### PR DESCRIPTION
## Summary
* add a dedicated turn counter entry to the action queue and expose the most recent cycle count so 10 000-point loops can be detected without manual counters
* propagate the visual queue through progress updates so the turn counter snapshot reaches the frontend and the backend only increments the shared turn value when a full gauge cycle elapses
* ensure battle setup contributes the new counter entry, keeps the stubbed battle logger optional, and include the visual queue in the final end-of-battle progress update
* track a separate action-turn counter so regeneration-style mechanics keep their cadence while the shared turn value continues to follow action-gauge cycles

## Testing
* `uv run pytest tests/test_action_queue.py -q`
* `uv run pytest tests/test_battle_setup.py -q`
* `./run-tests.sh` *(fails: missing accelerate/_IMPORT_ERROR and llms.torch_checker modules in test environment)*
* `uv run pytest backend/tests/test_turn_loop_finish_turn_branches.py -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_b_68d2d440ce58832caf3011d5c596c580