### PR TITLE
[FIX] Await effect modifiers during initialization

### DIFF
--- a/backend/autofighter/rooms/battle/enrage.py
+++ b/backend/autofighter/rooms/battle/enrage.py
@@ -132,7 +132,7 @@ async def update_enrage_state(
                 atk_mult=mult,
                 turns=9999,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             enrage_mods[idx] = mod
         state.stacks = new_stacks
         if turn > catastrophic_turn_threshold:

--- a/backend/autofighter/summons/base.py
+++ b/backend/autofighter/summons/base.py
@@ -7,6 +7,7 @@ characters, passives, cards, and relics.
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import dataclass
 import logging
 import random
@@ -169,7 +170,13 @@ class Summon(Stats):
                 if cls._is_beneficial_stat_modifier(mod):
                     scaled_mod = cls._scale_stat_modifier(mod, summon, stat_multiplier)
                     scaled_mod.apply()  # Apply the modifier to ensure it affects the summon's stats
-                    summon.effect_manager.add_modifier(scaled_mod)
+                    coro = summon.effect_manager.add_modifier(scaled_mod)
+                    try:
+                        loop = asyncio.get_running_loop()
+                    except RuntimeError:
+                        asyncio.run(coro)
+                    else:
+                        loop.create_task(coro)
                     log.debug(f"Shared beneficial StatModifier '{mod.name}' to summon {summon.id}")
 
     @classmethod

--- a/backend/plugins/cards/_base.py
+++ b/backend/plugins/cards/_base.py
@@ -66,7 +66,7 @@ class CardBase:
                 mod = create_stat_buff(
                     member, name=f"{self.id}_{attr}", turns=9999, **changes
                 )
-                mgr.add_modifier(mod)
+                await mgr.add_modifier(mod)
 
                 # Emit card effect event
                 await BUS.emit_async(

--- a/backend/plugins/cards/balanced_diet.py
+++ b/backend/plugins/cards/balanced_diet.py
@@ -32,9 +32,9 @@ class BalancedDiet(CardBase):
                     target,
                     name=f"{self.id}_heal_def",
                     turns=1,
-                    defense_mult=1.02  # +2% DEF
+                    defense_mult=1.02,  # +2% DEF
                 )
-                effect_manager.add_modifier(def_mod)
+                await effect_manager.add_modifier(def_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/critical_transfer.py
+++ b/backend/plugins/cards/critical_transfer.py
@@ -46,7 +46,7 @@ class CriticalTransfer(CardBase):
                 turns=1,
                 atk_mult=1 + 0.04 * total,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             await BUS.emit_async(
                 "card_effect",
                 self.id,

--- a/backend/plugins/cards/elemental_spark.py
+++ b/backend/plugins/cards/elemental_spark.py
@@ -39,7 +39,7 @@ class ElementalSpark(CardBase):
                 turns=9999,
                 effect_hit_rate_mult=1.05,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             chosen["mod"] = (mgr, mod)
             await BUS.emit_async(
                 "card_effect",

--- a/backend/plugins/cards/enduring_charm.py
+++ b/backend/plugins/cards/enduring_charm.py
@@ -44,7 +44,7 @@ class EnduringCharm(CardBase):
                         turns=2,
                         vitality_mult=1.03,
                     )
-                    effect_manager.add_modifier(vit_mod)
+                    await effect_manager.add_modifier(vit_mod)
 
                     log = logging.getLogger(__name__)
                     log.debug(
@@ -68,7 +68,7 @@ class EnduringCharm(CardBase):
 
         self.subscribe("turn_start", _check_low_hp)
 
-        def _on_damage_taken(target, attacker, damage, *_: object):
-            _check_low_hp()
+        async def _on_damage_taken(target, attacker, damage, *_: object):
+            await _check_low_hp()
 
         self.subscribe("damage_taken", _on_damage_taken)

--- a/backend/plugins/cards/enduring_will.py
+++ b/backend/plugins/cards/enduring_will.py
@@ -60,10 +60,12 @@ class EnduringWill(CardBase):
 
                         # Create temporary mitigation buff for this battle
                         mod = create_stat_buff(
-                            member, name=f"{self.id}_mitigation_bonus", turns=20,
-                            mitigation_mult=1.002  # +0.2% mitigation
+                            member,
+                            name=f"{self.id}_mitigation_bonus",
+                            turns=20,
+                            mitigation_mult=1.002,  # +0.2% mitigation
                         )
-                        mgr.add_modifier(mod)
+                        await mgr.add_modifier(mod)
 
                         import logging
                         log = logging.getLogger(__name__)

--- a/backend/plugins/cards/farsight_scope.py
+++ b/backend/plugins/cards/farsight_scope.py
@@ -37,7 +37,7 @@ class FarsightScope(CardBase):
                         turns=1,
                         crit_rate=0.06,
                     )
-                    effect_manager.add_modifier(crit_mod)
+                    await effect_manager.add_modifier(crit_mod)
 
                     log.debug(
                         "Farsight Scope low HP bonus: %s gains +6%% crit rate vs %s",

--- a/backend/plugins/cards/inspiring_banner.py
+++ b/backend/plugins/cards/inspiring_banner.py
@@ -40,9 +40,9 @@ class InspiringBanner(CardBase):
                         random_ally,
                         name=f"{self.id}_battle_start",
                         turns=2,
-                        atk_mult=1.02  # +2% ATK
+                        atk_mult=1.02,  # +2% ATK
                     )
-                    effect_manager.add_modifier(atk_mod)
+                    await effect_manager.add_modifier(atk_mod)
 
                     import logging
                     log = logging.getLogger(__name__)

--- a/backend/plugins/cards/iron_guard.py
+++ b/backend/plugins/cards/iron_guard.py
@@ -43,6 +43,6 @@ class IronGuard(CardBase):
                     turns=1,
                     defense_mult=1.10,
                 )
-                mgr.add_modifier(mod)
+                await mgr.add_modifier(mod)
 
         self.subscribe("damage_taken", _damage_taken)

--- a/backend/plugins/cards/keen_goggles.py
+++ b/backend/plugins/cards/keen_goggles.py
@@ -75,7 +75,7 @@ class KeenGoggles(CardBase):
                 crit_rate_mult=1 + (new_stacks * 0.01),
             )
             setattr(crit_mod, "source", source)
-            effect_manager.add_modifier(crit_mod)
+            await effect_manager.add_modifier(crit_mod)
 
             import logging
 

--- a/backend/plugins/cards/overclock.py
+++ b/backend/plugins/cards/overclock.py
@@ -59,7 +59,7 @@ class Overclock(CardBase):
                 _refresh_action_timings(ally)
 
             modifier.remove = _remove_and_refresh  # type: ignore[assignment]
-            manager.add_modifier(modifier)
+            await manager.add_modifier(modifier)
 
             await BUS.emit_async(
                 "card_effect",

--- a/backend/plugins/cards/polished_shield.py
+++ b/backend/plugins/cards/polished_shield.py
@@ -44,9 +44,9 @@ class PolishedShield(CardBase):
                 target,
                 name=f"{self.id}_resist_def",
                 turns=1,
-                defense=3
+                defense=3,
             )
-            effect_manager.add_modifier(def_mod)
+            await effect_manager.add_modifier(def_mod)
 
             import logging
             log = logging.getLogger(__name__)

--- a/backend/plugins/cards/precision_sights.py
+++ b/backend/plugins/cards/precision_sights.py
@@ -34,9 +34,9 @@ class PrecisionSights(CardBase):
                     attacker,
                     name=f"{self.id}_crit_boost_{unique_suffix}",
                     turns=2,
-                    crit_damage_mult=1.02  # +2% crit damage
+                    crit_damage_mult=1.02,  # +2% crit damage
                 )
