### PR TITLE
fix: remove redundant battleActive reactive update

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -119,7 +119,6 @@
     }
   }
 
-  $: setBattleActive($runState.battleActive);
   $: setManualSyncHalt(haltSync);
 
   // Convert backend-provided party lists into a flat array of player IDs.


### PR DESCRIPTION
## Summary
- remove the reactive setBattleActive call that re-wrote the existing value and caused an update loop

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d5e7b3e944832cb711e6e59fea8e7d