### PR TITLE
Fix action queue initialization tie breaking

### DIFF
--- a/backend/autofighter/action_queue.py
+++ b/backend/autofighter/action_queue.py
@@ -185,6 +185,7 @@ class ActionQueue:
                     combatant
                     for combatant in self.combatants
                     if combatant is not self.turn_counter
+                    and getattr(combatant, "id", None) != TURN_COUNTER_ID
                 ),
                 key=lambda combatant: (
                     float(getattr(combatant, "action_value", 0.0)),


### PR DESCRIPTION
## Summary
- ensure the action queue tie-break helper skips the turn counter when deduplicating gauges during initialization
- relax action queue math assertions to allow tie-broken values and add a regression test that the initial snapshot order is strictly increasing

## Testing
- [x] Backend tests
- [ ] Frontend tests
- [x] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

------
https://chatgpt.com/codex/tasks/task_b_68d2f577b9c8832c828931b2630d7bb6