### PR TITLE
Update LadyOfFire to five-star gacha rarity

### DIFF
--- a/backend/plugins/characters/lady_of_fire.py
+++ b/backend/plugins/characters/lady_of_fire.py
@@ -12,6 +12,7 @@ class LadyOfFire(PlayerBase):
     id = "lady_of_fire"
     name = "LadyOfFire"
     about = "A fierce pyromancer appearing to be 18-20 years old, whose dark red hair flows like liquid flame and whose very presence exudes overwhelming warmth. Living with Dissociative Schizophrenia, she channels her condition into her fire magic, allowing different aspects of her psyche to fuel increasingly intense infernal momentum. Each enemy defeated feeds her inner flame, building heat waves that grow stronger with every victory. Her red eyes burn with hot intensity, and her fire magic seems to pulse with the rhythm of her fractured consciousness, creating unpredictable but devastatingly effective pyroclastic attacks."
+    gacha_rarity = 5
     char_type: CharacterType = CharacterType.B
     damage_type: DamageTypeBase = field(default_factory=Fire)
     passives: list[str] = field(default_factory=lambda: ["lady_of_fire_infernal_momentum"])


### PR DESCRIPTION
## Summary
- set the LadyOfFire character's gacha rarity to 5 so she is included with the rest of the five-star roster

## Testing
- `ruff check . --fix`
- `ruff check plugins/characters/lady_of_fire.py --fix`
- `uv run hypercorn app:app --bind 0.0.0.0:59002` (manual verification via `curl /gacha`)


------
https://chatgpt.com/codex/tasks/task_b_68daea6aaef4832c87f5d7209a56de27