### PR TITLE
fix: hoist event amount constant in events drawer

### DIFF
--- a/frontend/src/lib/components/battle-review/EventsDrawer.svelte
+++ b/frontend/src/lib/components/battle-review/EventsDrawer.svelte
@@ -69,6 +69,7 @@
       {:else}
         <ul class="events-list">
           {#each filteredEvents as event (event.id)}
+            {@const amount = eventAmount(event)}
             <li>
               <button
                 type="button"
@@ -77,7 +78,6 @@
               >
                 <span class="event-time">T+{formatSeconds(event.time)}</span>
                 <span class="event-text">{formatEventLabel(event)}</span>
-                {@const amount = eventAmount(event)}
                 {#if amount}
                   <span class="event-amount">{amount}</span>
                 {/if}


### PR DESCRIPTION
## Summary
- hoist the event amount computation to the top of each events list iteration to satisfy Svelte compilation rules

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68d6c16c7748832cbeb817e2428375bc