### PR TITLE
fix: await effect helpers after async conversion

### DIFF
--- a/backend/autofighter/rooms/battle/enrage.py
+++ b/backend/autofighter/rooms/battle/enrage.py
@@ -132,7 +132,7 @@ async def update_enrage_state(
                 atk_mult=mult,
                 turns=9999,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             enrage_mods[idx] = mod
         state.stacks = new_stacks
         if turn > catastrophic_turn_threshold:
@@ -177,7 +177,7 @@ async def apply_enrage_bleed(
         max_hp = max(getattr(mgr.stats, "max_hp", 1), 1)
         for _ in range(stacks_to_add):
             dmg_per_tick = int(max_hp * party_bleed_ratio)
-            mgr.add_dot(
+            await mgr.add_dot(
                 damage_over_time_factory(
                     "Enrage Bleed",
                     dmg_per_tick,
@@ -189,7 +189,7 @@ async def apply_enrage_bleed(
         max_hp = max(getattr(foe_obj, "max_hp", 1), 1)
         for _ in range(stacks_to_add):
             dmg_per_tick = int(max_hp * foe_bleed_ratio)
-            mgr.add_dot(
+            await mgr.add_dot(
                 damage_over_time_factory(
                     "Enrage Bleed",
                     dmg_per_tick,

--- a/backend/plugins/cards/_base.py
+++ b/backend/plugins/cards/_base.py
@@ -66,7 +66,7 @@ class CardBase:
                 mod = create_stat_buff(
                     member, name=f"{self.id}_{attr}", turns=9999, **changes
                 )
-                mgr.add_modifier(mod)
+                await mgr.add_modifier(mod)
 
                 # Emit card effect event
                 await BUS.emit_async(

--- a/backend/plugins/cards/balanced_diet.py
+++ b/backend/plugins/cards/balanced_diet.py
@@ -34,7 +34,7 @@ class BalancedDiet(CardBase):
                     turns=1,
                     defense_mult=1.02  # +2% DEF
                 )
-                effect_manager.add_modifier(def_mod)
+                await effect_manager.add_modifier(def_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/critical_overdrive.py
+++ b/backend/plugins/cards/critical_overdrive.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.party import Party
 from autofighter.stats import BUS
@@ -43,7 +44,11 @@ class CriticalOverdrive(CardBase):
                     crit_rate=extra_rate,
                     crit_damage=excess * 2,
                 )
-                target.effect_manager.add_modifier(new_mod)
+                mgr = getattr(target, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(target)
+                    target.effect_manager = mgr
+                await mgr.add_modifier(new_mod)
                 state[pid] = new_mod
                 await BUS.emit_async(
                     "card_effect",

--- a/backend/plugins/cards/critical_transfer.py
+++ b/backend/plugins/cards/critical_transfer.py
@@ -46,7 +46,7 @@ class CriticalTransfer(CardBase):
                 turns=1,
                 atk_mult=1 + 0.04 * total,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             await BUS.emit_async(
                 "card_effect",
                 self.id,

--- a/backend/plugins/cards/elemental_spark.py
+++ b/backend/plugins/cards/elemental_spark.py
@@ -39,7 +39,7 @@ class ElementalSpark(CardBase):
                 turns=9999,
                 effect_hit_rate_mult=1.05,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             chosen["mod"] = (mgr, mod)
             await BUS.emit_async(
                 "card_effect",

--- a/backend/plugins/cards/enduring_charm.py
+++ b/backend/plugins/cards/enduring_charm.py
@@ -44,7 +44,7 @@ class EnduringCharm(CardBase):
                         turns=2,
                         vitality_mult=1.03,
                     )
-                    effect_manager.add_modifier(vit_mod)
+                    await effect_manager.add_modifier(vit_mod)
 
                     log = logging.getLogger(__name__)
                     log.debug(

--- a/backend/plugins/cards/enduring_will.py
+++ b/backend/plugins/cards/enduring_will.py
@@ -63,7 +63,7 @@ class EnduringWill(CardBase):
                             member, name=f"{self.id}_mitigation_bonus", turns=20,
                             mitigation_mult=1.002  # +0.2% mitigation
                         )
-                        mgr.add_modifier(mod)
+                        await mgr.add_modifier(mod)
 
                         import logging
                         log = logging.getLogger(__name__)

--- a/backend/plugins/cards/farsight_scope.py
+++ b/backend/plugins/cards/farsight_scope.py
@@ -37,7 +37,7 @@ class FarsightScope(CardBase):
                         turns=1,
                         crit_rate=0.06,
                     )
-                    effect_manager.add_modifier(crit_mod)
+                    await effect_manager.add_modifier(crit_mod)
 
                     log.debug(
                         "Farsight Scope low HP bonus: %s gains +6%% crit rate vs %s",

--- a/backend/plugins/cards/inspiring_banner.py
+++ b/backend/plugins/cards/inspiring_banner.py
@@ -42,7 +42,7 @@ class InspiringBanner(CardBase):
                         turns=2,
                         atk_mult=1.02  # +2% ATK
                     )
-                    effect_manager.add_modifier(atk_mod)
+                    await effect_manager.add_modifier(atk_mod)
 
                     import logging
                     log = logging.getLogger(__name__)

--- a/backend/plugins/cards/iron_guard.py
+++ b/backend/plugins/cards/iron_guard.py
@@ -43,6 +43,6 @@ class IronGuard(CardBase):
                     turns=1,
                     defense_mult=1.10,
                 )
-                mgr.add_modifier(mod)
+                await mgr.add_modifier(mod)
 
         self.subscribe("damage_taken", _damage_taken)

--- a/backend/plugins/cards/keen_goggles.py
+++ b/backend/plugins/cards/keen_goggles.py
@@ -75,7 +75,7 @@ class KeenGoggles(CardBase):
                 crit_rate_mult=1 + (new_stacks * 0.01),
             )
             setattr(crit_mod, "source", source)
-            effect_manager.add_modifier(crit_mod)
+            await effect_manager.add_modifier(crit_mod)
 
             import logging
 

--- a/backend/plugins/cards/overclock.py
+++ b/backend/plugins/cards/overclock.py
@@ -59,7 +59,7 @@ class Overclock(CardBase):
                 _refresh_action_timings(ally)
 
             modifier.remove = _remove_and_refresh  # type: ignore[assignment]
-            manager.add_modifier(modifier)
+            await manager.add_modifier(modifier)
 
             await BUS.emit_async(
                 "card_effect",

--- a/backend/plugins/cards/polished_shield.py
+++ b/backend/plugins/cards/polished_shield.py
@@ -46,7 +46,7 @@ class PolishedShield(CardBase):
                 turns=1,
                 defense=3
             )
-            effect_manager.add_modifier(def_mod)
+            await effect_manager.add_modifier(def_mod)
 
             import logging
             log = logging.getLogger(__name__)

--- a/backend/plugins/cards/precision_sights.py
+++ b/backend/plugins/cards/precision_sights.py
@@ -36,7 +36,7 @@ class PrecisionSights(CardBase):
                     turns=2,
                     crit_damage_mult=1.02  # +2% crit damage
                 )
-                effect_manager.add_modifier(crit_damage_mod)
+                await effect_manager.add_modifier(crit_damage_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/reality_split.py
+++ b/backend/plugins/cards/reality_split.py
@@ -54,7 +54,7 @@ class RealitySplit(CardBase):
             if entity is None or entity in members or entity is party:
                 _cleanup()
 
-        def _turn_start_handler(*_args) -> None:
+        async def _turn_start_handler(*_args) -> None:
             if not party.members:
                 return
             target = random.choice(party.members)
@@ -69,7 +69,7 @@ class RealitySplit(CardBase):
                 turns=1,
                 crit_rate=0.5,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
 
         async def _hit_landed(attacker, _target, amount, *_args) -> None:
             if attacker is not state["active"]:

--- a/backend/plugins/cards/sharpening_stone.py
+++ b/backend/plugins/cards/sharpening_stone.py
@@ -34,7 +34,7 @@ class SharpeningStone(CardBase):
                     turns=2,
                     crit_damage_mult=1.02  # +2% crit damage
                 )
-                effect_manager.add_modifier(crit_damage_mod)
+                await effect_manager.add_modifier(crit_damage_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/steel_bangles.py
+++ b/backend/plugins/cards/steel_bangles.py
@@ -37,7 +37,7 @@ class SteelBangles(CardBase):
                         turns=1,  # Lasts for 1 turn
                         atk_mult=0.97  # 3% damage reduction
                     )
-                    effect_manager.add_modifier(attack_debuff)
+                    await effect_manager.add_modifier(attack_debuff)
 
                     import logging
                     log = logging.getLogger(__name__)

--- a/backend/plugins/cards/swift_bandanna.py
+++ b/backend/plugins/cards/swift_bandanna.py
@@ -34,7 +34,7 @@ class SwiftBandanna(CardBase):
                     turns=1,
                     crit_rate_mult=1.01  # +1% crit rate
                 )
-                effect_manager.add_modifier(crit_mod)
+                await effect_manager.add_modifier(crit_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/swift_footwork.py
+++ b/backend/plugins/cards/swift_footwork.py
@@ -49,7 +49,7 @@ class SwiftFootwork(CardBase):
                     turns=2,
                     spd_mult=1.3,
                 )
-                mgr.add_modifier(burst)
+                await mgr.add_modifier(burst)
                 await BUS.emit_async(
                     "card_effect",
                     self.id,

--- a/backend/plugins/cards/tactical_kit.py
+++ b/backend/plugins/cards/tactical_kit.py
@@ -51,7 +51,7 @@ class TacticalKit(CardBase):
                             turns=1,
                             atk_mult=1.02  # +2% ATK
                         )
-                        effect_manager.add_modifier(atk_mod)
+                        await effect_manager.add_modifier(atk_mod)
 
                         import logging
                         log = logging.getLogger(__name__)

--- a/backend/plugins/cards/temporal_shield.py
+++ b/backend/plugins/cards/temporal_shield.py
@@ -36,7 +36,7 @@ class TemporalShield(CardBase):
                         turns=1,
                         mitigation_mult=100.0,
                     )
-                    mgr.add_modifier(mod)
+                    await mgr.add_modifier(mod)
                     await BUS.emit_async(
                         "card_effect",
                         self.id,

--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -45,7 +45,7 @@ class VitalCore(CardBase):
                         turns=2,
                         vitality_mult=1.03,
                     )
-                    effect_manager.add_modifier(vit_mod)
+                    await effect_manager.add_modifier(vit_mod)
 
                     log = logging.getLogger(__name__)
                     log.debug(

--- a/backend/plugins/cards/vital_surge.py
+++ b/backend/plugins/cards/vital_surge.py
@@ -5,6 +5,7 @@ from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.cards._base import CardBase
+from plugins.cards._base import safe_async_task
 
 
 @dataclass
@@ -35,7 +36,7 @@ class VitalSurge(CardBase):
                     atk_mult=1.55,
                 )
                 active[pid] = mod
-                mgr.add_modifier(mod)
+                await mgr.add_modifier(mod)
                 await BUS.emit_async(
                     "card_effect",
                     self.id,
@@ -55,15 +56,15 @@ class VitalSurge(CardBase):
 
         def _turn_start() -> None:
             for m in party.members:
-                _check(m)
+                safe_async_task(_check(m))
 
         def _damage_taken(victim, *_args) -> None:
             if victim in party.members:
-                _check(victim)
+                safe_async_task(_check(victim))
 
         def _heal_received(member, *_args) -> None:
             if member in party.members:
-                _check(member)
+                safe_async_task(_check(member))
 
         self.subscribe("turn_start", _turn_start)
         self.subscribe("damage_taken", _damage_taken)

--- a/backend/plugins/damage_types/fire.py
+++ b/backend/plugins/damage_types/fire.py
@@ -64,7 +64,7 @@ class Fire(DamageTypeBase):
                 mgr = EffectManager(foe)
                 foe.effect_manager = mgr
             try:
-                mgr.maybe_inflict_dot(actor, dealt)
+                await mgr.maybe_inflict_dot(actor, dealt)
             except Exception:
                 pass
         return True

--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -27,7 +27,7 @@ class Light(DamageTypeBase):
             if mgr is not None:
                 hot = damage_effects.create_hot(self.id, actor)
                 if hot is not None:
-                    mgr.add_hot(hot)
+                    await mgr.add_hot(hot)
             await pace_sleep(YIELD_MULTIPLIER)
 
         for ally in allies:
@@ -100,7 +100,7 @@ class Light(DamageTypeBase):
                 turns=10,
                 defense_mult=0.75,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             await pace_sleep(YIELD_MULTIPLIER)
 
         await BUS.emit_async("light_ultimate", actor)

--- a/backend/plugins/damage_types/lightning.py
+++ b/backend/plugins/damage_types/lightning.py
@@ -61,7 +61,7 @@ class Lightning(DamageTypeBase):
                 for _ in range(10):
                     effect = damage_effects.create_dot(random.choice(types), dmg, actor)
                     if effect is not None:
-                        mgr.add_dot(effect)
+                        await mgr.add_dot(effect)
                     await pace_sleep(YIELD_MULTIPLIER)
 
         # Set up aftertaste stacks

--- a/backend/plugins/damage_types/wind.py
+++ b/backend/plugins/damage_types/wind.py
@@ -66,7 +66,7 @@ class Wind(DamageTypeBase):
             turns=1,
             effect_hit_rate_mult=1.5,
         )
-        a_mgr.add_modifier(eh_mod)
+        await a_mgr.add_modifier(eh_mod)
 
         # Determine dynamic hit count (allow cards/relics to override via attributes)
         hits = int(getattr(actor, "wind_ultimate_hits", getattr(actor, "ultimate_hits", 25)) or 25)
@@ -121,7 +121,7 @@ class Wind(DamageTypeBase):
                         f_mgr = EffectManager(foe)
                         foe.effect_manager = f_mgr
                     effect_managers[foe] = f_mgr
-                f_mgr.maybe_inflict_dot(actor, dmg)
+                await f_mgr.maybe_inflict_dot(actor, dmg)
             except Exception:
                 pass
 

--- a/backend/plugins/dots/abyssal_corruption.py
+++ b/backend/plugins/dots/abyssal_corruption.py
@@ -8,5 +8,5 @@ class AbyssalCorruption(DamageOverTime):
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Abyssal Corruption", damage, turns, self.id)
 
-    def on_death(self, target_manager) -> None:
-        target_manager.add_dot(AbyssalCorruption(self.damage, self.turns))
+    async def on_death(self, target_manager) -> None:
+        await target_manager.add_dot(AbyssalCorruption(self.damage, self.turns))

--- a/backend/plugins/dots/celestial_atrophy.py
+++ b/backend/plugins/dots/celestial_atrophy.py
@@ -22,7 +22,7 @@ class CelestialAtrophy(DamageOverTime):
                 turns=self.turns,
                 atk=-1,
             )
-            manager.add_modifier(mod)
+            await manager.add_modifier(mod)
             self._mods.append(mod)
         alive = await super().tick(target)
         if not alive and manager is not None:

--- a/backend/plugins/passives/normal/ally_overload.py
+++ b/backend/plugins/passives/normal/ally_overload.py
@@ -94,7 +94,7 @@ class AllyOverload:
             em.hots.clear()
             target.hots.clear()
 
-            def _block_hot(self_em, *_: object, **__: object) -> None:
+            async def _block_hot(self_em, *_: object, **__: object) -> None:
                 return None
 
             self._add_hot_backup[entity_id] = em.add_hot

--- a/backend/plugins/passives/normal/bubbles_bubble_burst.py
+++ b/backend/plugins/passives/normal/bubbles_bubble_burst.py
@@ -113,7 +113,7 @@ class BubblesBubbleBurst:
                 if mgr is None:
                     mgr = EffectManager(combatant)
                     combatant.effect_manager = mgr
-                mgr.maybe_inflict_dot(bubbles, damage, turns=2)
+                await mgr.maybe_inflict_dot(bubbles, damage, turns=2)
 
     @classmethod
     def get_bubble_stacks(cls, bubbles: "Stats", enemy: "Stats") -> int:

--- a/backend/plugins/passives/normal/casno_phoenix_respite.py
+++ b/backend/plugins/passives/normal/casno_phoenix_respite.py
@@ -64,10 +64,10 @@ class CasnoPhoenixRespite:
             return
 
         cls._action_counts[entity_id] = 0
-        cls._schedule_rest(target)
+        await cls._schedule_rest(target)
 
     @classmethod
-    def _schedule_rest(cls, target: "Stats") -> None:
+    async def _schedule_rest(cls, target: "Stats") -> None:
         if getattr(target, "hp", 0) <= 0:
             return
 
@@ -93,7 +93,7 @@ class CasnoPhoenixRespite:
 
         cls._pending_rest[entity_id] = True
         cls._helper_effect_ids[entity_id] = helper_id
-        effect_manager.add_hot(helper_effect)
+        await effect_manager.add_hot(helper_effect)
         cls._register_battle_end(target)
 
     @classmethod

--- a/backend/plugins/relics/_base.py
+++ b/backend/plugins/relics/_base.py
@@ -56,7 +56,7 @@ class RelicBase:
             if not changes:
                 continue
             mod = create_stat_buff(member, name=self.id, turns=9999, **changes)
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             mods.append(mod)
 
             # Emit relic effect tracking for stat modifications

--- a/backend/plugins/relics/bent_dagger.py
+++ b/backend/plugins/relics/bent_dagger.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -35,7 +36,11 @@ class BentDagger(RelicBase):
 
             for member in party.members:
                 mod = create_stat_buff(member, name=f"{self.id}_kill", atk_mult=1.01, turns=9999)
-                member.effect_manager.add_modifier(mod)
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+                await mgr.add_modifier(mod)
 
                 # Track the ATK buff application
                 await BUS.emit_async("relic_effect", "bent_dagger", member, "atk_boost_applied", 1, {

--- a/backend/plugins/relics/guardian_charm.py
+++ b/backend/plugins/relics/guardian_charm.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from plugins.relics._base import RelicBase
 
@@ -44,7 +45,11 @@ class GuardianCharm(RelicBase):
         mod = create_stat_buff(
             member, name=self.id, defense_mult=1 + 0.2 * stacks, turns=9999
         )
-        member.effect_manager.add_modifier(mod)
+        mgr = getattr(member, "effect_manager", None)
+        if mgr is None:
+            mgr = EffectManager(member)
+            member.effect_manager = mgr
+        await mgr.add_modifier(mod)
 
     def describe(self, stacks: int) -> str:
         pct = 20 * stacks

--- a/backend/plugins/relics/killer_instinct.py
+++ b/backend/plugins/relics/killer_instinct.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.characters._base import PlayerBase
@@ -68,7 +69,11 @@ class KillerInstinct(RelicBase):
             })
 
             mod = create_stat_buff(user, name=f"{self.id}_atk", atk_mult=atk_mult, turns=1)
-            user.effect_manager.add_modifier(mod)
+            mgr = getattr(user, "effect_manager", None)
+            if mgr is None:
+                mgr = EffectManager(user)
+                user.effect_manager = mgr
+            await mgr.add_modifier(mod)
             _remove_buff(ultimate_buffs, id(user))
             ultimate_buffs[id(user)] = (user, mod)
 
@@ -108,7 +113,11 @@ class KillerInstinct(RelicBase):
                     spd_mult=speed_mult,
                     turns=2,
                 )
-                attacker.effect_manager.add_modifier(mod)
+                mgr = getattr(attacker, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(attacker)
+                    attacker.effect_manager = mgr
+                await mgr.add_modifier(mod)
                 speed_buffs[id(attacker)] = (attacker, mod)
 
         def _turn_end(*_args) -> None:

--- a/backend/plugins/relics/null_lantern.py
+++ b/backend/plugins/relics/null_lantern.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -81,7 +82,11 @@ class NullLantern(RelicBase):
                 max_hp_mult=mult,
                 hp_mult=mult,
             )
-            entity.effect_manager.add_modifier(mod)
+            mgr = getattr(entity, "effect_manager", None)
+            if mgr is None:
+                mgr = EffectManager(entity)
+                entity.effect_manager = mgr
+            await mgr.add_modifier(mod)
 
             await BUS.emit_async(
                 "relic_effect",

--- a/backend/plugins/relics/omega_core.py
+++ b/backend/plugins/relics/omega_core.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -59,7 +60,11 @@ class OmegaCore(RelicBase):
                     vitality_mult=mult,
                     mitigation_mult=mult,
                 )
-                member.effect_manager.add_modifier(mod)
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+                await mgr.add_modifier(mod)
                 safe_async_task(member.apply_healing(member.max_hp))
                 state["mods"][id(member)] = mod
             state["turn"] = 0

--- a/backend/plugins/relics/paradox_hourglass.py
+++ b/backend/plugins/relics/paradox_hourglass.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from dataclasses import field
 import random
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -41,7 +42,11 @@ class ParadoxHourglass(RelicBase):
                     defense=new_def - base_def,
                     turns=9999,
                 )
-                entity.effect_manager.add_modifier(mod)
+                mgr = getattr(entity, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(entity)
+                    entity.effect_manager = mgr
+                await mgr.add_modifier(mod)
                 state["foe"][id(entity)] = mod
 
                 # Track foe defense reduction
@@ -102,7 +107,11 @@ class ParadoxHourglass(RelicBase):
                     vitality_mult=mult,
                     mitigation_mult=mult,
                 )
-                m.effect_manager.add_modifier(mod)
+                mgr = getattr(m, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(m)
+                    m.effect_manager = mgr
+                await mgr.add_modifier(mod)
                 m.hp = m.max_hp
                 state["buffs"][id(m)] = mod
 

--- a/backend/plugins/relics/shiny_pebble.py
+++ b/backend/plugins/relics/shiny_pebble.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -42,7 +43,11 @@ class ShinyPebble(RelicBase):
                 mitigation=target.mitigation * (mit_mult - 1),
                 turns=1,
             )
-            target.effect_manager.add_modifier(mod)
+            mgr = getattr(target, "effect_manager", None)
+            if mgr is None:
+                mgr = EffectManager(target)
+                target.effect_manager = mgr
+            await mgr.add_modifier(mod)
             current_state["active"][id(target)] = (target, mod)
 
             # Track mitigation burst application

--- a/backend/plugins/relics/soul_prism.py
+++ b/backend/plugins/relics/soul_prism.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -39,13 +40,14 @@ class SoulPrism(RelicBase):
                 base = getattr(member, "_soul_prism_hp", member.max_hp)
                 member._soul_prism_hp = base
                 mod_id = f"{self.id}_{id(member)}"
-                existing = next(
-                    (m for m in member.effect_manager.mods if m.id == mod_id),
-                    None,
-                )
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+                existing = next((m for m in mgr.mods if m.id == mod_id), None)
                 if existing:
                     existing.remove()
-                    member.effect_manager.mods.remove(existing)
+                    mgr.mods.remove(existing)
                     if existing.id in member.mods:
                         member.mods.remove(existing.id)
                 mod = create_stat_buff(
@@ -57,7 +59,7 @@ class SoulPrism(RelicBase):
                     mitigation_mult=1 + buff,
                     turns=9999,
                 )
-                member.effect_manager.add_modifier(mod)
+                await mgr.add_modifier(mod)
                 heal = max(1, int(member.max_hp * 0.01))
 
                 # Track the revival

--- a/backend/plugins/relics/stellar_compass.py
+++ b/backend/plugins/relics/stellar_compass.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -42,7 +43,11 @@ class StellarCompass(RelicBase):
                 atk_mult=atk_mult,
                 turns=9999,
             )
-            attacker.effect_manager.add_modifier(mod)
+            mgr = getattr(attacker, "effect_manager", None)
+            if mgr is None:
+                mgr = EffectManager(attacker)
+                attacker.effect_manager = mgr
+            await mgr.add_modifier(mod)
             current_state["gold"] += 0.015 * copies
 
             # Track critical hit buff application

--- a/backend/plugins/relics/tattered_flag.py
+++ b/backend/plugins/relics/tattered_flag.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.relics._base import RelicBase
@@ -38,7 +39,11 @@ class TatteredFlag(RelicBase):
 
             for member in survivors:
                 mod = create_stat_buff(member, name=f"{self.id}_buff", atk_mult=1.03, turns=9999)
-                member.effect_manager.add_modifier(mod)
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+                await mgr.add_modifier(mod)
 
         self.subscribe(party, "damage_taken", _fallen)
 

--- a/backend/plugins/relics/timekeepers_hourglass.py
+++ b/backend/plugins/relics/timekeepers_hourglass.py
@@ -80,7 +80,7 @@ class TimekeepersHourglass(RelicBase):
                         spd_mult=boost,
                         turns=2,
                     )
-                    mgr.add_modifier(mod)
+                    await mgr.add_modifier(mod)
                     active_mods[id(member)] = mod
 
         def _battle_end(_entity) -> None:

--- a/backend/plugins/relics/travelers_charm.py
+++ b/backend/plugins/relics/travelers_charm.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.characters._base import PlayerBase
@@ -63,7 +64,11 @@ class TravelersCharm(RelicBase):
                     defense_mult=1 + d_pct,
                     mitigation_mult=1 + m_pct,
                 )
