### PR TITLE
feat: add UI end run action via shared shutdown helper

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -32,6 +32,7 @@ def _ensure_battle_logging_stub() -> None:
 
     writers.BattleLogger = BattleLogger  # type: ignore[attr-defined]
     writers.start_battle_logging = lambda *args, **kwargs: BattleLogger()  # noqa: E731
+    writers.start_run_logging = lambda *args, **kwargs: None  # noqa: E731
     writers.get_current_run_logger = lambda: BattleLogger()  # noqa: E731
     sys.modules["battle_logging.writers"] = writers
     setattr(battle_logging, "writers", writers)
@@ -42,13 +43,21 @@ def _ensure_user_level_stub() -> None:
         return
 
     services_pkg = sys.modules.get("services")
+    services_path = str(Path(__file__).resolve().parents[1] / "services")
+
     if services_pkg is None:
         services_pkg = types.ModuleType("services")
+        services_pkg.__path__ = [services_path]  # type: ignore[attr-defined]
         sys.modules["services"] = services_pkg
+    else:
+        existing = getattr(services_pkg, "__path__", [])
+        if not existing:
+            services_pkg.__path__ = [services_path]  # type: ignore[attr-defined]
 
     user_level = types.ModuleType("services.user_level_service")
     user_level.gain_user_exp = lambda *args, **kwargs: None  # noqa: E731
     user_level.get_user_level = lambda *args, **kwargs: 1  # noqa: E731
+    user_level.get_user_state = lambda *args, **kwargs: {"level": 1, "exp": 0}  # noqa: E731
     sys.modules["services.user_level_service"] = user_level
     setattr(services_pkg, "user_level_service", user_level)
 
@@ -58,13 +67,52 @@ def _ensure_tracking_stub() -> None:
         return
 
     tracking = types.ModuleType("tracking")
-    tracking.log_battle_summary = lambda *args, **kwargs: None  # noqa: E731
-    tracking.log_game_action = lambda *args, **kwargs: None  # noqa: E731
-    tracking.log_play_session_end = lambda *args, **kwargs: None  # noqa: E731
-    tracking.log_run_end = lambda *args, **kwargs: None  # noqa: E731
-    tracking.log_menu_action = lambda *args, **kwargs: None  # noqa: E731
-    tracking.log_overlay_action = lambda *args, **kwargs: None  # noqa: E731
+
+    async def _async_noop(*_args, **_kwargs):  # noqa: ANN001, D401
+        return None
+
+    tracking.log_battle_summary = _async_noop
+    tracking.log_card_acquisition = _async_noop
+    tracking.log_deck_change = _async_noop
+    tracking.log_game_action = _async_noop
+    tracking.log_character_pull = _async_noop
+    tracking.log_event_choice = _async_noop
+    tracking.log_login_event = _async_noop
+    tracking.log_shop_transaction = _async_noop
+    tracking.log_play_session_end = _async_noop
+    tracking.log_play_session_start = _async_noop
+    tracking.log_run_end = _async_noop
+    tracking.log_run_start = _async_noop
+    tracking.log_menu_action = _async_noop
+    tracking.log_overlay_action = _async_noop
+    tracking.log_settings_change = _async_noop
+    tracking.log_relic_acquisition = _async_noop
     sys.modules["tracking"] = tracking
+
+    class _TrackingConnection:
+        def __enter__(self):  # noqa: D401
+            return self
+
+        def __exit__(self, exc_type, exc, tb):  # noqa: D401, ANN001
+            return False
+
+        def execute(self, *_args, **_kwargs):  # noqa: ANN002, D401
+            class _Cursor:
+                description: list[tuple[str, ...]] = []
+
+                def fetchall(self):  # noqa: D401
+                    return []
+
+                def fetchone(self):  # noqa: D401
+                    return (0,)
+
+            return _Cursor()
+
+    class _TrackingManager:
+        def connection(self):  # noqa: D401
+            return _TrackingConnection()
+
+    tracking.get_tracking_manager = lambda: _TrackingManager()  # noqa: E731
 
 
 def _ensure_options_stub() -> None:
@@ -79,8 +127,12 @@ def _ensure_options_stub() -> None:
     def get_option(*_args, default=None, **_kwargs):  # noqa: ANN001, D401 - simple stub
         return default
 
+    def set_option(*_args, **_kwargs):  # noqa: ANN001, D401 - simple stub
+        return None
+
     options.OptionKey = OptionKey  # type: ignore[attr-defined]
     options.get_option = get_option  # type: ignore[attr-defined]
+    options.set_option = set_option  # type: ignore[attr-defined]
     sys.modules["options"] = options
 
 

--- a/backend/tests/test_ui_end_run.py
+++ b/backend/tests/test_ui_end_run.py
@@ -1,0 +1,59 @@
+import pytest  # noqa: F401
+from runs.lifecycle import battle_snapshots
+import sqlcipher3
+from test_app import app_with_db as _app_with_db  # noqa: F401
+
+app_with_db = _app_with_db
+
+
+@pytest.mark.asyncio
+async def test_ui_end_run_defaults_to_active_run(app_with_db):
+    app, db_path = app_with_db
+    client = app.test_client()
+
+    start_resp = await client.post("/run/start", json={"party": ["player"]})
+    start_data = await start_resp.get_json()
+    run_id = start_data["run_id"]
+
+    battle_snapshots[run_id] = {"dummy": True}
+
+    resp = await client.post("/ui/action", json={"action": "end_run"})
+    assert resp.status_code == 200
+    data = await resp.get_json()
+    assert data == {"message": "Run ended successfully"}
+
+    conn = sqlcipher3.connect(db_path)
+    try:
+        conn.execute("PRAGMA key = 'testkey'")
+        cur = conn.execute("SELECT 1 FROM runs WHERE id = ?", (run_id,))
+        assert cur.fetchone() is None
+    finally:
+        conn.close()
+
+    assert run_id not in battle_snapshots
+
+
+@pytest.mark.asyncio
+async def test_ui_end_run_missing_run_returns_404(app_with_db):
+    app, _ = app_with_db
+    client = app.test_client()
+
+    resp = await client.post(
+        "/ui/action",
+        json={"action": "end_run", "params": {"run_id": "does-not-exist"}},
+    )
+    assert resp.status_code == 404
+    data = await resp.get_json()
+    assert data == {"error": "Run not found"}
+
+
+@pytest.mark.asyncio
+async def test_ui_end_run_without_active_run_returns_400(app_with_db):
+    app, _ = app_with_db
+    client = app.test_client()
+
+    resp = await client.post("/ui/action", json={"action": "end_run"})
+    assert resp.status_code == 400
+    data = await resp.get_json()
+    assert data["error"] == "No active run"
+    assert data["status"] == "error"


### PR DESCRIPTION
## Summary
- add a shared `shutdown_run` helper in `run_service` and reuse it from the REST endpoint
- expose the `end_run` UI action so the frontend can terminate a run with the same cleanup as the API
- expand backend test stubs and add a UI action test suite covering successful and error flows

## Testing
- `uv run pytest backend/tests/test_ui_end_run.py`
- `ruff check backend/tests/conftest.py backend/routes/ui.py backend/services/run_service.py`


------
https://chatgpt.com/codex/tasks/task_b_68db6f505b60832c8007f0a87962fd6b