### PR TITLE
Scale Light HoT healing with caster stats

### DIFF
--- a/backend/plugins/damage_effects.py
+++ b/backend/plugins/damage_effects.py
@@ -5,6 +5,7 @@ import logging
 
 from autofighter.effects import DamageOverTime
 from autofighter.effects import HealingOverTime
+from autofighter.stats import Stats
 from plugins.dots.abyssal_corruption import AbyssalCorruption
 from plugins.dots.blazing_torment import BlazingTorment
 from plugins.dots.celestial_atrophy import CelestialAtrophy
@@ -31,8 +32,10 @@ DOT_FACTORIES: dict[str, Callable[[float, object], DamageOverTime]] = {
     "Wind": lambda dmg, src: _set_source(GaleErosion(int(dmg * 0.25), 3), src),
 }
 
-HOT_FACTORIES: dict[str, Callable[[object], HealingOverTime]] = {
-    "Light": lambda src: _set_source(RadiantRegeneration(), src),
+# RadiantRegeneration(source: Stats) requires the caster instance so the HoT can
+# scale its base healing from the source's attack and vitality.
+HOT_FACTORIES: dict[str, Callable[[Stats], HealingOverTime]] = {
+    "Light": lambda src: _set_source(RadiantRegeneration(src), src),
 }
 
 

--- a/backend/plugins/hots/radiant_regeneration.py
+++ b/backend/plugins/hots/radiant_regeneration.py
@@ -1,4 +1,5 @@
 from autofighter.effects import HealingOverTime
+from autofighter.stats import Stats
 
 
 class RadiantRegeneration(HealingOverTime):
@@ -6,5 +7,8 @@ class RadiantRegeneration(HealingOverTime):
     # Include element in the id so frontends can infer visuals without extra metadata
     id = "light_radiant_regeneration"
 
-    def __init__(self, healing: int = 5, turns: int = 2) -> None:
+    def __init__(self, source: Stats, *, turns: int = 2) -> None:
+        base = max(15, int(source.atk * 0.2))
+        healing = int(base * max(source.vitality, 1.0))
         super().__init__("Radiant Regeneration", healing, turns, self.id)
+        self.source = source

--- a/backend/tests/test_lady_light_radiant_aegis.py
+++ b/backend/tests/test_lady_light_radiant_aegis.py
@@ -33,7 +33,7 @@ async def test_radiant_aegis_hot_event_applies_shields():
 
     await passive.apply(healer)
 
-    hot = RadiantRegeneration()
+    hot = RadiantRegeneration(healer)
     hot.healing = 8  # Boost base healing so scaling is visible
     hot.source = healer
     ally.effect_manager.add_hot(hot)

--- a/backend/tests/test_light_hot.py
+++ b/backend/tests/test_light_hot.py
@@ -6,9 +6,10 @@ from plugins.damage_types.light import Light
 
 
 @pytest.mark.asyncio
-async def test_radiant_regeneration_stacks():
+async def test_radiant_regeneration_stacks_and_scales_with_vitality():
     light = Light()
     actor = Stats(damage_type=light)
+    actor.set_base_stat("atk", 300)
     ally = Stats()
     actor.effect_manager = EffectManager(actor)
     ally.effect_manager = EffectManager(ally)
@@ -17,14 +18,28 @@ async def test_radiant_regeneration_stacks():
     stacks = [h for h in ally.effect_manager.hots if h.id == "light_radiant_regeneration"]
     assert len(stacks) == 2
 
+    expected_base = max(15, int(actor.atk * 0.2))
+    expected_healing = int(expected_base * max(actor.vitality, 1.0))
+    assert stacks[0].healing == expected_healing
+
+    actor.vitality = 2.5
+    actor.set_base_stat("atk", 420)
+    await light.on_action(actor, [actor, ally], [])
+    stacks = [h for h in ally.effect_manager.hots if h.id == "light_radiant_regeneration"]
+    assert len(stacks) == 3
+    expected_base = max(15, int(actor.atk * 0.2))
+    expected_healing = int(expected_base * max(actor.vitality, 1.0))
+    assert stacks[-1].healing == expected_healing
+
 
 @pytest.mark.asyncio
 async def test_light_heals_low_hp_ally():
     light = Light()
     actor = Stats(damage_type=light)
     actor.set_base_stat('atk', 50)
-    ally = Stats(hp=20)
-    ally.set_base_stat('max_hp', 100)
+    ally = Stats()
+    ally.max_hp = 100
+    ally.hp = 20
     actor.effect_manager = EffectManager(actor)
     ally.effect_manager = EffectManager(ally)
     proceed = await light.on_action(actor, [actor, ally], [])


### PR DESCRIPTION
## Summary
- compute Radiant Regeneration healing from the casting Stats object and retain the HoT source for stacking
- update the Light HoT factory to pass the caster into Radiant Regeneration and document the new signature
- expand Light HoT tests to validate attack/vitality scaling, boosted vitality cases, and the low-HP emergency heal path

## Testing
- [x] Backend tests (`uv run --project backend pytest backend/tests/test_light_hot.py`)
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)


------
https://chatgpt.com/codex/tasks/task_b_68ea1ba2abec832c816a31fef96c1c74