### PR TITLE
Refresh run wizard metadata hash

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -40,7 +40,7 @@
     syncBattlePolling,
     syncMapPolling
   } from '$lib';
-  import { updateParty, acknowledgeLoot } from '$lib/systems/uiApi.js';
+  import { updateParty, acknowledgeLoot, resetRunConfigurationMetadataCache } from '$lib/systems/uiApi.js';
   import { getPlayers } from '$lib/systems/api.js';
   import { deriveSeedParty, sanitizePartyIds } from '$lib/systems/partySeed.js';
   import { buildRunMenu } from '$lib/components/RunButtons.svelte';
@@ -609,7 +609,18 @@
     // Ensure we truly start fresh: end any active runs first
     try { await endAllRuns(); } catch {}
     await primePartySeed();
-    openOverlay('run-choose', { runs: [], metadataHash: null });
+
+    let metadataHash = null;
+    try {
+      const data = await getActiveRuns();
+      metadataHash = data?.metadataHash ?? null;
+    } catch {}
+
+    if (!metadataHash) {
+      resetRunConfigurationMetadataCache();
+    }
+
+    openOverlay('run-choose', { runs: [], metadataHash });
   }
 
   async function handleParty() {


### PR DESCRIPTION
## Summary
- fetch the latest run configuration metadata hash before launching the new run wizard
- reset the cached run configuration metadata when no hash is available so the wizard reloads backend data

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68e75fd16bcc832c957a700330b05828