### PR TITLE
Enable reward overlay loot SFX on first reveal

### DIFF
--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -145,7 +145,7 @@
   let dropPopTransition = null;
   let lastDropSignature = null;
   let lastReducedMotion = null;
-  let lootSfxEnabled = false;
+  let lootSfxEnabled = true;
   let lootSfxBlocked = false;
   let lootSfxNoticeLogged = false;
 


### PR DESCRIPTION
## Summary
- allow reward overlay loot audio to attempt playback on the first drop so sequential timers run as expected
- retain autoplay blocking guard so NotAllowedError continues to disable audio until the user gestures

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68e6a51477a4832ca6b50662edda0a1e