### PR TITLE
[FIX] Stabilize action queue tie-breaking

### DIFF
--- a/backend/autofighter/rooms/battle/progress.py
+++ b/backend/autofighter/rooms/battle/progress.py
@@ -96,9 +96,25 @@ async def build_action_queue_snapshot(
     """Capture the current visual action queue ordering."""
 
     def _build() -> list[ActionQueueEntry]:
+        def _sort_key(combatant: Stats) -> tuple[float, float, str]:
+            try:
+                value = float(getattr(combatant, "action_value", 0.0))
+            except Exception:
+                value = 0.0
+            if value < 0.0:
+                value = 0.0
+
+            try:
+                offset = float(getattr(combatant, "_action_sort_offset"))
+            except Exception:
+                offset = 0.0
+
+            identifier = getattr(combatant, "id", "")
+            return (value, offset, identifier)
+
         ordered = sorted(
             list(party_members) + list(foes),
-            key=lambda combatant: getattr(combatant, "action_value", 0.0),
+            key=_sort_key,
         )
         extras: list[ActionQueueEntry] = []
         for ent in ordered:


### PR DESCRIPTION
## Summary
- stop mutating combatant action values when stabilizing the action queue and introduce dedicated sort offsets for tie-breaking
- update the battle progress snapshot helper to respect the new ordering while exposing the real countdown values
- extend action queue regression coverage to ensure equal-speed combatants retain deterministic order with non-negative countdowns

## Testing
- pytest backend/tests/test_action_queue.py
- bun test tests/floor-transition.test.js *(fails: bun's built-in test runner does not provide `vi.mock`)*
- bunx vitest run *(fails: vite plugin setup requires a consumer during Vitest startup)*

------
https://chatgpt.com/codex/tasks/task_b_68e5bfc4ce5c832cb6a41c9f73386180