### PR TITLE
Handle loot SFX gesture without replaying audio

### DIFF
--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -203,6 +203,7 @@
   }
 
   function handleLootSfxGesture() {
+    const wasBlocked = lootSfxBlocked;
     if (lootSfxBlocked) {
       lootSfxBlocked = false;
     }
@@ -211,7 +212,7 @@
     if (dropSfxPlayer && typeof dropSfxPlayer.setVolume === 'function') {
       dropSfxPlayer.setVolume(normalizedSfxVolume);
     }
-    if (visibleDrops.length > 0) {
+    if (wasBlocked && visibleDrops.length > 0) {
       playRewardDropAudio();
     }
   }


### PR DESCRIPTION
## Summary
- only replay reward drop audio when gestures transition from a blocked autoplay state while still resetting volume on pointer interactions

## Testing
- bun test tests/assetloader.test.js tests/shop-purchase-sequence.test.js
- bun test tests/stat-tabs-persistence.test.js *(fails: expects context="module" markup in StatTabs.svelte)*

------
https://chatgpt.com/codex/tasks/task_b_68e9ffb39cb4832c9e99422a9808e825