### PR TITLE
Add foe speed RDR bonus assertion to run configuration test

### DIFF
--- a/backend/tests/test_run_configuration_service.py
+++ b/backend/tests/test_run_configuration_service.py
@@ -24,6 +24,11 @@ def test_run_configuration_metadata_details():
     assert preview_five["raw_bonus"] == pytest.approx(2.5)
     foe_speed = next(mod for mod in metadata["modifiers"] if mod["id"] == "foe_speed")
     assert foe_speed["reward_bonuses"]["exp_bonus_per_stack"] == pytest.approx(0.5)
+    assert foe_speed["reward_bonuses"]["rdr_bonus_per_stack"] == pytest.approx(0.01)
+    assert (
+        foe_speed["reward_bonuses"]["rdr_bonus_per_stack"]
+        < foe_speed["reward_bonuses"]["exp_bonus_per_stack"]
+    )
     pressure = next(mod for mod in metadata["modifiers"] if mod["id"] == "pressure")
     assert "encounter_bonus" in pressure["effects"]
     pressure_preview = next(item for item in pressure["preview"] if item["stacks"] == 10)


### PR DESCRIPTION
## Summary
- extend the run configuration metadata test to verify the foe speed modifier's RDR bonus per stack
- ensure the RDR bonus remains lower than the corresponding EXP bonus for the foe speed modifier

## Testing
- [ ] Backend tests (fails: existing import errors in battle logging tests and syntax error in test_event_bus_performance)
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

------
https://chatgpt.com/codex/tasks/task_b_68ea06250e24832ca13bd659271c8c55