-                member.effect_manager.add_modifier(mod)
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+                await mgr.add_modifier(mod)
                 active[pid] = (member, mod)
                 applied_count += 1
 

--- a/backend/plugins/relics/wooden_idol.py
+++ b/backend/plugins/relics/wooden_idol.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from dataclasses import field
 
+from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
 from plugins.characters._base import PlayerBase
@@ -52,7 +53,11 @@ class WoodenIdol(RelicBase):
                     effect_resistance=bonus,
                     turns=1,
                 )
-                member.effect_manager.add_modifier(mod)
+                mgr = getattr(member, "effect_manager", None)
+                if mgr is None:
+                    mgr = EffectManager(member)
+                    member.effect_manager = mgr
+                await mgr.add_modifier(mod)
                 active[pid] = (member, mod)
                 applied_count += 1
 

--- a/backend/tests/test_800_dots_performance.py
+++ b/backend/tests/test_800_dots_performance.py
@@ -39,7 +39,7 @@ async def test_many_dots_performance():
             id=f"dot_{i}",
             source=target
         )
-        manager.add_dot(dot)
+        await manager.add_dot(dot)
 
     print(f"Added {len(manager.dots)} DOT effects")
     print(f"Target HP: {target.hp}/{target.max_hp}")

--- a/backend/tests/test_async_dot_optimizations.py
+++ b/backend/tests/test_async_dot_optimizations.py
@@ -26,7 +26,7 @@ async def test_small_dot_count_still_logs_individually():
     # Add 5 DOTs (below the 10 threshold)
     for i in range(5):
         dot = DamageOverTime(f"dot_{i}", damage=1, turns=2, id=f"dot_{i}", source=target)
