### PR TITLE
Fix Generic ultimate foe targeting opponents

### DIFF
--- a/backend/plugins/damage_types/generic.py
+++ b/backend/plugins/damage_types/generic.py
@@ -33,11 +33,9 @@ class Generic(DamageTypeBase):
         has_luna_reservoir = bool(
             actor_passives and "luna_lunar_reservoir" in actor_passives
         )
-        target_pool = (
-            [a for a in allies if a.hp > 0]
-            if getattr(actor, "plugin_type", "") == "foe"
-            else [e for e in enemies if e.hp > 0]
-        )
+        target_pool = [
+            target for target in enemies if getattr(target, "hp", 0) > 0
+        ]
         if not target_pool:
             return True
         target = target_pool[0]


### PR DESCRIPTION
## Summary
- ensure the generic damage type ultimate always pulls targets from the opposing party
- add a regression test confirming foe generic ultimates damage enemies instead of allies

## Testing
- `uv run pytest tests/test_generic_ultimate.py`


------
https://chatgpt.com/codex/tasks/task_b_68e4635efad0832c82ec372e6836a499