### PR TITLE
Address feedback: prevent idle battle snapshot churn

### DIFF
--- a/frontend/src/lib/components/GameViewport.svelte
+++ b/frontend/src/lib/components/GameViewport.svelte
@@ -188,14 +188,18 @@
     const nextParty = Array.isArray(roomData?.party) ? roomData.party : [];
     const nextFoes = Array.isArray(roomData?.foes) ? roomData.foes : [];
 
-    const shouldRefreshSnapshot = !battleActive || battleId !== lastBattleId;
-    if (shouldRefreshSnapshot) {
+    const currentRosterKey = buildRosterKey(battlePartySnapshot, battleFoeSnapshot);
+    const nextRosterKey = buildRosterKey(nextParty, nextFoes);
+    const shouldRefreshBattleId = battleId !== lastBattleId;
+    const shouldRefreshIdleRoster = !battleActive && nextRosterKey !== currentRosterKey;
+
+    if (shouldRefreshBattleId || shouldRefreshIdleRoster) {
       battlePartySnapshot = cloneRosterEntities(nextParty);
       battleFoeSnapshot = cloneRosterEntities(nextFoes);
       lastBattleId = battleId;
     }
 
-    const rosterKey = buildRosterKey(battlePartySnapshot, battleFoeSnapshot);
+    const rosterKey = shouldRefreshBattleId || shouldRefreshIdleRoster ? nextRosterKey : currentRosterKey;
     const key = `${battleId}|${rosterKey}`;
     if (key !== lastMusicKey) {
       lastMusicKey = key;


### PR DESCRIPTION
## Summary
- avoid refreshing battle party/foe snapshots while idle unless the roster actually changes
- reuse the existing roster key when no refresh occurs to keep music identity stable without extra cloning

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68db7222e0a0832c87e21558653eb9e5