-        manager.add_dot(dot)
+        await manager.add_dot(dot)
 
     # Should still log individually
     await manager.tick()
@@ -48,7 +48,7 @@ async def test_large_dot_count_uses_batch_processing():
     # Add 100 DOTs (above the 20 threshold for parallel processing)
     for i in range(100):
         dot = DamageOverTime(f"dot_{i}", damage=1, turns=2, id=f"dot_{i}", source=target)
-        manager.add_dot(dot)
+        await manager.add_dot(dot)
 
     initial_hp = target.hp
     await manager.tick()
@@ -74,8 +74,8 @@ async def test_mixed_dots_and_hots():
     for i in range(30):
         dot = DamageOverTime(f"dot_{i}", damage=2, turns=3, id=f"dot_{i}", source=target)
         hot = HealingOverTime(f"hot_{i}", healing=1, turns=3, id=f"hot_{i}", source=target)
-        manager.add_dot(dot)
-        manager.add_hot(hot)
+        await manager.add_dot(dot)
+        await manager.add_hot(hot)
 
     initial_hp = target.hp
     await manager.tick()
@@ -103,7 +103,7 @@ async def test_dot_expiration_with_optimizations():
     for i in range(25):
         turns = 1 if i < 10 else 2  # 10 expire after 1 tick, 15 after 2 ticks
         dot = DamageOverTime(f"dot_{i}", damage=1, turns=turns, id=f"dot_{i}", source=target)
