### PR TITLE
fix: tame Luna Lunar Reservoir action scaling

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -62,7 +62,7 @@ first spawn and reuse it for future sessions unless customized.
 | LadyOfFire | B | 5★ | Fire | `lady_of_fire_infernal_momentum` converts defeated foes into escalating heat-wave stacks for overwhelming fire damage. | Standard gacha recruit. |
 | LadyStorm | B | 6★ | Wind / Lightning (randomized) | `lady_storm_supercell` weaves slipstreams into charge detonations that grant tailwinds and shred mitigation. | 6★ gacha headliner. |
 | LadyWind | B | 5★ | Wind | `lady_wind_tempest_guard` sustains a permanent slipstream of dodge and mitigation, feeding on critical hits. | Standard gacha recruit. |
-| Luna | B | Story | Generic | `luna_lunar_reservoir` charges astral swords; boss-ranked variants pre-summon blades that mirror her actions, while glitched non-boss ranks cache twin Lightstream swords before combat. | Story antagonist only; cannot be unlocked or recruited. |
+| Luna | B | Story | Generic | `luna_lunar_reservoir` charges astral swords, doubling actions up to 32 per turn before adding +1 per extra 25 charge; boss-ranked variants pre-summon blades that mirror her actions, while glitched non-boss ranks cache twin Lightstream swords before combat. | Story antagonist only; cannot be unlocked or recruited. |
 | Mezzy | B | 5★ | Any (randomized) | `mezzy_gluttonous_bulwark` devours incoming attacks, siphoning stats and reducing damage taken. | Standard gacha recruit. |
 | Mimic | C | 0★ | Any (randomized) | `mimic_player_copy` mirrors allied passives and stat gains. | Mirrors an active party member during scripted mirror fights; non-selectable. |
 | PersonaIce | A | 5★ | Ice | `persona_ice_cryo_cycle` layers mitigation and thaws stored frost into end-of-turn healing barriers. | Standard gacha recruit. |

--- a/backend/plugins/passives/normal/luna_lunar_reservoir.py
+++ b/backend/plugins/passives/normal/luna_lunar_reservoir.py
@@ -133,7 +133,10 @@ class LunaLunarReservoir:
         setattr(charge_target, "luna_sword_charge", current_charge)
 
         doubles = min(current_charge // 25, 2000)
-        charge_target.actions_per_turn = 2 << doubles
+        if doubles <= 4:
+            charge_target.actions_per_turn = 2 << doubles
+        else:
+            charge_target.actions_per_turn = 32 + (doubles - 4)
 
         bonus_effect_name = "luna_lunar_reservoir_atk_bonus"
         if current_charge > 2000:

--- a/backend/tests/test_character_passives.py
+++ b/backend/tests/test_character_passives.py
@@ -49,6 +49,15 @@ async def test_luna_lunar_reservoir_passive():
         LunaLunarReservoir.add_charge(luna, 25)
         assert LunaLunarReservoir.get_charge(luna) == 100
         assert luna.actions_per_turn == 32
+
+        # After hitting 32 actions, each additional 25 charge should add +1 action
+        LunaLunarReservoir.add_charge(luna, 25)
+        assert LunaLunarReservoir.get_charge(luna) == 125
+        assert luna.actions_per_turn == 33
+
+        LunaLunarReservoir.add_charge(luna, 75)
+        assert LunaLunarReservoir.get_charge(luna) == 200
+        assert luna.actions_per_turn == 36
     finally:
         LunaLunarReservoir._charge_points.clear()
         LunaLunarReservoir._swords_by_owner.clear()


### PR DESCRIPTION
## Summary
- cap Luna Lunar Reservoir's action doubling at 32 actions and award +1 per extra 25 charge beyond that point
- extend the passive test to cover the capped growth and refresh the roster reference entry
- restore the guard that keeps linear action gains from continuing past the legacy 2000-step limit

## Testing
- uv run pytest tests/test_character_passives.py tests/test_passive_stacks.py

------
https://chatgpt.com/codex/tasks/task_b_68e75d2c3a58832ca2473b3770c4e224