### PR TITLE
feat: use MenuPanel for battle review menu overlay

### DIFF
--- a/frontend/src/lib/components/battle-review/BattleReviewMenu.svelte
+++ b/frontend/src/lib/components/battle-review/BattleReviewMenu.svelte
@@ -256,7 +256,7 @@
 </MenuPanel>
 
 <style>
-  .battle-review-menu {
+  :global(.battle-review-menu) {
     gap: 1rem;
     color: #fff;
   }


### PR DESCRIPTION
## Summary
- wrap the battle review menu markup in the shared MenuPanel component for consistent glass styling and scroll behavior
- trim redundant container flex properties now provided by MenuPanel while keeping existing spacing and colors

## Testing
- bun test frontend/tests/battle-review-menu-overlay.test.js
- bun run lint


------
https://chatgpt.com/codex/tasks/task_b_68dcc1e38d34832c983819e091af921b