### PR TITLE
fix: dedupe relic cleanup subscriptions

### DIFF
--- a/backend/plugins/relics/_base.py
+++ b/backend/plugins/relics/_base.py
@@ -84,6 +84,12 @@ class RelicBase:
 
         store = self._ensure_subscription_store(party)
         entries = store.setdefault(self.id, [])
+        for existing_event, existing_callback, is_cleanup in entries:
+            if is_cleanup:
+                continue
+            if existing_event == event and existing_callback is callback:
+                self._ensure_cleanup_subscription(party, entries, BUS)
+                return callback
         entries.append((event, callback, False))
         BUS.subscribe(event, callback)
         self._ensure_cleanup_subscription(party, entries, BUS)


### PR DESCRIPTION
## Summary
- ensure relic event subscriptions register a single battle_end cleanup hook per party
- track relic subscription metadata so cleanup callbacks are removed along with other listeners
- guard relic subscriptions against duplicate handler registration and verify cleanup across repeated battles

## Testing
- uv run ruff check backend/plugins/relics/_base.py backend/tests/test_relic_subscription_cleanup.py
- uv run pytest tests/test_relic_subscription_cleanup.py

------
https://chatgpt.com/codex/tasks/task_b_68d39c4e5d20832cae54a4ae1040cc91