-                effect_manager.add_modifier(crit_damage_mod)
+                await effect_manager.add_modifier(crit_damage_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/reality_split.py
+++ b/backend/plugins/cards/reality_split.py
@@ -54,7 +54,7 @@ class RealitySplit(CardBase):
             if entity is None or entity in members or entity is party:
                 _cleanup()
 
-        def _turn_start_handler(*_args) -> None:
+        async def _turn_start_handler(*_args) -> None:
             if not party.members:
                 return
             target = random.choice(party.members)
@@ -69,7 +69,7 @@ class RealitySplit(CardBase):
                 turns=1,
                 crit_rate=0.5,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
 
         async def _hit_landed(attacker, _target, amount, *_args) -> None:
             if attacker is not state["active"]:

--- a/backend/plugins/cards/sharpening_stone.py
+++ b/backend/plugins/cards/sharpening_stone.py
@@ -32,9 +32,9 @@ class SharpeningStone(CardBase):
                     attacker,
                     name=f"{self.id}_crit_boost",
                     turns=2,
-                    crit_damage_mult=1.02  # +2% crit damage
+                    crit_damage_mult=1.02,  # +2% crit damage
                 )
-                effect_manager.add_modifier(crit_damage_mod)
+                await effect_manager.add_modifier(crit_damage_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/steel_bangles.py
+++ b/backend/plugins/cards/steel_bangles.py
@@ -35,9 +35,9 @@ class SteelBangles(CardBase):
                         target,
                         name=f"{self.id}_attack_debuff",
                         turns=1,  # Lasts for 1 turn
-                        atk_mult=0.97  # 3% damage reduction
+                        atk_mult=0.97,  # 3% damage reduction
                     )
