### PR TITLE
Ensure DoT and HoT ticks respect pacing

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -225,6 +225,15 @@ class DamageOverTime:
     source: Stats | None = None
 
     async def tick(self, target: Stats, *_: object) -> bool:
+        try:
+            from autofighter.rooms.battle.pacing import YIELD_MULTIPLIER
+            from autofighter.rooms.battle.pacing import pace_sleep
+        except (ImportError, ModuleNotFoundError):
+            YIELD_MULTIPLIER = 0.0
+
+            async def pace_sleep(_multiplier: float = 1.0) -> None:
+                await asyncio.sleep(0)
+
         from autofighter.stats import BUS  # Import here to avoid circular imports
 
         source_actor = self.source or target
@@ -273,6 +282,7 @@ class DamageOverTime:
                 "final_damage": dmg
             })
 
+        await pace_sleep(YIELD_MULTIPLIER)
         self.turns -= 1
         return self.turns > 0
 
@@ -288,6 +298,15 @@ class HealingOverTime:
     source: Stats | None = None
 
     async def tick(self, target: Stats, *_: object) -> bool:
+        try:
+            from autofighter.rooms.battle.pacing import YIELD_MULTIPLIER
+            from autofighter.rooms.battle.pacing import pace_sleep
+        except (ImportError, ModuleNotFoundError):
+            YIELD_MULTIPLIER = 0.0
+
+            async def pace_sleep(_multiplier: float = 1.0) -> None:
+                await asyncio.sleep(0)
+
         from autofighter.stats import BUS  # Import here to avoid circular imports
 
         if getattr(target, "hp", 0) <= 0:
@@ -314,6 +333,7 @@ class HealingOverTime:
         })
 
         await target.apply_healing(heal, healer=healer)
+        await pace_sleep(YIELD_MULTIPLIER)
         self.turns -= 1
         return self.turns > 0
 


### PR DESCRIPTION
## Summary
- await the pacing helpers from DamageOverTime.tick and HealingOverTime.tick so every tick yields after resolving damage or healing
- add regression tests that assert DoT/HoT ticks and the parallel DoT branch all invoke the pacing helpers

## Testing
- uv run ruff check autofighter/effects.py tests/test_effects.py --fix
- uv run pytest tests/test_effects.py -k "damage_over_time_tick_awaits_pacing or healing_over_time_tick_awaits_pacing or parallel_dot_ticks_respect_pacing"

------
https://chatgpt.com/codex/tasks/task_b_68e04dd91464832c9d60d67b573d69d1