### PR TITLE
fix: ensure boss rush runs keep default pressure

### DIFF
--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -319,7 +319,7 @@ async def handle_ui_action() -> tuple[str, int, dict[str, Any]]:
             # Validate start_run parameters
             members = params.get("party", ["player"])
             damage_type = params.get("damage_type", "")
-            pressure = params.get("pressure", 0)
+            pressure = params.get("pressure")
 
             if not isinstance(members, list):
                 return create_error_response("Party must be a list of member IDs", 400)

--- a/backend/services/run_service.py
+++ b/backend/services/run_service.py
@@ -118,7 +118,7 @@ async def _validate_party_members(members: list[str]) -> None:
 async def start_run(
     members: list[str],
     damage_type: str = "",
-    pressure: int = 0,
+    pressure: int | None = None,
     run_type: str | None = None,
     modifiers: dict[str, object] | None = None,
 ) -> dict[str, object]:
@@ -171,7 +171,7 @@ async def start_run(
         configuration: RunConfigurationSelection = validate_run_configuration(
             run_type=run_type,
             modifiers=modifiers or {},
-            fallback_pressure=pressure,
+            fallback_pressure=pressure if pressure is not None else None,
         )
     except ValueError as exc:
         raise ValueError(str(exc)) from exc


### PR DESCRIPTION
## Summary
- stop start_run from overriding run-type pressure defaults when no override is provided
- have the UI endpoint forward an unspecified pressure value as null so defaults remain intact

## Testing
- uv run pytest backend/tests/test_run_configuration_service.py backend/tests/test_mapgen.py *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_b_68e1b8a50514832ca1ea4ba19ef834d0