-                    effect_manager.add_modifier(attack_debuff)
+                    await effect_manager.add_modifier(attack_debuff)
 
                     import logging
                     log = logging.getLogger(__name__)

--- a/backend/plugins/cards/swift_bandanna.py
+++ b/backend/plugins/cards/swift_bandanna.py
@@ -32,9 +32,9 @@ class SwiftBandanna(CardBase):
                     dodger,
                     name=f"{self.id}_dodge_crit",
                     turns=1,
-                    crit_rate_mult=1.01  # +1% crit rate
+                    crit_rate_mult=1.01,  # +1% crit rate
                 )
-                effect_manager.add_modifier(crit_mod)
+                await effect_manager.add_modifier(crit_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/swift_footwork.py
+++ b/backend/plugins/cards/swift_footwork.py
@@ -49,7 +49,7 @@ class SwiftFootwork(CardBase):
                     turns=2,
                     spd_mult=1.3,
                 )
-                mgr.add_modifier(burst)
+                await mgr.add_modifier(burst)
                 await BUS.emit_async(
                     "card_effect",
                     self.id,

--- a/backend/plugins/cards/tactical_kit.py
+++ b/backend/plugins/cards/tactical_kit.py
@@ -49,9 +49,9 @@ class TacticalKit(CardBase):
                             actor,
                             name=f"{self.id}_hp_to_atk",
                             turns=1,
-                            atk_mult=1.02  # +2% ATK
+                            atk_mult=1.02,  # +2% ATK
                         )
-                        effect_manager.add_modifier(atk_mod)
+                        await effect_manager.add_modifier(atk_mod)
 
                         import logging
                         log = logging.getLogger(__name__)

--- a/backend/plugins/cards/temporal_shield.py
+++ b/backend/plugins/cards/temporal_shield.py
@@ -36,7 +36,7 @@ class TemporalShield(CardBase):
                         turns=1,
                         mitigation_mult=100.0,
                     )
-                    mgr.add_modifier(mod)
+                    await mgr.add_modifier(mod)
                     await BUS.emit_async(
                         "card_effect",
                         self.id,

--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -45,7 +45,7 @@ class VitalCore(CardBase):
                         turns=2,
                         vitality_mult=1.03,
                     )
-                    effect_manager.add_modifier(vit_mod)
+                    await effect_manager.add_modifier(vit_mod)
 
                     log = logging.getLogger(__name__)
                     log.debug(
@@ -67,8 +67,8 @@ class VitalCore(CardBase):
 
                     loop.call_soon_threadsafe(lambda: loop.call_later(20, _remove_boost))
 
-        def _on_damage_taken(target, attacker, damage, *_: object):
-            _check_low_hp()
+        async def _on_damage_taken(target, attacker, damage, *_: object):
+            await _check_low_hp()
 
         self.subscribe("turn_start", _check_low_hp)
         self.subscribe("damage_taken", _on_damage_taken)

--- a/backend/plugins/cards/vital_surge.py
+++ b/backend/plugins/cards/vital_surge.py
@@ -35,7 +35,7 @@ class VitalSurge(CardBase):
                     atk_mult=1.55,
                 )
                 active[pid] = mod
-                mgr.add_modifier(mod)
+                await mgr.add_modifier(mod)
                 await BUS.emit_async(
                     "card_effect",
                     self.id,
@@ -53,17 +53,17 @@ class VitalSurge(CardBase):
                     if hasattr(member, "mods") and mod.id in member.mods:
                         member.mods.remove(mod.id)
 
-        def _turn_start() -> None:
+        async def _turn_start() -> None:
             for m in party.members:
-                _check(m)
+                await _check(m)
 
-        def _damage_taken(victim, *_args) -> None:
+        async def _damage_taken(victim, *_args) -> None:
             if victim in party.members:
-                _check(victim)
+                await _check(victim)
 
-        def _heal_received(member, *_args) -> None:
+        async def _heal_received(member, *_args) -> None:
             if member in party.members:
-                _check(member)
+                await _check(member)
 
         self.subscribe("turn_start", _turn_start)
         self.subscribe("damage_taken", _damage_taken)

--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -100,7 +100,7 @@ class Light(DamageTypeBase):
                 turns=10,
                 defense_mult=0.75,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             await pace_sleep(YIELD_MULTIPLIER)
 
         await BUS.emit_async("light_ultimate", actor)

--- a/backend/plugins/damage_types/wind.py
+++ b/backend/plugins/damage_types/wind.py
@@ -66,7 +66,7 @@ class Wind(DamageTypeBase):
             turns=1,
             effect_hit_rate_mult=1.5,
         )
