### PR TITLE
Address feedback: avoid double charge on hit landed

### DIFF
--- a/backend/plugins/passives/normal/luna_lunar_reservoir.py
+++ b/backend/plugins/passives/normal/luna_lunar_reservoir.py
@@ -231,7 +231,7 @@ class LunaLunarReservoir:
 
         if event == "ultimate_used":
             cls._charge_points[entity_id] += 64 * multiplier
-        else:
+        elif event != "hit_landed":
             cls._charge_points[entity_id] += 1 * multiplier
 
         current_charge = cls._charge_points[entity_id]


### PR DESCRIPTION
## Summary
- guard Lunar Reservoir charge gains so hit_landed triggers do not add an extra point

## Testing
- uv run pytest tests/test_character_passives.py::test_luna_prime_hit_landed_heals_and_stacks tests/test_luna_swords.py::test_prime_luna_sword_hits_gain_stacks_and_heal *(fails: test selection not found in repo)*

------
https://chatgpt.com/codex/tasks/task_b_68e76bdcbd24832c8a7e37575ce6999c