### PR TITLE
Handle bonus entries when normalizing active queue values

### DIFF
--- a/backend/autofighter/rooms/battle/progress.py
+++ b/backend/autofighter/rooms/battle/progress.py
@@ -126,7 +126,8 @@ async def build_action_queue_snapshot(
                 identifier = str(entry.get("id", ""))
                 if identifier == TURN_COUNTER_ID:
                     continue
-                if not active_consumed:
+                is_bonus = bool(entry.get("bonus"))
+                if not active_consumed and not is_bonus:
                     active_consumed = True
                     continue
 


### PR DESCRIPTION
## Summary
- update `_normalize_entries` to ignore bonus entries when identifying the active combatant

## Testing
- uv run pytest tests/test_action_queue.py tests/test_battle_progress_helpers.py *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e5dfc49248832cb380a422e0ff2c3f