### PR TITLE
Update Luna overflow description to match 55% overflow ATK bonus

### DIFF
--- a/backend/plugins/passives/normal/luna_lunar_reservoir.py
+++ b/backend/plugins/passives/normal/luna_lunar_reservoir.py
@@ -292,5 +292,5 @@ class LunaLunarReservoir:
     def get_description(cls) -> str:
         return (
             "Gains 1 charge per action. Every 25 charge doubles actions per turn (capped after 2000 doublings). "
-            "Stacks above 2000 grant +15% of Luna's base ATK, +1% of her base SPD, and +1% additional actions from the doubled cadence per 100 excess charge with no automatic drain."
+            "Stacks above 2000 grant +55% of Luna's base ATK, +1% of her base SPD, and +1% additional actions from the doubled cadence per 100 excess charge with no automatic drain."
         )


### PR DESCRIPTION
## Summary
- update Luna's Lunar Reservoir description to reflect the 55% base ATK overflow bonus

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ea244c92f4832c8ccb57f4cf7fe8d4