### PR TITLE
Trim reward preview bonuses to EXP and RDR

### DIFF
--- a/frontend/src/lib/components/RewardPreviewCard.svelte
+++ b/frontend/src/lib/components/RewardPreviewCard.svelte
@@ -2,9 +2,7 @@
   export let title = 'Reward Preview';
   export let preview = {
     exp_bonus: 0,
-    rdr_bonus: 0,
-    foe_bonus: 0,
-    player_bonus: 0
+    rdr_bonus: 0
   };
   export let formatValue = (value) => value;
 </script>
@@ -21,14 +19,6 @@
     <div>
       <span class="preview-label">RDR Bonus</span>
       <span class="preview-value">{formatValue(preview.rdr_bonus)}</span>
-    </div>
-    <div>
-      <span class="preview-label">Foe Bonus</span>
-      <span class="preview-value">{formatValue(preview.foe_bonus)}</span>
-    </div>
-    <div>
-      <span class="preview-label">Player Bonus</span>
-      <span class="preview-value">{formatValue(preview.player_bonus)}</span>
     </div>
   </div>
 </section>

--- a/frontend/src/lib/components/RunChooser.svelte
+++ b/frontend/src/lib/components/RunChooser.svelte
@@ -451,12 +451,6 @@ import WizardNavigation from './WizardNavigation.svelte';
     if (Number.isFinite(reward.rdr_bonus) && reward.rdr_bonus !== 0) {
       rewardSegments.push(`RDR ${formatRewardBonus(reward.rdr_bonus)}`);
     }
-    if (Number.isFinite(reward.foe_bonus) && reward.foe_bonus !== 0) {
-      rewardSegments.push(`Foe ${formatRewardBonus(reward.foe_bonus)}`);
-    }
-    if (Number.isFinite(reward.player_bonus) && reward.player_bonus !== 0) {
-      rewardSegments.push(`Player ${formatRewardBonus(reward.player_bonus)}`);
-    }
     const rewardText = rewardSegments.length ? `. Reward preview ${rewardSegments.join(', ')}` : '';
     return `Apply preset ${index + 1}: ${stackText}${rewardText}`;
   }
@@ -1316,14 +1310,6 @@ import WizardNavigation from './WizardNavigation.svelte';
                             <div>
                               <span class="preview-label">RDR</span>
                               <span class="preview-value">{formatRewardBonus(preset.reward.rdr_bonus)}</span>
-                            </div>
-                            <div>
-                              <span class="preview-label">Foe</span>
-                              <span class="preview-value">{formatRewardBonus(preset.reward.foe_bonus)}</span>
-                            </div>
-                            <div>
-                              <span class="preview-label">Player</span>
-                              <span class="preview-value">{formatRewardBonus(preset.reward.player_bonus)}</span>
                             </div>
                           </div>
                         </button>

--- a/frontend/tests/run-wizard-flow.vitest.js
+++ b/frontend/tests/run-wizard-flow.vitest.js
@@ -161,7 +161,7 @@ describe('RunChooser wizard flow', () => {
     logMenuAction.mockResolvedValue();
   });
 
-  test('computeRewardPreview distinguishes foe EXP and RDR bonuses', () => {
+  test('computeRewardPreview calculates EXP and RDR bonuses', () => {
     const modifiers = [
       {
         id: 'enemy_buff',
@@ -178,7 +178,6 @@ describe('RunChooser wizard flow', () => {
 
     expect(preview.exp_bonus).toBe(2);
     expect(preview.rdr_bonus).toBe(0.04);
-    expect(preview.foe_bonus).toBe(2);
     expect(preview.exp_bonus).not.toBeCloseTo(preview.rdr_bonus);
   });
 


### PR DESCRIPTION
## Summary
- update RewardPreviewCard to only render the EXP and RDR preview rows
- remove foe/player bonuses from the quick-start preset summary and aria labels
- refresh the run wizard Vitest coverage to assert only the EXP and RDR rows

## Testing
- bunx vitest run tests/run-wizard-flow.vitest.js *(fails: @sveltejs/vite-plugin-svelte load hook expects config during Vitest startup)*

------
https://chatgpt.com/codex/tasks/task_b_68ea0b0daf20832c8ae4e59382f5b986