-        manager.add_dot(dot)
+        await manager.add_dot(dot)
 
     # First tick - 10 should expire
     await manager.tick()
@@ -129,11 +129,11 @@ async def test_dead_characters_dont_receive_dots_or_hots():
 
     # Try to add DOT to dead character
     dot = DamageOverTime("test_dot", damage=10, turns=3, id="test_dot", source=source)
-    manager.add_dot(dot)
+    await manager.add_dot(dot)
 
     # Try to add HOT to dead character
     hot = HealingOverTime("test_hot", healing=5, turns=2, id="test_hot", source=source)
-    manager.add_hot(hot)
+    await manager.add_hot(hot)
 
     # Verify no effects were added
     assert len(manager.dots) == 0
@@ -157,11 +157,11 @@ async def test_living_characters_can_still_receive_effects():
 
     # Add DOT to living character
     dot = DamageOverTime("test_dot", damage=10, turns=3, id="test_dot", source=source)
-    manager.add_dot(dot)
+    await manager.add_dot(dot)
 
     # Add HOT to living character
     hot = HealingOverTime("test_hot", healing=5, turns=2, id="test_hot", source=source)
-    manager.add_hot(hot)
+    await manager.add_hot(hot)
 
     # Verify effects were added
     assert len(manager.dots) == 1

