### PR TITLE
Fix minimum heal rounding under vitality scaling

### DIFF
--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -1018,13 +1018,17 @@ class Stats:
         self_type = _ensure(self)
         amount = self_type.on_heal_received(amount, healer, self)
         src_vit = healer.vitality if healer is not None else 1.0
+        positive_request = amount > 0
         # Healing is amplified by both source and target vitality
         amount = amount * src_vit * self.vitality
         # Enrage: reduce healing output globally by N% per enrage stack
         enr = get_enrage_percent()
         if enr > 0:
             amount *= max(1.0 - enr, 0.0)
-        amount = int(amount)
+        if positive_request:
+            amount = max(1, math.floor(amount))
+        else:
+            amount = int(amount)
 
         # Handle overheal/shields if enabled
         if self.overheal_enabled:

--- a/backend/tests/test_stats.py
+++ b/backend/tests/test_stats.py
@@ -1,0 +1,27 @@
+import pytest
+
+from autofighter.stats import Stats
+from autofighter.stats import get_enrage_percent
+from autofighter.stats import set_enrage_percent
+
+
+@pytest.mark.asyncio
+async def test_apply_healing_minimum_one_with_low_vitality():
+    previous_enrage = get_enrage_percent()
+    try:
+        set_enrage_percent(0.5)
+        healer = Stats()
+        target = Stats()
+
+        target.max_hp = 20
+        target.hp = 5
+
+        healer.vitality = 0.2
+        target.vitality = 0.3
+
+        healed = await target.apply_healing(1, healer=healer)
+
+        assert healed == 1
+        assert target.hp == 6
+    finally:
+        set_enrage_percent(previous_enrage)


### PR DESCRIPTION
## Summary
- clamp positive healing requests in `Stats.apply_healing` so vitality/enrage scaling never drops them below 1 HP
- add an async regression test covering low-vitality heal scenarios to guard against the regression

## Testing
- uv run pytest tests/test_character_passives.py tests/test_stats.py *(fails: existing Luna prime charge expectations already failing on main)*

------
https://chatgpt.com/codex/tasks/task_b_68ea0a753f34832cb8ee54ac69ea3f77