### PR TITLE
Fix Luna Lightstream swords reusing summon identifiers

### DIFF
--- a/backend/plugins/characters/luna.py
+++ b/backend/plugins/characters/luna.py
@@ -71,7 +71,6 @@ class _LunaSwordCoordinator:
             return
         self._sword_refs[id(sword)] = weakref.ref(sword)
         sword.actions_per_turn = owner.actions_per_turn
-        sword.summon_type = f"luna_sword_{label.lower()}"
         sword.summon_source = "luna_sword"
         sword.is_temporary = False
         tags = set(getattr(sword, "tags", set()))
@@ -298,10 +297,16 @@ class Luna(PlayerBase):
 
         helper = _LunaSwordCoordinator(self, registry)
         created = False
+        label_counts: dict[str, int] = {}
         for label, damage_type in sword_specs:
+            key = label.lower()
+            count = label_counts.get(key, 0) + 1
+            label_counts[key] = count
+            summon_type_base = f"luna_sword_{key}"
+            summon_type = summon_type_base if count == 1 else f"{summon_type_base}_{count}"
             summon = SummonManager.create_summon(
                 self,
-                summon_type=f"luna_sword_{label.lower()}",
+                summon_type=summon_type,
                 source="luna_sword",
                 stat_multiplier=1.0,
                 override_damage_type=damage_type,

--- a/backend/tests/test_luna_swords.py
+++ b/backend/tests/test_luna_swords.py
@@ -175,6 +175,8 @@ async def test_luna_glitched_non_boss_gets_lightstream_swords(monkeypatch):
     swords = SummonManager.get_summons(luna.id)
     assert len(swords) == 2
     assert {getattr(s, "luna_sword_label", None) for s in swords} == {"Lightstream"}
-    assert all(getattr(s, "summon_type", "") == "luna_sword_lightstream" for s in swords)
+    summon_types = [getattr(s, "summon_type", "") for s in swords]
+    assert all(st.startswith("luna_sword_lightstream") for st in summon_types)
+    assert len(set(summon_types)) == len(summon_types)
     damage_ids = {getattr(getattr(s, "damage_type", None), "id", None) for s in swords}
     assert damage_ids == {"Fire", "Ice"}


### PR DESCRIPTION
## Summary
- ensure Luna Lightstream summons get unique type suffixes when multiple swords share a label
- keep the generated summon identifiers intact when tagging Luna swords
- add regression coverage asserting unique Lightstream summon ids and payload types

## Testing
- uv run pytest tests/test_luna_swords.py tests/test_turn_loop_summon_updates.py
- uv run ruff check plugins/characters/luna.py tests/test_luna_swords.py tests/test_turn_loop_summon_updates.py

------
https://chatgpt.com/codex/tasks/task_b_68e73b32a8ec832cb899fb61d78f6688