--- a/backend/tests/test_card_effects.py
+++ b/backend/tests/test_card_effects.py
@@ -190,7 +190,7 @@ async def test_mindful_tassel_boosts_first_debuff():
         id="bleed",
         source=ally,
     )
-    mgr.add_dot(bleed)
+    await mgr.add_dot(bleed)
     loop.run_until_complete(asyncio.sleep(0))
     assert bleed.damage == 105
     assert bleed.turns == 11
@@ -202,7 +202,7 @@ async def test_mindful_tassel_boosts_first_debuff():
         id="poison",
         source=ally,
     )
-    mgr.add_dot(poison)
+    await mgr.add_dot(poison)
     loop.run_until_complete(asyncio.sleep(0))
     assert poison.damage == 100
     assert poison.turns == 10

--- a/backend/tests/test_celestial_atrophy.py
+++ b/backend/tests/test_celestial_atrophy.py
@@ -14,7 +14,7 @@ async def test_celestial_atrophy_stacks_and_cleans_up():
     target.effect_manager = manager
 
     dot = CelestialAtrophy(0, 3)
-    manager.add_dot(dot)
+    await manager.add_dot(dot)
 
     await manager.tick()
     assert target.atk == 9

--- a/backend/tests/test_character_passives.py
+++ b/backend/tests/test_character_passives.py
@@ -309,7 +309,7 @@ async def test_ally_overload_battle_end_restores_hots():
     assert ally.effect_manager.add_hot is not original_add_hot
 
     blocked_hot = HealingOverTime("blocked", 5, 2, "blocked")
