### PR TITLE
Fix Radiant Aegis shield handling

### DIFF
--- a/backend/plugins/passives/normal/lady_light_radiant_aegis.py
+++ b/backend/plugins/passives/normal/lady_light_radiant_aegis.py
@@ -44,13 +44,10 @@ class LadyLightRadiantAegis:
         # Grant one-turn shield to the healed ally
         shield_amount = int(hot_amount * 0.5)  # Shield equal to 50% of HoT amount
 
-        shield_effect = StatEffect(
-            name=f"{self.id}_hot_shield",
-            stat_modifiers={"hp": shield_amount},  # Temporary HP boost
-            duration=1,  # One turn shield
-            source=self.id,
-        )
-        healed_ally.add_effect(shield_effect)
+        if shield_amount > 0:
+            if not healed_ally.overheal_enabled:
+                healed_ally.enable_overheal()
+            healed_ally.shields += shield_amount
 
         # Grant +5% effect resistance for one turn
         resistance_effect = StatEffect(
@@ -67,7 +64,13 @@ class LadyLightRadiantAegis:
 
         # Heal ally for additional 5% of their max HP
         additional_healing = int(cleansed_ally.max_hp * 0.05)
-        cleansed_ally.hp = min(cleansed_ally.max_hp, cleansed_ally.hp + additional_healing)
+        if additional_healing > 0:
+            await cleansed_ally.apply_healing(
+                additional_healing,
+                healer=target,
+                source_type="cleanse",
+                source_name=self.id,
+            )
 
         # Grant Lady Light +2% attack (stacking with no cap)
         attack_increase = int(target.atk * 0.02)

--- a/backend/tests/test_lady_light_radiant_aegis.py
+++ b/backend/tests/test_lady_light_radiant_aegis.py
@@ -1,0 +1,66 @@
+import asyncio
+
+import pytest
+
+from autofighter.stats import BUS
+from autofighter.stats import Stats
+from plugins.passives.normal.lady_light_radiant_aegis import LadyLightRadiantAegis
+
+
+@pytest.mark.asyncio
+async def test_radiant_aegis_shields_persist_after_tick():
+    passive = LadyLightRadiantAegis()
+    healer = Stats()
+    ally = Stats()
+
+    ally.shields = 0
+    ally.overheal_enabled = False
+
+    await passive.apply(healer)
+    await passive.on_hot_applied(healer, ally, hot_amount=200)
+
+    assert ally.overheal_enabled is True
+    assert ally.shields == 100
+
+    hot_res_effect = f"{passive.id}_hot_resistance"
+    assert any(effect.name == hot_res_effect for effect in ally.get_active_effects())
+
+    ally.tick_effects()
+
+    assert not any(effect.name == hot_res_effect for effect in ally.get_active_effects())
+    assert ally.shields == 100
+
+
+@pytest.mark.asyncio
+async def test_radiant_aegis_cleanse_heal_emits_event():
+    passive = LadyLightRadiantAegis()
+    target = Stats()
+    ally = Stats()
+
+    await passive.apply(target)
+    expected_heal = int(ally.max_hp * 0.05)
+    ally.hp = ally.max_hp - 200
+
+    events: list[tuple[Stats, Stats, int, str, str]] = []
+
+    def _on_heal_received(tgt, healer, amount, source_type, source_name):
+        events.append((tgt, healer, amount, source_type, source_name))
+
+    BUS.subscribe("heal_received", _on_heal_received)
+
+    try:
+        await passive.on_dot_cleanse(target, ally)
+        await asyncio.sleep(0.05)
+    finally:
+        BUS.unsubscribe("heal_received", _on_heal_received)
+
+    assert ally.hp == ally.max_hp - 200 + expected_heal
+
+    assert any(
+        event[0] is ally
+        and event[1] is target
+        and event[2] == expected_heal
+        and event[3] == "cleanse"
+        and event[4] == passive.id
+        for event in events
+    )


### PR DESCRIPTION
## Summary
- update Lady Light's Radiant Aegis passive to grant shields via the overheal system and route cleanse healing through apply_healing
- add regression tests for shield persistence and cleanse healing event emission

## Testing
- uv run pytest tests/test_lady_light_radiant_aegis.py

------
https://chatgpt.com/codex/tasks/task_b_68db0086be8c832c9ca0851d23294ee1