### PR TITLE
fix: prefer latest effect instance for keen goggles

### DIFF
--- a/backend/plugins/cards/keen_goggles.py
+++ b/backend/plugins/cards/keen_goggles.py
@@ -39,7 +39,7 @@ class KeenGoggles(CardBase):
             else:
                 pool = manager.mods
 
-            effect = next((eff for eff in pool if getattr(eff, "id", None) == effect_id), None)
+            effect = next((eff for eff in reversed(pool) if getattr(eff, "id", None) == effect_id), None)
             if effect is None:
                 return
 


### PR DESCRIPTION
## Summary
- select the most recently applied effect instance when identifying debuff sources for Keen Goggles stacks

## Testing
- uv run ruff check backend/plugins/cards/keen_goggles.py

------
https://chatgpt.com/codex/tasks/task_b_68dda955eed8832ca7c5167f29be2e94