-    ally.effect_manager.add_hot(blocked_hot)
+    await ally.effect_manager.add_hot(blocked_hot)
     assert not ally.effect_manager.hots
     assert not ally.hots
 
@@ -320,7 +320,7 @@ async def test_ally_overload_battle_end_restores_hots():
     assert ally.effect_manager.add_hot.__func__ is original_add_hot.__func__
 
     restored_hot = HealingOverTime("restored", 7, 3, "restored")
-    ally.effect_manager.add_hot(restored_hot)
+    await ally.effect_manager.add_hot(restored_hot)
 
     assert ally.effect_manager.hots == [restored_hot]
     assert ally.hots == [restored_hot.id]

--- a/backend/tests/test_dark_ultimate.py
+++ b/backend/tests/test_dark_ultimate.py
@@ -27,8 +27,9 @@ def test_dark_ultimate_dot_scaling(monkeypatch):
     ally = Stats()
     actor.effect_manager = EffectManager(actor)
     ally.effect_manager = EffectManager(ally)
-    actor.effect_manager.add_dot(DamageOverTime("d1", 1, 1, "d1"))
-    ally.effect_manager.add_dot(DamageOverTime("d2", 1, 1, "d2"))
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(actor.effect_manager.add_dot(DamageOverTime("d1", 1, 1, "d1")))
+    loop.run_until_complete(ally.effect_manager.add_dot(DamageOverTime("d2", 1, 1, "d2")))
 
     target = Stats()
     actor.allies = [actor, ally]

--- a/backend/tests/test_effect_resisted_cards.py
+++ b/backend/tests/test_effect_resisted_cards.py
@@ -47,7 +47,8 @@ def _trigger_resist(target: Stats, attacker: Stats) -> None:
         target.effect_manager = manager
 
     with patch("autofighter.effects.random.random", return_value=1.0):
-        manager.maybe_inflict_dot(attacker, 100)
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(manager.maybe_inflict_dot(attacker, 100))
 
 
 def test_calm_beads_grants_charge_on_resist():

--- a/backend/tests/test_effect_serialization.py
+++ b/backend/tests/test_effect_serialization.py
@@ -1,3 +1,5 @@
+import asyncio
+
 from autofighter.effects import DamageOverTime
 from autofighter.effects import EffectManager
 from autofighter.effects import HealingOverTime
@@ -13,9 +15,9 @@ def test_serialize_effect_details():
 
     source = Stats()
     source.id = "s"
-    mgr.add_dot(DamageOverTime("burn", 5, 2, "burn", source))
-    mgr.add_dot(DamageOverTime("burn", 5, 1, "burn", source))
-    mgr.add_hot(HealingOverTime("regen", 3, 1, "regen", source))
+    asyncio.run(mgr.add_dot(DamageOverTime("burn", 5, 2, "burn", source)))
+    asyncio.run(mgr.add_dot(DamageOverTime("burn", 5, 1, "burn", source)))
+    asyncio.run(mgr.add_hot(HealingOverTime("regen", 3, 1, "regen", source)))
 
     target.passives = ["attack_up", "luna_lunar_reservoir", "luna_lunar_reservoir"]
 