-        a_mgr.add_modifier(eh_mod)
+        await a_mgr.add_modifier(eh_mod)
 
         # Determine dynamic hit count (allow cards/relics to override via attributes)
         hits = int(getattr(actor, "wind_ultimate_hits", getattr(actor, "ultimate_hits", 25)) or 25)

--- a/backend/plugins/dots/celestial_atrophy.py
+++ b/backend/plugins/dots/celestial_atrophy.py
@@ -22,7 +22,7 @@ class CelestialAtrophy(DamageOverTime):
                 turns=self.turns,
                 atk=-1,
             )
-            manager.add_modifier(mod)
+            await manager.add_modifier(mod)
             self._mods.append(mod)
         alive = await super().tick(target)
         if not alive and manager is not None:

--- a/backend/plugins/relics/_base.py
+++ b/backend/plugins/relics/_base.py
@@ -56,7 +56,7 @@ class RelicBase:
             if not changes:
                 continue
             mod = create_stat_buff(member, name=self.id, turns=9999, **changes)
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             mods.append(mod)
 
             # Emit relic effect tracking for stat modifications

--- a/backend/plugins/relics/bent_dagger.py
+++ b/backend/plugins/relics/bent_dagger.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -34,8 +35,17 @@ class BentDagger(RelicBase):
             })
 
             for member in party.members:
-                mod = create_stat_buff(member, name=f"{self.id}_kill", atk_mult=1.01, turns=9999)
-                member.effect_manager.add_modifier(mod)
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+                mod = create_stat_buff(
+                    member,
+                    name=f"{self.id}_kill",
+                    atk_mult=1.01,
+                    turns=9999,
+                )
+                await mgr.add_modifier(mod)
 
                 # Track the ATK buff application
                 await BUS.emit_async("relic_effect", "bent_dagger", member, "atk_boost_applied", 1, {

--- a/backend/plugins/relics/guardian_charm.py
+++ b/backend/plugins/relics/guardian_charm.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from plugins.relics._base import RelicBase
 
@@ -41,10 +42,18 @@ class GuardianCharm(RelicBase):
             },
         )
 
+        mgr = getattr(member, "effect_manager", None)
+        if mgr is None:
+            mgr = EffectManager(member)
+            member.effect_manager = mgr
+
         mod = create_stat_buff(
-            member, name=self.id, defense_mult=1 + 0.2 * stacks, turns=9999
+            member,
+            name=self.id,
+            defense_mult=1 + 0.2 * stacks,
+            turns=9999,
         )
-        member.effect_manager.add_modifier(mod)
+        await mgr.add_modifier(mod)
 
     def describe(self, stacks: int) -> str:
         pct = 20 * stacks

--- a/backend/plugins/relics/null_lantern.py
+++ b/backend/plugins/relics/null_lantern.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -72,6 +73,11 @@ class NullLantern(RelicBase):
             if current_stacks <= 0:
                 return
             mult = 1 + 1.5 * current_state["cleared"] * current_stacks
+            mgr = getattr(entity, "effect_manager", None)
+            if mgr is None:
+                mgr = EffectManager(entity)
+                entity.effect_manager = mgr
+
             mod = create_stat_buff(
                 entity,
                 name=f"{self.id}_foe_{current_state['cleared']}",
@@ -81,7 +87,7 @@ class NullLantern(RelicBase):
                 max_hp_mult=mult,
                 hp_mult=mult,
             )
-            entity.effect_manager.add_modifier(mod)
+            await mgr.add_modifier(mod)
 
             await BUS.emit_async(
                 "relic_effect",

--- a/backend/plugins/relics/omega_core.py
+++ b/backend/plugins/relics/omega_core.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -44,6 +45,11 @@ class OmegaCore(RelicBase):
                     "stacks": stacks
                 })
 
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+
                 mod = create_stat_buff(
                     member,
                     name=f"{self.id}_{id(member)}",
@@ -59,7 +65,7 @@ class OmegaCore(RelicBase):
                     vitality_mult=mult,
                     mitigation_mult=mult,
                 )
