### PR TITLE
Fix relic effect event metadata

### DIFF
--- a/backend/plugins/effects/aftertaste.py
+++ b/backend/plugins/effects/aftertaste.py
@@ -94,7 +94,7 @@ class Aftertaste:
             await BUS.emit_async(
                 "relic_effect",
                 "aftertaste",
-                attacker,
+                target,
                 "aftertaste",
                 amount,
                 {
@@ -108,6 +108,7 @@ class Aftertaste:
                     ),
                     "actual_damage": amount,
                 },
+                attacker,
             )
 
             dmg = await target.apply_damage(amount, temp_attacker, action_name="Aftertaste")

--- a/backend/tests/test_card_relic_snapshot_events.py
+++ b/backend/tests/test_card_relic_snapshot_events.py
@@ -144,6 +144,9 @@ async def test_card_and_relic_events_record_snapshot_metadata(monkeypatch):
 
     assert calls == [expected_multiplier, expected_multiplier]
 
+    attacker = Stats()
+    attacker.id = "attacker"
+
     await BUS.emit_async(
         "relic_effect",
         "aftertaste",
@@ -156,6 +159,7 @@ async def test_card_and_relic_events_record_snapshot_metadata(monkeypatch):
             "base_damage": 18,
             "actual_damage": 21,
         },
+        attacker,
     )
 
     events = list(battle_snapshots[run_id].get("recent_events", []))
@@ -163,9 +167,13 @@ async def test_card_and_relic_events_record_snapshot_metadata(monkeypatch):
     aftertaste_event = events[-1]
     assert aftertaste_event["type"] == "relic_effect"
     assert aftertaste_event["amount"] == 21
+    assert aftertaste_event["source_id"] == attacker.id
     assert aftertaste_event["target_id"] == member.id
     aftertaste_metadata = aftertaste_event.get("metadata", {})
     assert aftertaste_metadata["relic_id"] == "aftertaste"
     assert aftertaste_metadata["effect"] == "aftertaste"
     assert aftertaste_metadata["details"]["effect_label"] == "aftertaste"
     assert aftertaste_metadata["details"]["effect_type"] == "aftertaste"
+
+    assert battle_snapshots[run_id]["active_id"] == attacker.id
+    assert battle_snapshots[run_id]["active_target_id"] == member.id

--- a/backend/tests/test_event_bus_performance.py
+++ b/backend/tests/test_event_bus_performance.py
@@ -125,7 +125,7 @@ class TestEventBusPerformance:
                 await BUS.emit_async(
                     "relic_effect",
                     "aftertaste",
-                    attacker,
+                    target,
                     "aftertaste",
                     25,
                     {
@@ -135,6 +135,7 @@ class TestEventBusPerformance:
                         "random_damage_type": "Fire",
                         "actual_damage": 25,
                     },
+                    attacker,
                 )
 
                 # Then emits damage_dealt when damage is applied

--- a/backend/tests/test_relic_effects_advanced.py
+++ b/backend/tests/test_relic_effects_advanced.py
@@ -115,10 +115,16 @@ async def test_killer_instinct_grants_extra_turn():
 
     speed_events: list[tuple[int, dict[str, object]]] = []
 
-    def _capture_relic_effect(relic_id, *_args):
+    def _capture_relic_effect(
+        relic_id,
+        recipient,
+        event_name,
+        value,
+        payload,
+        *_extra,
+    ):
         if relic_id != "killer_instinct":
             return
-        _, event_name, value, payload = _args
         if event_name == "kill_speed_boost":
             speed_events.append((value, payload))
 


### PR DESCRIPTION
## Summary
- ensure the Aftertaste relic emits the damage recipient as the relic_effect target and includes the attacker separately
- propagate the optional attacker through the relic_effect event handler so recent event payloads capture both source_id and target_id
- update snapshot and performance tests to assert the new metadata and to use the revised event signature

## Testing
- uv run pytest tests/test_card_relic_snapshot_events.py
- uv run pytest *(fails: missing battle_logging/tracking modules and pre-existing SyntaxError in several tests)*

------
https://chatgpt.com/codex/tasks/task_b_68dee65b6b60832c9e28e125a8f335ce