--- a/backend/tests/test_frozen_wound.py
+++ b/backend/tests/test_frozen_wound.py
@@ -26,7 +26,7 @@ async def test_frozen_wound_miss_chance(stacks, roll, expect_miss, monkeypatch):
     actor.effect_manager = EffectManager(actor)
     target.effect_manager = EffectManager(target)
     for _ in range(stacks):
-        actor.effect_manager.add_dot(FrozenWound(1, 1))
+        await actor.effect_manager.add_dot(FrozenWound(1, 1))
     monkeypatch.setattr("plugins.dots.frozen_wound.random.random", lambda: roll)
     proceed = await actor.effect_manager.on_action()
     if proceed:

--- a/backend/tests/test_lady_echo_resonant_static.py
+++ b/backend/tests/test_lady_echo_resonant_static.py
@@ -17,8 +17,8 @@ async def test_chain_bonus_counts_effect_manager_dots():
 
     target = Stats()
     target.effect_manager = EffectManager(target)
-    target.effect_manager.add_dot(DamageOverTime("d1", 1, 1, "d1"))
-    target.effect_manager.add_dot(DamageOverTime("d2", 1, 1, "d2"))
+    await target.effect_manager.add_dot(DamageOverTime("d1", 1, 1, "d1"))
+    await target.effect_manager.add_dot(DamageOverTime("d2", 1, 1, "d2"))
 
     passive = LadyEchoResonantStatic()
     await passive.apply(attacker, hit_target=target)

--- a/backend/tests/test_lady_light_radiant_aegis.py
+++ b/backend/tests/test_lady_light_radiant_aegis.py
@@ -36,7 +36,7 @@ async def test_radiant_aegis_hot_event_applies_shields():
     hot = RadiantRegeneration(healer)
     hot.healing = 8  # Boost base healing so scaling is visible
     hot.source = healer
-    ally.effect_manager.add_hot(hot)
+    await ally.effect_manager.add_hot(hot)
 
     await asyncio.sleep(0.05)
 
@@ -61,7 +61,7 @@ async def test_radiant_aegis_dot_cleanse_triggers_on_light_ultimate():
     ally.hp = ally.max_hp - 100
     healer.effect_manager = EffectManager(healer)
     ally.effect_manager = EffectManager(ally)
-    ally.effect_manager.add_dot(Bleed(10, 3))
+    await ally.effect_manager.add_dot(Bleed(10, 3))
 
     await passive.apply(healer)
 

--- a/backend/tests/test_light_ultimate.py
+++ b/backend/tests/test_light_ultimate.py
@@ -29,7 +29,7 @@ async def test_light_ultimate_heals_and_cleanses():
     actor.effect_manager = EffectManager(actor)
     ally.effect_manager = EffectManager(ally)
     enemy.effect_manager = EffectManager(enemy)
-    ally.effect_manager.add_dot(Bleed(10, 3))
+    await ally.effect_manager.add_dot(Bleed(10, 3))
     actor.add_ultimate_charge(actor.ultimate_charge_max)
     await light.ultimate(actor, [actor, ally], [enemy])
     assert ally.hp == ally.max_hp

--- a/backend/tests/test_lightning_pop.py
+++ b/backend/tests/test_lightning_pop.py
@@ -27,8 +27,8 @@ async def test_lightning_pop_damage_and_stacks():
 
     dot1 = DamageOverTime("Test", 40, 3, "t1", attacker)
     dot2 = DamageOverTime("Test2", 20, 5, "t2", attacker)
-    target.effect_manager.add_dot(dot1)
-    target.effect_manager.add_dot(dot2)
+    await target.effect_manager.add_dot(dot1)
+    await target.effect_manager.add_dot(dot2)
     initial_turns = [d.turns for d in target.effect_manager.dots]
     initial_count = len(target.effect_manager.dots)
     start_hp = target.hp
@@ -68,7 +68,7 @@ async def test_lightning_dot_ticks_do_not_trigger_on_hit():
     target.effect_manager = EffectManager(target)
 
     dot = DamageOverTime("Lightning DoT", 20, 2, "lightning_dot", attacker)
-    target.effect_manager.add_dot(dot)
+    await target.effect_manager.add_dot(dot)
 
     calls: list[bool] = []
     original_apply_damage = target.__class__.apply_damage

--- a/backend/tests/test_optimized_performance.py
+++ b/backend/tests/test_optimized_performance.py
@@ -38,7 +38,7 @@ async def test_optimized_performance():
             id=f"dot_{i}",
             source=target
         )
-        manager.add_dot(dot)
+        await manager.add_dot(dot)
 
     print(f"Added {len(manager.dots)} DOT effects")
     print(f"Target HP: {target.hp}/{target.max_hp}")

--- a/backend/tests/test_status_phase_events.py
+++ b/backend/tests/test_status_phase_events.py
@@ -79,8 +79,8 @@ async def test_status_phase_events_emit_with_pacing(monkeypatch):
     hot = HealingOverTime("regen", healing=10, turns=1, id="hot_1", source=target)
     dot = DamageOverTime("burn", damage=10, turns=1, id="dot_1", source=target)
 
-    manager.add_hot(hot)
-    manager.add_dot(dot)
+    await manager.add_hot(hot)
+    await manager.add_dot(dot)
 
     captured_events: list[tuple[str, tuple[object, ...]]] = []
 
@@ -285,8 +285,8 @@ async def test_status_phase_events_update_snapshot_queue(monkeypatch):
     hot = HealingOverTime("regen", healing=10, turns=1, id="hot_1", source=target)
     dot = DamageOverTime("burn", damage=10, turns=1, id="dot_1", source=target)
 
-    manager.add_hot(hot)
-    manager.add_dot(dot)
+    await manager.add_hot(hot)
+    await manager.add_dot(dot)
 
     set_battle_active(True)
     try:

