### PR TITLE
fix: clear stale higher-tier cache entries

### DIFF
--- a/frontend/src/lib/components/upgradeCacheUtils.js
+++ b/frontend/src/lib/components/upgradeCacheUtils.js
@@ -36,8 +36,9 @@ export function mergeUpgradePayload(previousData, result) {
   }
 
   if (result && Object.prototype.hasOwnProperty.call(result, 'materials_remaining')) {
+    const hasItems = Object.prototype.hasOwnProperty.call(result, 'items');
     const elementKey = String(result.element || base.element || '').toLowerCase();
-    if (elementKey) {
+    if (elementKey && !hasItems) {
       const materialKey = `${elementKey}_1`;
       const tierPrefix = `${elementKey}_`;
       const nextItems = { ...(base.items || {}) };


### PR DESCRIPTION
## Summary
- gate higher-tier cache clearing to only aggregated responses lacking item breakdowns

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e7e6d664a8832cac0f10ffcf7cb2da