### PR TITLE
[TASK] Add backend run pruning startup task

### DIFF
--- a/.codex/tasks/56d43991-run-startup-pruning.task
+++ b/.codex/tasks/56d43991-run-startup-pruning.task
@@ -1,0 +1,28 @@
+# Task: Backend run pruning on startup
+
+## Summary
+Implement automatic cleanup of stale runs when the backend boots so the UI always presents a fresh start instead of resurfacing outdated sessions. This addresses Goal `33e45df1-run-start-flow` step 1.
+
+## Context
+- `/ui` helpers call `get_default_active_run()` which currently just returns the first stored run without checking age, so previous runs persist after a restart.【F:backend/routes/ui.py†L45-L71】
+- The `runs` table retains party/map payloads across restarts because nothing clears them during app startup.【F:backend/services/run_service.py†L97-L158】
+- In-memory battle caches (`battle_tasks`, `battle_snapshots`, `battle_locks`) can also linger until `cleanup_battle_state()` runs, which delays true reset.【F:backend/runs/lifecycle.py†L23-L86】
+
+## Scope
+1. Add an application startup hook that purges persistent and in-memory run state before the server begins serving requests. Include logging so operators know when cleanup occurs.
+2. Ensure associated artifacts (battle logs, login reward progress tracking, etc.) are handled safely—either preserve analytics data or document that it is untouched.
+3. Keep backup/restore behavior predictable: document that stored backups must be re-imported after restart if a run was in progress, or adjust the cleanup to respect explicit backups.
+4. Update backend docs/process notes to describe the new startup behavior (`backend/README.md` and relevant `.codex/implementation` entries).
+5. Add regression coverage: e.g., a test that seeds a run, triggers the startup hook, and verifies the run table and battle caches are empty.
+
+## Acceptance Criteria
+- Booting the backend removes all entries from `runs` (and related battle state) before `/ui` responses are served.
+- Cleanup is idempotent and does not raise errors when no runs exist.
+- Documentation explicitly calls out the startup pruning behavior and any implications for saves/backups.
+- Automated test(s) cover the cleanup logic.
+- Goal file `33e45df1-run-start-flow.goal` is referenced in the PR summary for traceability; no direct modifications to the goal file.
+
+## Dependencies / Notes
+- Coordinate with whoever owns run backup/restore endpoints so expectations stay aligned (`services/run_service.py` helpers like `backup_save`, `restore_save`).
+- Validate that login reward streak tracking and analytics events remain intact after pruning.
+- If adding new helper functions, keep files under ~300 lines or split appropriately per repository guidelines.


### PR DESCRIPTION
## Summary
- add a Task Master assignment to clean up stale runs during backend startup
- capture scope, acceptance criteria, and dependencies for pruning persistent and in-memory run state

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_b_68e03180b438832cbdf3099fad1d3335