-                member.effect_manager.add_modifier(mod)
+                await mgr.add_modifier(mod)
                 safe_async_task(member.apply_healing(member.max_hp))
                 state["mods"][id(member)] = mod
             state["turn"] = 0

--- a/backend/plugins/relics/shiny_pebble.py
+++ b/backend/plugins/relics/shiny_pebble.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -36,13 +37,18 @@ class ShinyPebble(RelicBase):
             current_state["triggered"].add(id(target))
             stacks = party.relics.count(self.id)
             mit_mult = 1 + 0.03 * stacks
+            mgr = getattr(target, "effect_manager", None)
+            if mgr is None:
+                mgr = EffectManager(target)
+                target.effect_manager = mgr
+
             mod = create_stat_buff(
                 target,
                 name=f"{self.id}_{id(target)}",
                 mitigation=target.mitigation * (mit_mult - 1),
                 turns=1,
             )
-            target.effect_manager.add_modifier(mod)
+            await mgr.add_modifier(mod)
             current_state["active"][id(target)] = (target, mod)
 
             # Track mitigation burst application

--- a/backend/plugins/relics/soul_prism.py
+++ b/backend/plugins/relics/soul_prism.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -48,6 +49,11 @@ class SoulPrism(RelicBase):
                     member.effect_manager.mods.remove(existing)
                     if existing.id in member.mods:
                         member.mods.remove(existing.id)
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+
                 mod = create_stat_buff(
                     member,
                     name=mod_id,
@@ -57,7 +63,7 @@ class SoulPrism(RelicBase):
                     mitigation_mult=1 + buff,
                     turns=9999,
                 )
-                member.effect_manager.add_modifier(mod)
+                await mgr.add_modifier(mod)
                 heal = max(1, int(member.max_hp * 0.01))
 
                 # Track the revival

--- a/backend/plugins/relics/stellar_compass.py
+++ b/backend/plugins/relics/stellar_compass.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -36,13 +37,18 @@ class StellarCompass(RelicBase):
             atk_mult = 1 + 0.015 * crits * copies
             mod_name = f"{self.id}_crit_{attacker_id}"
             attacker.remove_effect_by_name(mod_name)
+            mgr = getattr(attacker, "effect_manager", None)
+            if mgr is None:
+                mgr = EffectManager(attacker)
+                attacker.effect_manager = mgr
+
             mod = create_stat_buff(
                 attacker,
                 name=mod_name,
                 atk_mult=atk_mult,
                 turns=9999,
             )
-            attacker.effect_manager.add_modifier(mod)
+            await mgr.add_modifier(mod)
             current_state["gold"] += 0.015 * copies
 
             # Track critical hit buff application

--- a/backend/plugins/relics/tattered_flag.py
+++ b/backend/plugins/relics/tattered_flag.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -37,8 +38,17 @@ class TatteredFlag(RelicBase):
             })
 
             for member in survivors:
-                mod = create_stat_buff(member, name=f"{self.id}_buff", atk_mult=1.03, turns=9999)
-                member.effect_manager.add_modifier(mod)
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+                mod = create_stat_buff(
+                    member,
+                    name=f"{self.id}_buff",
+                    atk_mult=1.03,
+                    turns=9999,
+                )
+                await mgr.add_modifier(mod)
 
         self.subscribe(party, "damage_taken", _fallen)
 

--- a/backend/plugins/relics/timekeepers_hourglass.py
+++ b/backend/plugins/relics/timekeepers_hourglass.py
@@ -80,7 +80,7 @@ class TimekeepersHourglass(RelicBase):
                         spd_mult=boost,
                         turns=2,
                     )
-                    mgr.add_modifier(mod)
+                    await mgr.add_modifier(mod)
                     active_mods[id(member)] = mod
 
         def _battle_end(_entity) -> None:

--- a/backend/plugins/relics/travelers_charm.py
+++ b/backend/plugins/relics/travelers_charm.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.characters._base import PlayerBase
@@ -56,6 +57,11 @@ class TravelersCharm(RelicBase):
                 member = next((m for m in party.members if id(m) == pid), None)
                 if member is None:
                     continue
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+
                 mod = create_stat_buff(
                     member,
                     name=f"{self.id}_{pid}",
@@ -63,7 +69,7 @@ class TravelersCharm(RelicBase):
                     defense_mult=1 + d_pct,
                     mitigation_mult=1 + m_pct,
                 )
