### PR TITLE
fix: canonical action queue ids

### DIFF
--- a/backend/autofighter/rooms/battle/progress.py
+++ b/backend/autofighter/rooms/battle/progress.py
@@ -35,6 +35,7 @@ class ActionQueueEntry(TypedDict, total=False):
     """Representation of a combatant in the visual action queue."""
 
     id: str
+    legacy_id: NotRequired[str]
     action_gauge: int
     action_value: float
     base_action_value: float
@@ -101,6 +102,33 @@ async def build_action_queue_snapshot(
     def _build() -> list[ActionQueueEntry]:
         combined_entities = list(party_members) + list(foes)
 
+        identifier_cache: dict[int, tuple[str, str | None, str | None]] = {}
+
+        def _identifiers(combatant: Stats) -> tuple[str, str | None, str | None]:
+            cached = identifier_cache.get(id(combatant))
+            if cached is not None:
+                return cached
+
+            canonical, legacy = _snapshots.canonical_entity_pair(combatant)
+
+            canonical_id = canonical or None
+            raw_identifier = getattr(combatant, "id", None)
+            raw_id = None
+            if raw_identifier is not None:
+                try:
+                    raw_id = str(raw_identifier)
+                except Exception:
+                    raw_id = None
+                if canonical_id is None:
+                    canonical_id = raw_id
+
+            if canonical_id is None:
+                canonical_id = str(id(combatant))
+
+            bundle = (canonical_id, legacy, raw_id)
+            identifier_cache[id(combatant)] = bundle
+            return bundle
+
         def _sort_key(combatant: Stats) -> tuple[float, float, str]:
             try:
                 value = float(getattr(combatant, "action_value", 0.0))
@@ -117,7 +145,7 @@ async def build_action_queue_snapshot(
                 except ValueError:
                     offset = 0.0
 
-            identifier = getattr(combatant, "id", "")
+            identifier, _, _ = _identifiers(combatant)
             return (value, offset, identifier)
 
         def _normalize_entries(entries: list[ActionQueueEntry]) -> list[ActionQueueEntry]:
@@ -151,8 +179,23 @@ async def build_action_queue_snapshot(
 
             return entries
 
-        def _entry_from_snapshot(raw: MutableMapping[str, Any]) -> ActionQueueEntry:
-            identifier = str(raw.get("id", ""))
+        def _entry_from_snapshot(
+            raw: MutableMapping[str, Any], *, entity: Stats | None
+        ) -> ActionQueueEntry:
+            source_identifier = str(raw.get("id", ""))
+
+            canonical_id = source_identifier
+            legacy_id: str | None = None
+            if entity is not None:
+                resolved_id, legacy_identifier, raw_identifier = _identifiers(entity)
+                canonical_id = resolved_id or canonical_id
+                if legacy_identifier:
+                    legacy_id = legacy_identifier
+                elif raw_identifier and raw_identifier != canonical_id:
+                    legacy_id = raw_identifier
+
+            if not canonical_id:
+                canonical_id = source_identifier
 
             try:
                 action_value = float(raw.get("action_value", 0.0) or 0.0)
@@ -171,11 +214,13 @@ async def build_action_queue_snapshot(
                 base_value = 0.0
 
             entry: ActionQueueEntry = {
-                "id": identifier,
+                "id": canonical_id,
                 "action_gauge": raw.get("action_gauge", 0),
                 "action_value": action_value,
                 "base_action_value": base_value,
             }
+            if legacy_id:
+                entry["legacy_id"] = legacy_id
             if raw.get("bonus"):
                 entry["bonus"] = True
             return entry
@@ -201,16 +246,30 @@ async def build_action_queue_snapshot(
             if base_value < 0.0:
                 base_value = 0.0
 
-            return {
-                "id": getattr(combatant, "id", ""),
+            canonical_id, legacy_id, raw_identifier = _identifiers(combatant)
+            entry: ActionQueueEntry = {
+                "id": canonical_id,
                 "action_gauge": getattr(combatant, "action_gauge", 0),
                 "action_value": action_value,
                 "base_action_value": base_value,
             }
+            if legacy_id:
+                entry["legacy_id"] = legacy_id
+            elif raw_identifier and raw_identifier != canonical_id:
+                entry["legacy_id"] = raw_identifier
+            return entry
 
         visible_entities = [
             entity for entity in combined_entities if not getattr(entity, "despawned", False)
         ]
+
+        visible_by_identifier: dict[str, Stats] = {}
+        for entity in visible_entities:
+            primary_id, legacy_identifier, raw_identifier = _identifiers(entity)
+            for identifier in (primary_id, legacy_identifier, raw_identifier):
+                if not identifier:
+                    continue
+                visible_by_identifier.setdefault(identifier, entity)
 
         if visual_queue is not None:
             try:
@@ -219,24 +278,20 @@ async def build_action_queue_snapshot(
                 queue_snapshot = []
 
             if queue_snapshot:
-                visible_by_id: dict[str, Stats] = {}
-                for entity in visible_entities:
-                    identifier = getattr(entity, "id", None)
-                    if identifier:
-                        visible_by_id.setdefault(str(identifier), entity)
-
                 entries: list[ActionQueueEntry] = []
                 for raw in queue_snapshot:
                     identifier = str(raw.get("id", ""))
                     if not identifier:
                         continue
                     if identifier != TURN_COUNTER_ID:
-                        entity = visible_by_id.get(identifier)
+                        entity = visible_by_identifier.get(identifier)
                         if entity is None:
                             continue
                         if getattr(entity, "despawned", False):
                             continue
-                    entries.append(_entry_from_snapshot(raw))
+                    else:
+                        entity = visible_by_identifier.get(identifier)
+                    entries.append(_entry_from_snapshot(raw, entity=entity))
 
                 if entries:
                     return _normalize_entries(entries)

--- a/frontend/src/lib/battle/ActionQueue.svelte
+++ b/frontend/src/lib/battle/ActionQueue.svelte
@@ -30,7 +30,21 @@
   $: enragePulse = showEnrageChip && !motionDisabled && flashEnrageCounter;
 
   function findCombatant(id) {
-    return combatants.find((c) => c.id === id) || null;
+    if (id === null || id === undefined) return null;
+    const target = String(id);
+    if (!target) return null;
+    return (
+      combatants.find((c) => {
+        if (!c) return false;
+        const baseId = c.id === null || c.id === undefined ? null : String(c.id);
+        if (baseId === target) {
+          return true;
+        }
+        const instanceId =
+          c.instance_id === null || c.instance_id === undefined ? null : String(c.instance_id);
+        return instanceId === target;
+      }) || null
+    );
   }
 
   const TURN_COUNTER_ID = 'turn_counter';


### PR DESCRIPTION
## Summary
- build action queue snapshots with canonical combatant identifiers and expose legacy ids alongside them
- allow the battle action queue component to resolve entries using either canonical instance ids or legacy base ids so duplicate summons stay in sync

## Testing
- `uv run pytest backend/tests/test_battle_progress_helpers.py` *(fails: ModuleNotFoundError: No module named 'cryptography')*
- `bunx vitest run frontend/tests/battle-turn-phase.vitest.js` *(fails: No test files found, exiting with code 1)*

------
https://chatgpt.com/codex/tasks/task_b_68e7337508b8832ca74aa8d0b1e8c5c3