### PR TITLE
fix: simplify Echo Bell relic description

### DIFF
--- a/backend/plugins/relics/echo_bell.py
+++ b/backend/plugins/relics/echo_bell.py
@@ -20,10 +20,7 @@ class EchoBell(RelicBase):
     name: str = "Echo Bell"
     stars: int = 2
     effects: dict[str, float] = field(default_factory=dict)
-    about: str = (
-        "First action each battle has 15% chance per stack to trigger Aftertaste "
-        "(overflow converts every +100% into a guaranteed extra hit)."
-    )
+    about: str = "First action each battle gains +15% Aftertaste chance per stack; every 100% becomes a guaranteed extra hit."
 
     async def apply(self, party) -> None:
         await super().apply(party)


### PR DESCRIPTION
## Summary
- simplify the Echo Bell relic description to match the concise tone used elsewhere

## Testing
- uv run pytest *(fails: import errors for battle_logging modules in test suite)*

------
https://chatgpt.com/codex/tasks/task_b_68ea1a581f14832c849fa2bb75fa11c5