### PR TITLE
Align tests with updated star material ratios

### DIFF
--- a/backend/tests/test_new_upgrade_system.py
+++ b/backend/tests/test_new_upgrade_system.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 import sqlcipher3
 
-STAR_TO_MATERIALS = {1: 1, 2: 150, 3: 22500, 4: 3375000}
+STAR_TO_MATERIALS = {1: 1, 2: 125, 3: 125**2, 4: 125**3}
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- update the upgrade system test fixture to use the same STAR_TO_MATERIALS mapping as the service

## Testing
- not run (missing cryptography dependency)


------
https://chatgpt.com/codex/tasks/task_b_68e2b5159f48832c8f470d6c16837a45