### PR TITLE
Sync reward overlay with audio/motion settings

### DIFF
--- a/frontend/.codex/implementation/reward-overlay.md
+++ b/frontend/.codex/implementation/reward-overlay.md
@@ -1,11 +1,26 @@
 # Reward Overlay
 
-`src/lib/RewardOverlay.svelte` presents battle rewards using `RewardCard.svelte` for cards and `CurioChoice.svelte` for relics.
+`src/lib/components/RewardOverlay.svelte` presents battle rewards using `RewardCard.svelte` for cards and `CurioChoice.svelte` for relics.
 Both components wrap `CardArt.svelte`, which builds the Star Rail–style frame with a star-colored header, centered icon, star count, and description.
 `OverlayHost.svelte` spawns `FloatingLoot.svelte` elements when `roomData.loot` is present, so gold and item drops briefly rise on screen and are omitted from the reward overlay.
 Assets are resolved by star folder and id through the centralized registry
 re-exported from `assetLoader.js`, so card, relic, and material lookups share
 the same caching and fallback logic as the rest of the UI.
+
+## Inputs
+
+`RewardOverlay.svelte` receives the player's audio and motion preferences so
+icons and entry animations match accessibility expectations:
+
+- `sfxVolume` (default `5`) clamps to the 0–10 slider range. When the value is
+  `0`, `CardArt` is placed in `quiet` mode to suppress twinkles while the player
+  has sound effects muted.
+- `reducedMotion` (default `false`) removes the reveal animation delay and also
+  toggles `CardArt` into `quiet` mode so the overlay respects motion-reduction
+  settings end to end.
+
+Both props are forwarded from `OverlayHost.svelte`, which normalizes the
+viewport's overlay settings before rendering.
 
 Loot items now surface backend-provided `ui` metadata. `RewardOverlay.svelte`
 and the overlay host both prefer `item.ui.label` over hard-coded ids when

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -438,7 +438,9 @@
       relics={roomData.relic_choices || []}
       items={roomData.loot?.items || []}
       gold={roomData.loot?.gold || 0}
+      {sfxVolume}
       {fullIdleMode}
+      reducedMotion={overlayReducedMotion}
       on:select={(e) => dispatch('rewardSelect', e.detail)}
       on:next={() => dispatch('nextRoom')}
       on:lootAcknowledge={() => dispatch('lootAcknowledge')}


### PR DESCRIPTION
## Summary
- forward the viewport sfx volume and motion preferences when rendering the reward overlay
- teach RewardOverlay to accept the new props, clamp audio levels, and quiet card art animations when motion is reduced or sfx are muted
- document the additional inputs in the reward overlay implementation notes for future contributors

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68e57f62389c832c9839394b9df4c8e7