--- a/backend/tests/test_summons_system.py
+++ b/backend/tests/test_summons_system.py
@@ -665,7 +665,7 @@ async def test_summon_inherits_beneficial_effects(monkeypatch):
         id="test_hot_id",
         source=summoner
     )
-    summoner.effect_manager.add_hot(hot)
+    asyncio.run(summoner.effect_manager.add_hot(hot))
 
     # Add beneficial StatModifier
     stat_mod = StatModifier(
@@ -676,7 +676,7 @@ async def test_summon_inherits_beneficial_effects(monkeypatch):
         deltas={"crit_rate": 0.1},  # +10% crit rate - beneficial
         multipliers={"crit_damage": 1.5}  # 1.5x crit damage - beneficial
     )
-    summoner.effect_manager.add_modifier(stat_mod)
+    asyncio.run(summoner.effect_manager.add_modifier(stat_mod))
 
     # Create summon with 50% stat inheritance
     summon = Summon.create_from_summoner(
@@ -762,7 +762,7 @@ async def test_summon_does_not_inherit_harmful_effects(monkeypatch):
         id="test_dot_id",
         source=summoner
     )
-    summoner.effect_manager.add_dot(dot)
+    asyncio.run(summoner.effect_manager.add_dot(dot))
 
     # Add harmful StatModifier
     harmful_mod = StatModifier(
@@ -773,7 +773,7 @@ async def test_summon_does_not_inherit_harmful_effects(monkeypatch):
         deltas={"crit_rate": -0.1},  # -10% crit rate - harmful
         multipliers={"crit_damage": 0.5}  # 0.5x crit damage - harmful
     )
-    summoner.effect_manager.add_modifier(harmful_mod)
+    asyncio.run(summoner.effect_manager.add_modifier(harmful_mod))
 
     # Create summon
     summon = Summon.create_from_summoner(

--- a/backend/tests/test_turn_loop_summon_updates.py
+++ b/backend/tests/test_turn_loop_summon_updates.py
@@ -42,13 +42,13 @@ class DummyEffectManager:
     async def on_action(self):
         return True
 
-    def maybe_inflict_dot(self, *_):  # pragma: no cover - simple stub
+    async def maybe_inflict_dot(self, *_):  # pragma: no cover - simple stub
         return None
 
-    def add_hot(self, *_):  # pragma: no cover - simple stub
+    async def add_hot(self, *_):  # pragma: no cover - simple stub
         return None
 
-    def add_modifier(self, *_):  # pragma: no cover - simple stub
+    async def add_modifier(self, *_):  # pragma: no cover - simple stub
         return None
 
 

--- a/backend/tests/test_turn_timeout.py
+++ b/backend/tests/test_turn_timeout.py
@@ -34,7 +34,7 @@ class DummyEffectManager:
     async def on_action(self):
         return True
 
-    def maybe_inflict_dot(self, *_):  # pragma: no cover - simple stub
+    async def maybe_inflict_dot(self, *_):  # pragma: no cover - simple stub
         return None
 
 

--- a/backend/tests/test_wind_multi_target.py
+++ b/backend/tests/test_wind_multi_target.py
@@ -16,9 +16,9 @@ async def test_wind_player_hits_all_foes(monkeypatch):
 
     original = EffectManager.maybe_inflict_dot
 
-    def spy(self, attacker, damage, turns=None):
+    async def spy(self, attacker, damage, turns=None):
         calls.append(self.stats.id)
-        return original(self, attacker, damage, turns)
+        return await original(self, attacker, damage, turns)
 
     monkeypatch.setattr(EffectManager, "maybe_inflict_dot", spy)
     node = MapNode(
@@ -57,9 +57,9 @@ async def test_wind_foe_hits_all_party_members(monkeypatch):
 
     original = EffectManager.maybe_inflict_dot
 
-    def spy(self, attacker, damage, turns=None):
+    async def spy(self, attacker, damage, turns=None):
         calls.append(self.stats.id)
-        return original(self, attacker, damage, turns)
+        return await original(self, attacker, damage, turns)
 
     monkeypatch.setattr(EffectManager, "maybe_inflict_dot", spy)
     node = MapNode(

--- a/backend/tests/test_wind_spread_regression.py
+++ b/backend/tests/test_wind_spread_regression.py
@@ -22,7 +22,7 @@ class DummyEffectManager:
     def __init__(self) -> None:
         self.dot_calls: list[tuple[object, float]] = []
 
-    def maybe_inflict_dot(self, member, damage: float) -> None:
+    async def maybe_inflict_dot(self, member, damage: float) -> None:
         self.dot_calls.append((member, damage))
 
 

--- a/backend/tests/test_wind_ultimate_dot_transfer.py
+++ b/backend/tests/test_wind_ultimate_dot_transfer.py
@@ -44,7 +44,7 @@ async def test_wind_ultimate_transfers_from_foes():
 
     dot = BlazingTorment(1, 3)
     dot.source = player
-    foe2.effect_manager.add_dot(dot)
+    await foe2.effect_manager.add_dot(dot)
 
     player.use_ultimate = _use_ultimate.__get__(player, Stats)
 
@@ -93,7 +93,7 @@ async def test_wind_foe_ultimate_transfers_from_allies():
 
     dot = BlazingTorment(1, 3)
     dot.source = foe
-    p2.effect_manager.add_dot(dot)
+    await p2.effect_manager.add_dot(dot)
 
     foe.use_ultimate = _use_ultimate.__get__(foe, Stats)
 


### PR DESCRIPTION
## Summary
- await EffectManager helper coroutines in damage type ultimates, passives, and relic/card scripts
- convert Abyssal Corruption and Bubble Burst logic to async-safe patterns and make Reality Split's turn handler await modifier application
- update tests and stubs to handle asynchronous effect helper APIs

## Testing
- [x] Backend tests (`pytest backend/tests/test_effects.py`)
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68eab46f6d90832c86e939ab20cd8240