### PR TITLE
Fix metadata refresh cycle in RunChooser metadata handling

### DIFF
--- a/frontend/src/lib/components/RunChooser.svelte
+++ b/frontend/src/lib/components/RunChooser.svelte
@@ -46,7 +46,7 @@
   let sanitizedMetadataHash = null;
   let currentMetadataHash = null;
   let lastRequestedMetadataHash = null;
-  let shouldRefetchMetadata = false;
+  let needsMetadataRefresh = false;
 
   const hasOwn = (obj, key) => Object.prototype.hasOwnProperty.call(obj, key);
   const EFFECT_LABEL_MAP = {
@@ -97,12 +97,11 @@
   $: quickStartPresets = deriveQuickStartPresets(runTypeId);
   $: sanitizedMetadataHash = normalizeMetadataHash(metadataHash);
   $: currentMetadataHash = normalizeMetadataHash(metadata?.metadata_hash ?? metadata?.version);
-  $: shouldRefetchMetadata =
+  $: needsMetadataRefresh =
     Boolean(sanitizedMetadataHash) &&
     sanitizedMetadataHash !== currentMetadataHash &&
-    sanitizedMetadataHash !== lastRequestedMetadataHash &&
     !metadataLoading;
-  $: if (shouldRefetchMetadata) {
+  $: if (needsMetadataRefresh && sanitizedMetadataHash !== lastRequestedMetadataHash) {
     lastRequestedMetadataHash = sanitizedMetadataHash;
     void fetchMetadata({ metadataHash: sanitizedMetadataHash });
   }


### PR DESCRIPTION
## Summary
- derive a metadata refresh flag in RunChooser.svelte without depending on the last requested hash
- guard the metadata fetch so it only runs when the sanitized hash has not already been requested

## Testing
- VITE_API_BASE=http://localhost bun run build

------
https://chatgpt.com/codex/tasks/task_b_68e2a784c534832c9d254c5bdc2795d3