### PR TITLE
Fix themed adjective scaling import order

### DIFF
--- a/backend/plugins/themedadj/__init__.py
+++ b/backend/plugins/themedadj/__init__.py
@@ -1,9 +1,17 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from autofighter.rooms.foes.scaling import apply_permanent_scaling
 from plugins import PluginLoader
+
+if TYPE_CHECKING:
+    from autofighter.rooms.foes.scaling import (
+        apply_permanent_scaling as ApplyPermanentScaling,
+    )
+
+
+_apply_permanent_scaling: "ApplyPermanentScaling | None" = None
 
 
 def stat_buff(cls):
@@ -41,7 +49,16 @@ def stat_buff(cls):
             target.max_hp = base_hp
 
         if mults or additive:
-            apply_permanent_scaling(
+            global _apply_permanent_scaling
+
+            if _apply_permanent_scaling is None:
+                from autofighter.rooms.foes.scaling import (
+                    apply_permanent_scaling as _imported_apply_permanent_scaling,
+                )
+
+                _apply_permanent_scaling = _imported_apply_permanent_scaling
+
+            _apply_permanent_scaling(
                 target,
                 multipliers=mults or None,
                 deltas=additive or None,

--- a/backend/tests/test_themedadj_plugins.py
+++ b/backend/tests/test_themedadj_plugins.py
@@ -1,19 +1,21 @@
+import importlib
 from pathlib import Path
 import sys
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from autofighter.stats import Stats
-from plugins.themedadj import Atrocious
-from plugins.themedadj import loader
 
 
 def test_themed_adjectives_import_and_decorate() -> None:
-    plugins = loader.get_plugins("themedadj")
+    import autofighter.party  # noqa: F401  # Ensure party initializes first
+
+    themedadj = importlib.import_module("plugins.themedadj")
+    plugins = themedadj.loader.get_plugins("themedadj")
     assert "atrocious" in plugins
 
     target = Stats()
-    Atrocious().apply(target)
+    getattr(themedadj, "Atrocious")().apply(target)
 
     assert target.atk == 220
     assert target.max_hp == 1900


### PR DESCRIPTION
## Summary
- lazily import themed adjective scaling helper to avoid circular initialization
- update themed adjective smoke test to import the plugin after the party module

## Testing
- `ruff check backend/plugins/themedadj/__init__.py backend/tests/test_themedadj_plugins.py --fix`
- `pytest backend/tests/test_themedadj_plugins.py`
- `uv run app.py`

------
https://chatgpt.com/codex/tasks/task_b_68d6bd9d2bf4832ca1184f55a653d3ac