### PR TITLE
Address floater state reset during empty resolve snapshots

### DIFF
--- a/frontend/src/lib/components/BattleView.svelte
+++ b/frontend/src/lib/components/BattleView.svelte
@@ -2221,7 +2221,18 @@
         recentEvents = [];
       }
 
-      if (!hasRecentEventArray || snap.recent_events.length === 0) {
+      const hasOverlayEvents = Array.isArray(recentEvents) && recentEvents.length > 0;
+      const hasFloaterEvents = Array.isArray(floaterFeed) && floaterFeed.length > 0;
+      const hasPendingFloaterState =
+        (Array.isArray(pendingFloaterRawEvents) && pendingFloaterRawEvents.length > 0) ||
+        (Array.isArray(pendingFloaterNormalizedEvents) && pendingFloaterNormalizedEvents.length > 0);
+
+      if (
+        (!hasRecentEventArray || snap.recent_events.length === 0) &&
+        !hasOverlayEvents &&
+        !hasFloaterEvents &&
+        !hasPendingFloaterState
+      ) {
         floaterFeed = [];
         recentEventCounts = new Map();
         lastRecentEventTokens = [];


### PR DESCRIPTION
## Summary
- prevent floater and projectile state from being cleared when resolve snapshots publish overlay batches

## Testing
- bun x vitest run --config tests/vitest.process.config.mjs *(fails: config file missing in repository path)*

------
https://chatgpt.com/codex/tasks/task_b_68e7fd0c41e4832c9e1f1163fc144cd6