-                member.effect_manager.add_modifier(mod)
+                await mgr.add_modifier(mod)
                 active[pid] = (member, mod)
                 applied_count += 1
 

--- a/backend/plugins/relics/wooden_idol.py
+++ b/backend/plugins/relics/wooden_idol.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.characters._base import PlayerBase
@@ -45,6 +46,11 @@ class WoodenIdol(RelicBase):
                 if member is None:
                     continue
 
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+
                 # Create a temporary stat buff for the resistance bonus
                 mod = create_stat_buff(
                     member,
@@ -52,7 +58,7 @@ class WoodenIdol(RelicBase):
                     effect_resistance=bonus,
                     turns=1,
                 )
-                member.effect_manager.add_modifier(mod)
+                await mgr.add_modifier(mod)
                 active[pid] = (member, mod)
                 applied_count += 1
 

--- a/backend/tests/backend/rooms/battle/test_enrage.py
+++ b/backend/tests/backend/rooms/battle/test_enrage.py
@@ -32,7 +32,7 @@ class DummyEffectManager:
         self.mods: list[Any] = []
         self.dots: list[Any] = []
 
-    def add_modifier(self, mod: Any) -> None:
+    async def add_modifier(self, mod: Any) -> None:
         self.mods.append(mod)
 
     def add_dot(self, dot: Any) -> None:

--- a/backend/tests/test_effects.py
+++ b/backend/tests/test_effects.py
@@ -283,7 +283,7 @@ async def test_stat_modifier_applies_and_expires():
         atk=5,
         defense_mult=2,
     )
-    manager.add_modifier(mod)
+    await manager.add_modifier(mod)
     assert stats.atk == 15
     assert stats.defense == 40
     await manager.tick()

--- a/backend/tests/test_enrage_progress_updates.py
+++ b/backend/tests/test_enrage_progress_updates.py
@@ -35,7 +35,7 @@ class DummyEffectManager:
     async def on_action(self, *_: object) -> bool:  # pragma: no cover - unused
         return True
 
-    def add_modifier(self, mod: DummyMod) -> None:
+    async def add_modifier(self, mod: DummyMod) -> None:
         self.mods.append(mod)
 
 

--- a/backend/tests/test_summons_system.py
+++ b/backend/tests/test_summons_system.py
@@ -676,7 +676,7 @@ async def test_summon_inherits_beneficial_effects(monkeypatch):
         deltas={"crit_rate": 0.1},  # +10% crit rate - beneficial
         multipliers={"crit_damage": 1.5}  # 1.5x crit damage - beneficial
     )
-    summoner.effect_manager.add_modifier(stat_mod)
+    await summoner.effect_manager.add_modifier(stat_mod)
 
     # Create summon with 50% stat inheritance
     summon = Summon.create_from_summoner(
@@ -773,7 +773,7 @@ async def test_summon_does_not_inherit_harmful_effects(monkeypatch):
         deltas={"crit_rate": -0.1},  # -10% crit rate - harmful
         multipliers={"crit_damage": 0.5}  # 0.5x crit damage - harmful
     )
-    summoner.effect_manager.add_modifier(harmful_mod)
+    await summoner.effect_manager.add_modifier(harmful_mod)
 
     # Create summon
     summon = Summon.create_from_summoner(

--- a/backend/tests/test_turn_loop_summon_updates.py
+++ b/backend/tests/test_turn_loop_summon_updates.py
@@ -48,7 +48,7 @@ class DummyEffectManager:
     def add_hot(self, *_):  # pragma: no cover - simple stub
         return None
 
-    def add_modifier(self, *_):  # pragma: no cover - simple stub
+    async def add_modifier(self, *_):  # pragma: no cover - simple stub
         return None
 
 


### PR DESCRIPTION
## Summary
- update `EffectManager.add_modifier` to return an awaitable and emit batched events asynchronously
- make card and relic base classes (and their concrete event hooks) await modifier registration while ensuring managers exist
- adjust summon effect sharing plus unit tests to handle coroutine-based modifier application

## Testing
- uv run pytest backend/tests/test_effects.py
- uv run pytest backend/tests/test_summons_system.py
- uv run pytest backend/tests/backend/rooms/battle/test_enrage.py

------
https://chatgpt.com/codex/tasks/task_b_68eab472eea4832cbf80ab420d855f81