### PR TITLE
Add double-click buy gesture to shop menu

### DIFF
--- a/frontend/src/lib/components/ShopMenu.svelte
+++ b/frontend/src/lib/components/ShopMenu.svelte
@@ -183,6 +183,11 @@
     if (!entry || isEntrySold(entry) || isEntryDisabled(entry)) {
       return;
     }
+    const ident = entry.ident || identOf(entry);
+    if (ident && selectedIds.has(ident)) {
+      selectedIds.delete(ident);
+      selectedIds = new Set(selectedIds);
+    }
     buy(entry);
   }
 


### PR DESCRIPTION
## Summary
- add a double-click handler to ShopMenu slots that triggers `buy` only when the entry is available and not already processing
- factor sold/disabled checks so quick buys respect existing processing and sold state
- document the new quick-buy gesture in the Shop Menu implementation notes
- clear double-clicked entries from the manual selection list to prevent duplicate purchases when buying in bulk

## Testing
- [ ] Backend tests
- [ ] Frontend tests (bun test tests/start-run-damage-type.test.js fails: expected "Fire" but received "Light")
- [x] Linting
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68da8b2adbd0832c8cd8e402e69b1080