### PR TITLE
Refactor summon cloning and Phoenix Respite scheduling to async

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -382,7 +382,7 @@ class EffectManager:
             "current_stacks": len([d for d in self.dots if d.id == effect.id])
         })
 
-    def add_hot(self, effect: HealingOverTime) -> None:
+    async def add_hot(self, effect: HealingOverTime) -> None:
         """Attach a HoT instance to the tracked stats.
 
         Healing effects simply accumulate; each copy heals separately every
@@ -398,7 +398,7 @@ class EffectManager:
         self.stats.hots.append(effect.id)
 
         # Emit effect applied event - batched for performance
-        BUS.emit_batched("effect_applied", effect.name, self.stats, {
+        await BUS.emit_batched_async("effect_applied", effect.name, self.stats, {
             "effect_type": "hot",
             "effect_id": effect.id,
             "healing": effect.healing,
@@ -406,7 +406,7 @@ class EffectManager:
             "current_stacks": len([h for h in self.hots if h.id == effect.id])
         })
 
-    def add_modifier(self, effect: StatModifier) -> None:
+    async def add_modifier(self, effect: StatModifier) -> None:
         """Attach a stat modifier to the tracked stats."""
         from autofighter.stats import BUS  # Import here to avoid circular imports
 
@@ -414,7 +414,7 @@ class EffectManager:
         self.stats.mods.append(effect.id)
 
         # Emit effect applied event - batched for performance
-        BUS.emit_batched("effect_applied", effect.name, self.stats, {
+        await BUS.emit_batched_async("effect_applied", effect.name, self.stats, {
             "effect_type": "stat_modifier",
             "effect_id": effect.id,
             "turns": effect.turns,

--- a/backend/autofighter/rooms/battle/enrage.py
+++ b/backend/autofighter/rooms/battle/enrage.py
@@ -132,7 +132,7 @@ async def update_enrage_state(
                 atk_mult=mult,
                 turns=9999,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             enrage_mods[idx] = mod
         state.stacks = new_stacks
         if turn > catastrophic_turn_threshold:

--- a/backend/autofighter/rooms/battle/setup.py
+++ b/backend/autofighter/rooms/battle/setup.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import asyncio
 import copy
+import inspect
 from dataclasses import dataclass
 from typing import Sequence
 
@@ -83,7 +84,9 @@ async def setup_battle(
         _scale_stats(stats, node, strength)
         prepare = getattr(stats, "prepare_for_battle", None)
         if callable(prepare):
-            prepare(node, registry)
+            maybe_coro = prepare(node, registry)
+            if inspect.isawaitable(maybe_coro):
+                await maybe_coro
 
     members = await _clone_members(party.members)
     combat_party = Party(
@@ -125,7 +128,9 @@ async def setup_battle(
         member.effect_manager = manager
         prepare = getattr(member, "prepare_for_battle", None)
         if callable(prepare):
-            prepare(node, registry)
+            maybe_coro = prepare(node, registry)
+            if inspect.isawaitable(maybe_coro):
+                await maybe_coro
 
     try:
         entities = list(combat_party.members) + list(foes)

--- a/backend/autofighter/summons/base.py
+++ b/backend/autofighter/summons/base.py
@@ -48,7 +48,7 @@ class Summon(Stats):
             self.instance_id = ""
 
     @classmethod
-    def create_from_summoner(
+    async def create_from_summoner(
         cls,
         summoner: Stats,
         summon_type: str = "generic",
@@ -120,14 +120,14 @@ class Summon(Stats):
             summon.passives = [p for p in summoner.passives if any(sp in p for sp in safe_passives)]
 
         # Share beneficial effects (buffs and HOTs) from summoner but not debuffs or DOTs
-        cls._share_beneficial_effects(summoner, summon, stat_multiplier)
+        await cls._share_beneficial_effects(summoner, summon, stat_multiplier)
 
         log.debug(f"Created {summon_type} summon for {summoner.id} with {stat_multiplier*100}% stats")
 
         return summon
 
     @classmethod
-    def _share_beneficial_effects(
+    async def _share_beneficial_effects(
         cls,
         summoner: Stats,
         summon: "Summon",
@@ -161,7 +161,7 @@ class Summon(Stats):
             # Copy all HOTs (healing over time effects are inherently beneficial)
             for hot in effect_mgr.hots:
                 scaled_hot = cls._scale_hot_effect(hot, stat_multiplier)
-                summon.effect_manager.add_hot(scaled_hot)
+                await summon.effect_manager.add_hot(scaled_hot)
                 log.debug(f"Shared HOT '{hot.name}' to summon {summon.id}")
 
             # Copy beneficial StatModifiers (buffs)
@@ -169,7 +169,7 @@ class Summon(Stats):
                 if cls._is_beneficial_stat_modifier(mod):
                     scaled_mod = cls._scale_stat_modifier(mod, summon, stat_multiplier)
                     scaled_mod.apply()  # Apply the modifier to ensure it affects the summon's stats
-                    summon.effect_manager.add_modifier(scaled_mod)
+                    await summon.effect_manager.add_modifier(scaled_mod)
                     log.debug(f"Shared beneficial StatModifier '{mod.name}' to summon {summon.id}")
 
     @classmethod

--- a/backend/autofighter/summons/manager.py
+++ b/backend/autofighter/summons/manager.py
@@ -41,7 +41,7 @@ class SummonManager:
         log.debug("SummonManager initialized")
 
     @classmethod
-    def create_summon(
+    async def create_summon(
         cls,
         summoner: Stats,
         summon_type: str = "generic",
@@ -101,7 +101,7 @@ class SummonManager:
 
         active_list = cls._active_summons.setdefault(summoner_id, [])
 
-        summon = Summon.create_from_summoner(
+        summon = await Summon.create_from_summoner(
             summoner,
             summon_type,
             source,
@@ -113,7 +113,7 @@ class SummonManager:
         cls._instance_counters[summoner_id] = counter
         summon.instance_id = f"{summoner_id}#{counter}"
         cls._active_summons[summoner_id].append(summon)
-        BUS.emit_batched("summon_created", summoner, summon, source)
+        await BUS.emit_batched_async("summon_created", summoner, summon, source)
         log.info("Created %s summon for %s from %s", summon_type, summoner_id, source)
         return summon
 

--- a/backend/plugins/cards/_base.py
+++ b/backend/plugins/cards/_base.py
@@ -66,7 +66,7 @@ class CardBase:
                 mod = create_stat_buff(
                     member, name=f"{self.id}_{attr}", turns=9999, **changes
                 )
-                mgr.add_modifier(mod)
+                await mgr.add_modifier(mod)
 
                 # Emit card effect event
                 await BUS.emit_async(

--- a/backend/plugins/cards/balanced_diet.py
+++ b/backend/plugins/cards/balanced_diet.py
@@ -34,7 +34,7 @@ class BalancedDiet(CardBase):
                     turns=1,
                     defense_mult=1.02  # +2% DEF
                 )
-                effect_manager.add_modifier(def_mod)
+                await effect_manager.add_modifier(def_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/critical_overdrive.py
+++ b/backend/plugins/cards/critical_overdrive.py
@@ -43,7 +43,7 @@ class CriticalOverdrive(CardBase):
                     crit_rate=extra_rate,
                     crit_damage=excess * 2,
                 )
-                target.effect_manager.add_modifier(new_mod)
+                await target.effect_manager.add_modifier(new_mod)
                 state[pid] = new_mod
                 await BUS.emit_async(
                     "card_effect",

--- a/backend/plugins/cards/critical_transfer.py
+++ b/backend/plugins/cards/critical_transfer.py
@@ -46,7 +46,7 @@ class CriticalTransfer(CardBase):
                 turns=1,
                 atk_mult=1 + 0.04 * total,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             await BUS.emit_async(
                 "card_effect",
                 self.id,

--- a/backend/plugins/cards/elemental_spark.py
+++ b/backend/plugins/cards/elemental_spark.py
@@ -39,7 +39,7 @@ class ElementalSpark(CardBase):
                 turns=9999,
                 effect_hit_rate_mult=1.05,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             chosen["mod"] = (mgr, mod)
             await BUS.emit_async(
                 "card_effect",

--- a/backend/plugins/cards/enduring_charm.py
+++ b/backend/plugins/cards/enduring_charm.py
@@ -44,7 +44,7 @@ class EnduringCharm(CardBase):
                         turns=2,
                         vitality_mult=1.03,
                     )
-                    effect_manager.add_modifier(vit_mod)
+                    await effect_manager.add_modifier(vit_mod)
 
                     log = logging.getLogger(__name__)
                     log.debug(

--- a/backend/plugins/cards/enduring_will.py
+++ b/backend/plugins/cards/enduring_will.py
@@ -63,7 +63,7 @@ class EnduringWill(CardBase):
                             member, name=f"{self.id}_mitigation_bonus", turns=20,
                             mitigation_mult=1.002  # +0.2% mitigation
                         )
-                        mgr.add_modifier(mod)
+                        await mgr.add_modifier(mod)
 
                         import logging
                         log = logging.getLogger(__name__)

--- a/backend/plugins/cards/farsight_scope.py
+++ b/backend/plugins/cards/farsight_scope.py
@@ -37,7 +37,7 @@ class FarsightScope(CardBase):
                         turns=1,
                         crit_rate=0.06,
                     )
-                    effect_manager.add_modifier(crit_mod)
+                    await effect_manager.add_modifier(crit_mod)
 
                     log.debug(
                         "Farsight Scope low HP bonus: %s gains +6%% crit rate vs %s",

--- a/backend/plugins/cards/inspiring_banner.py
+++ b/backend/plugins/cards/inspiring_banner.py
@@ -42,7 +42,7 @@ class InspiringBanner(CardBase):
                         turns=2,
                         atk_mult=1.02  # +2% ATK
                     )
-                    effect_manager.add_modifier(atk_mod)
+                    await effect_manager.add_modifier(atk_mod)
 
                     import logging
                     log = logging.getLogger(__name__)

--- a/backend/plugins/cards/iron_guard.py
+++ b/backend/plugins/cards/iron_guard.py
@@ -43,6 +43,6 @@ class IronGuard(CardBase):
                     turns=1,
                     defense_mult=1.10,
                 )
-                mgr.add_modifier(mod)
+                await mgr.add_modifier(mod)
 
         self.subscribe("damage_taken", _damage_taken)

--- a/backend/plugins/cards/keen_goggles.py
+++ b/backend/plugins/cards/keen_goggles.py
@@ -75,7 +75,7 @@ class KeenGoggles(CardBase):
                 crit_rate_mult=1 + (new_stacks * 0.01),
             )
             setattr(crit_mod, "source", source)
-            effect_manager.add_modifier(crit_mod)
+            await effect_manager.add_modifier(crit_mod)
 
             import logging
 

--- a/backend/plugins/cards/overclock.py
+++ b/backend/plugins/cards/overclock.py
@@ -59,7 +59,7 @@ class Overclock(CardBase):
                 _refresh_action_timings(ally)
 
             modifier.remove = _remove_and_refresh  # type: ignore[assignment]
-            manager.add_modifier(modifier)
+            await manager.add_modifier(modifier)
 
             await BUS.emit_async(
                 "card_effect",

--- a/backend/plugins/cards/phantom_ally.py
+++ b/backend/plugins/cards/phantom_ally.py
@@ -79,7 +79,7 @@ class PhantomAlly(CardBase):
                 override_damage_type = None
         else:
             override_damage_type = original_damage_type
-        summon = SummonManager.create_summon(
+        summon = await SummonManager.create_summon(
             summoner=original,
             summon_type="phantom",
             source=self.id,

--- a/backend/plugins/cards/polished_shield.py
+++ b/backend/plugins/cards/polished_shield.py
@@ -46,7 +46,7 @@ class PolishedShield(CardBase):
                 turns=1,
                 defense=3
             )
-            effect_manager.add_modifier(def_mod)
+            await effect_manager.add_modifier(def_mod)
 
             import logging
             log = logging.getLogger(__name__)

--- a/backend/plugins/cards/precision_sights.py
+++ b/backend/plugins/cards/precision_sights.py
@@ -36,7 +36,7 @@ class PrecisionSights(CardBase):
                     turns=2,
                     crit_damage_mult=1.02  # +2% crit damage
                 )
-                effect_manager.add_modifier(crit_damage_mod)
+                await effect_manager.add_modifier(crit_damage_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/reality_split.py
+++ b/backend/plugins/cards/reality_split.py
@@ -54,7 +54,7 @@ class RealitySplit(CardBase):
             if entity is None or entity in members or entity is party:
                 _cleanup()
 
-        def _turn_start_handler(*_args) -> None:
+        async def _turn_start_handler(*_args) -> None:
             if not party.members:
                 return
             target = random.choice(party.members)
@@ -69,7 +69,7 @@ class RealitySplit(CardBase):
                 turns=1,
                 crit_rate=0.5,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
 
         async def _hit_landed(attacker, _target, amount, *_args) -> None:
             if attacker is not state["active"]:

--- a/backend/plugins/cards/sharpening_stone.py
+++ b/backend/plugins/cards/sharpening_stone.py
@@ -34,7 +34,7 @@ class SharpeningStone(CardBase):
                     turns=2,
                     crit_damage_mult=1.02  # +2% crit damage
                 )
-                effect_manager.add_modifier(crit_damage_mod)
+                await effect_manager.add_modifier(crit_damage_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/steel_bangles.py
+++ b/backend/plugins/cards/steel_bangles.py
@@ -37,7 +37,7 @@ class SteelBangles(CardBase):
                         turns=1,  # Lasts for 1 turn
                         atk_mult=0.97  # 3% damage reduction
                     )
-                    effect_manager.add_modifier(attack_debuff)
+                    await effect_manager.add_modifier(attack_debuff)
 
                     import logging
                     log = logging.getLogger(__name__)

--- a/backend/plugins/cards/swift_bandanna.py
+++ b/backend/plugins/cards/swift_bandanna.py
@@ -34,7 +34,7 @@ class SwiftBandanna(CardBase):
                     turns=1,
                     crit_rate_mult=1.01  # +1% crit rate
                 )
-                effect_manager.add_modifier(crit_mod)
+                await effect_manager.add_modifier(crit_mod)
 
                 import logging
                 log = logging.getLogger(__name__)

--- a/backend/plugins/cards/swift_footwork.py
+++ b/backend/plugins/cards/swift_footwork.py
@@ -49,7 +49,7 @@ class SwiftFootwork(CardBase):
                     turns=2,
                     spd_mult=1.3,
                 )
-                mgr.add_modifier(burst)
+                await mgr.add_modifier(burst)
                 await BUS.emit_async(
                     "card_effect",
                     self.id,

--- a/backend/plugins/cards/tactical_kit.py
+++ b/backend/plugins/cards/tactical_kit.py
@@ -51,7 +51,7 @@ class TacticalKit(CardBase):
                             turns=1,
                             atk_mult=1.02  # +2% ATK
                         )
-                        effect_manager.add_modifier(atk_mod)
+                        await effect_manager.add_modifier(atk_mod)
 
                         import logging
                         log = logging.getLogger(__name__)

--- a/backend/plugins/cards/temporal_shield.py
+++ b/backend/plugins/cards/temporal_shield.py
@@ -36,7 +36,7 @@ class TemporalShield(CardBase):
                         turns=1,
                         mitigation_mult=100.0,
                     )
-                    mgr.add_modifier(mod)
+                    await mgr.add_modifier(mod)
                     await BUS.emit_async(
                         "card_effect",
                         self.id,

--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -45,7 +45,7 @@ class VitalCore(CardBase):
                         turns=2,
                         vitality_mult=1.03,
                     )
-                    effect_manager.add_modifier(vit_mod)
+                    await effect_manager.add_modifier(vit_mod)
 
                     log = logging.getLogger(__name__)
                     log.debug(

--- a/backend/plugins/cards/vital_surge.py
+++ b/backend/plugins/cards/vital_surge.py
@@ -35,7 +35,7 @@ class VitalSurge(CardBase):
                     atk_mult=1.55,
                 )
                 active[pid] = mod
-                mgr.add_modifier(mod)
+                await mgr.add_modifier(mod)
                 await BUS.emit_async(
                     "card_effect",
                     self.id,
@@ -53,17 +53,17 @@ class VitalSurge(CardBase):
                     if hasattr(member, "mods") and mod.id in member.mods:
                         member.mods.remove(mod.id)
 
-        def _turn_start() -> None:
+        async def _turn_start(*_) -> None:
             for m in party.members:
-                _check(m)
+                await _check(m)
 
-        def _damage_taken(victim, *_args) -> None:
+        async def _damage_taken(victim, *_args) -> None:
             if victim in party.members:
-                _check(victim)
+                await _check(victim)
 
-        def _heal_received(member, *_args) -> None:
+        async def _heal_received(member, *_args) -> None:
             if member in party.members:
-                _check(member)
+                await _check(member)
 
         self.subscribe("turn_start", _turn_start)
         self.subscribe("damage_taken", _damage_taken)

--- a/backend/plugins/characters/luna.py
+++ b/backend/plugins/characters/luna.py
@@ -276,7 +276,7 @@ class Luna(PlayerBase):
             return weight * 6.0
         return weight
 
-    def prepare_for_battle(
+    async def prepare_for_battle(
         self,
         node: MapNode,
         registry: "PassiveRegistry",
@@ -320,7 +320,7 @@ class Luna(PlayerBase):
             label_counts[key] = count
             summon_type_base = f"luna_sword_{key}"
             summon_type = summon_type_base if count == 1 else f"{summon_type_base}_{count}"
-            summon = SummonManager.create_summon(
+            summon = await SummonManager.create_summon(
                 self,
                 summon_type=summon_type,
                 source="luna_sword",

--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -27,7 +27,7 @@ class Light(DamageTypeBase):
             if mgr is not None:
                 hot = damage_effects.create_hot(self.id, actor)
                 if hot is not None:
-                    mgr.add_hot(hot)
+                    await mgr.add_hot(hot)
             await pace_sleep(YIELD_MULTIPLIER)
 
         for ally in allies:
@@ -69,7 +69,7 @@ class Light(DamageTypeBase):
                     pass
 
             for dot in removed_dots:
-                BUS.emit_batched(
+                await BUS.emit_batched_async(
                     "dot_cleansed",
                     actor,
                     ally,
@@ -100,7 +100,7 @@ class Light(DamageTypeBase):
                 turns=10,
                 defense_mult=0.75,
             )
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             await pace_sleep(YIELD_MULTIPLIER)
 
         await BUS.emit_async("light_ultimate", actor)

--- a/backend/plugins/damage_types/wind.py
+++ b/backend/plugins/damage_types/wind.py
@@ -66,7 +66,7 @@ class Wind(DamageTypeBase):
             turns=1,
             effect_hit_rate_mult=1.5,
         )
-        a_mgr.add_modifier(eh_mod)
+        await a_mgr.add_modifier(eh_mod)
 
         # Determine dynamic hit count (allow cards/relics to override via attributes)
         hits = int(getattr(actor, "wind_ultimate_hits", getattr(actor, "ultimate_hits", 25)) or 25)

--- a/backend/plugins/dots/celestial_atrophy.py
+++ b/backend/plugins/dots/celestial_atrophy.py
@@ -22,7 +22,7 @@ class CelestialAtrophy(DamageOverTime):
                 turns=self.turns,
                 atk=-1,
             )
-            manager.add_modifier(mod)
+            await manager.add_modifier(mod)
             self._mods.append(mod)
         alive = await super().tick(target)
         if not alive and manager is not None:

--- a/backend/plugins/passives/normal/ally_overload.py
+++ b/backend/plugins/passives/normal/ally_overload.py
@@ -94,7 +94,7 @@ class AllyOverload:
             em.hots.clear()
             target.hots.clear()
 
-            def _block_hot(self_em, *_: object, **__: object) -> None:
+            async def _block_hot(self_em, *_: object, **__: object) -> None:
                 return None
 
             self._add_hot_backup[entity_id] = em.add_hot

--- a/backend/plugins/passives/normal/becca_menagerie_bond.py
+++ b/backend/plugins/passives/normal/becca_menagerie_bond.py
@@ -235,7 +235,7 @@ class BeccaMenagerieBond:
         damage_type = self._get_jellyfish_damage_type(jellyfish_type)
 
         # Create new summon using summons system
-        summon = SummonManager.create_summon(
+        summon = await SummonManager.create_summon(
             summoner=target,
             summon_type=f"jellyfish_{jellyfish_type}",
             source=self.id,

--- a/backend/plugins/passives/normal/casno_phoenix_respite.py
+++ b/backend/plugins/passives/normal/casno_phoenix_respite.py
@@ -64,10 +64,10 @@ class CasnoPhoenixRespite:
             return
 
         cls._action_counts[entity_id] = 0
-        cls._schedule_rest(target)
+        await cls._schedule_rest(target)
 
     @classmethod
-    def _schedule_rest(cls, target: "Stats") -> None:
+    async def _schedule_rest(cls, target: "Stats") -> None:
         if getattr(target, "hp", 0) <= 0:
             return
 
@@ -93,7 +93,7 @@ class CasnoPhoenixRespite:
 
         cls._pending_rest[entity_id] = True
         cls._helper_effect_ids[entity_id] = helper_id
-        effect_manager.add_hot(helper_effect)
+        await effect_manager.add_hot(helper_effect)
         cls._register_battle_end(target)
 
     @classmethod

--- a/backend/plugins/relics/_base.py
+++ b/backend/plugins/relics/_base.py
@@ -56,7 +56,7 @@ class RelicBase:
             if not changes:
                 continue
             mod = create_stat_buff(member, name=self.id, turns=9999, **changes)
-            mgr.add_modifier(mod)
+            await mgr.add_modifier(mod)
             mods.append(mod)
 
             # Emit relic effect tracking for stat modifications

--- a/backend/plugins/relics/bent_dagger.py
+++ b/backend/plugins/relics/bent_dagger.py
@@ -35,7 +35,7 @@ class BentDagger(RelicBase):
 
             for member in party.members:
                 mod = create_stat_buff(member, name=f"{self.id}_kill", atk_mult=1.01, turns=9999)
-                member.effect_manager.add_modifier(mod)
+                await member.effect_manager.add_modifier(mod)
 
                 # Track the ATK buff application
                 await BUS.emit_async("relic_effect", "bent_dagger", member, "atk_boost_applied", 1, {

--- a/backend/plugins/relics/guardian_charm.py
+++ b/backend/plugins/relics/guardian_charm.py
@@ -44,7 +44,7 @@ class GuardianCharm(RelicBase):
         mod = create_stat_buff(
             member, name=self.id, defense_mult=1 + 0.2 * stacks, turns=9999
         )
-        member.effect_manager.add_modifier(mod)
+        await member.effect_manager.add_modifier(mod)
 
     def describe(self, stacks: int) -> str:
         pct = 20 * stacks

--- a/backend/plugins/relics/killer_instinct.py
+++ b/backend/plugins/relics/killer_instinct.py
@@ -68,7 +68,7 @@ class KillerInstinct(RelicBase):
             })
 
             mod = create_stat_buff(user, name=f"{self.id}_atk", atk_mult=atk_mult, turns=1)
-            user.effect_manager.add_modifier(mod)
+            await user.effect_manager.add_modifier(mod)
             _remove_buff(ultimate_buffs, id(user))
             ultimate_buffs[id(user)] = (user, mod)
 
@@ -108,7 +108,7 @@ class KillerInstinct(RelicBase):
                     spd_mult=speed_mult,
                     turns=2,
                 )
-                attacker.effect_manager.add_modifier(mod)
+                await attacker.effect_manager.add_modifier(mod)
                 speed_buffs[id(attacker)] = (attacker, mod)
 
         def _turn_end(*_args) -> None:

--- a/backend/plugins/relics/null_lantern.py
+++ b/backend/plugins/relics/null_lantern.py
@@ -81,7 +81,7 @@ class NullLantern(RelicBase):
                 max_hp_mult=mult,
                 hp_mult=mult,
             )
-            entity.effect_manager.add_modifier(mod)
+            await entity.effect_manager.add_modifier(mod)
 
             await BUS.emit_async(
                 "relic_effect",

--- a/backend/plugins/relics/omega_core.py
+++ b/backend/plugins/relics/omega_core.py
@@ -59,7 +59,7 @@ class OmegaCore(RelicBase):
                     vitality_mult=mult,
                     mitigation_mult=mult,
                 )
-                member.effect_manager.add_modifier(mod)
+                await member.effect_manager.add_modifier(mod)
                 safe_async_task(member.apply_healing(member.max_hp))
                 state["mods"][id(member)] = mod
             state["turn"] = 0

--- a/backend/plugins/relics/paradox_hourglass.py
+++ b/backend/plugins/relics/paradox_hourglass.py
@@ -41,7 +41,7 @@ class ParadoxHourglass(RelicBase):
                     defense=new_def - base_def,
                     turns=9999,
                 )
-                entity.effect_manager.add_modifier(mod)
+                await entity.effect_manager.add_modifier(mod)
                 state["foe"][id(entity)] = mod
 
                 # Track foe defense reduction
@@ -102,7 +102,7 @@ class ParadoxHourglass(RelicBase):
                     vitality_mult=mult,
                     mitigation_mult=mult,
                 )
-                m.effect_manager.add_modifier(mod)
+                await m.effect_manager.add_modifier(mod)
                 m.hp = m.max_hp
                 state["buffs"][id(m)] = mod
 

--- a/backend/plugins/relics/shiny_pebble.py
+++ b/backend/plugins/relics/shiny_pebble.py
@@ -42,7 +42,7 @@ class ShinyPebble(RelicBase):
                 mitigation=target.mitigation * (mit_mult - 1),
                 turns=1,
             )
-            target.effect_manager.add_modifier(mod)
+            await target.effect_manager.add_modifier(mod)
             current_state["active"][id(target)] = (target, mod)
 
             # Track mitigation burst application

--- a/backend/plugins/relics/soul_prism.py
+++ b/backend/plugins/relics/soul_prism.py
@@ -57,7 +57,7 @@ class SoulPrism(RelicBase):
                     mitigation_mult=1 + buff,
                     turns=9999,
                 )
-                member.effect_manager.add_modifier(mod)
+                await member.effect_manager.add_modifier(mod)
                 heal = max(1, int(member.max_hp * 0.01))
 
                 # Track the revival

--- a/backend/plugins/relics/stellar_compass.py
+++ b/backend/plugins/relics/stellar_compass.py
@@ -42,7 +42,7 @@ class StellarCompass(RelicBase):
                 atk_mult=atk_mult,
                 turns=9999,
             )
-            attacker.effect_manager.add_modifier(mod)
+            await attacker.effect_manager.add_modifier(mod)
             current_state["gold"] += 0.015 * copies
 
             # Track critical hit buff application

--- a/backend/plugins/relics/tattered_flag.py
+++ b/backend/plugins/relics/tattered_flag.py
@@ -38,7 +38,7 @@ class TatteredFlag(RelicBase):
 
             for member in survivors:
                 mod = create_stat_buff(member, name=f"{self.id}_buff", atk_mult=1.03, turns=9999)
-                member.effect_manager.add_modifier(mod)
+                await member.effect_manager.add_modifier(mod)
 
         self.subscribe(party, "damage_taken", _fallen)
 

--- a/backend/plugins/relics/timekeepers_hourglass.py
+++ b/backend/plugins/relics/timekeepers_hourglass.py
@@ -80,7 +80,7 @@ class TimekeepersHourglass(RelicBase):
                         spd_mult=boost,
                         turns=2,
                     )
-                    mgr.add_modifier(mod)
+                    await mgr.add_modifier(mod)
                     active_mods[id(member)] = mod
 
         def _battle_end(_entity) -> None:

--- a/backend/plugins/relics/travelers_charm.py
+++ b/backend/plugins/relics/travelers_charm.py
@@ -63,7 +63,7 @@ class TravelersCharm(RelicBase):
                     defense_mult=1 + d_pct,
                     mitigation_mult=1 + m_pct,
                 )
-                member.effect_manager.add_modifier(mod)
+                await member.effect_manager.add_modifier(mod)
                 active[pid] = (member, mod)
                 applied_count += 1
 

--- a/backend/plugins/relics/wooden_idol.py
+++ b/backend/plugins/relics/wooden_idol.py
@@ -52,7 +52,7 @@ class WoodenIdol(RelicBase):
                     effect_resistance=bonus,
                     turns=1,
                 )
-                member.effect_manager.add_modifier(mod)
+                await member.effect_manager.add_modifier(mod)
                 active[pid] = (member, mod)
                 applied_count += 1
 

--- a/backend/tests/test_async_dot_optimizations.py
+++ b/backend/tests/test_async_dot_optimizations.py
@@ -75,7 +75,7 @@ async def test_mixed_dots_and_hots():
         dot = DamageOverTime(f"dot_{i}", damage=2, turns=3, id=f"dot_{i}", source=target)
         hot = HealingOverTime(f"hot_{i}", healing=1, turns=3, id=f"hot_{i}", source=target)
         manager.add_dot(dot)
-        manager.add_hot(hot)
+        await manager.add_hot(hot)
 
     initial_hp = target.hp
     await manager.tick()
@@ -133,7 +133,7 @@ async def test_dead_characters_dont_receive_dots_or_hots():
 
     # Try to add HOT to dead character
     hot = HealingOverTime("test_hot", healing=5, turns=2, id="test_hot", source=source)
-    manager.add_hot(hot)
+    await manager.add_hot(hot)
 
     # Verify no effects were added
     assert len(manager.dots) == 0
@@ -161,7 +161,7 @@ async def test_living_characters_can_still_receive_effects():
 
     # Add HOT to living character
     hot = HealingOverTime("test_hot", healing=5, turns=2, id="test_hot", source=source)
-    manager.add_hot(hot)
+    await manager.add_hot(hot)
 
     # Verify effects were added
     assert len(manager.dots) == 1

--- a/backend/tests/test_battle_progress_helpers.py
+++ b/backend/tests/test_battle_progress_helpers.py
@@ -54,7 +54,7 @@ async def test_collect_summon_snapshots_groups_by_owner():
     summoner = Stats(hp=1_000)
     summoner.id = "summoner"
     summoner.ensure_permanent_summon_slots(1)
-    summon = SummonManager.create_summon(summoner, summon_type="test", source="unit_test")
+    summon = await SummonManager.create_summon(summoner, summon_type="test", source="unit_test")
     assert summon is not None
 
     snapshots = await collect_summon_snapshots([summoner])
@@ -98,7 +98,7 @@ async def test_build_battle_progress_payload_includes_snapshots_and_events():
     party_member = Stats(hp=1_000)
     party_member.id = "hero"
     party_member.ensure_permanent_summon_slots(1)
-    hero_summon = SummonManager.create_summon(
+    hero_summon = await SummonManager.create_summon(
         party_member,
         summon_type="sprite",
         source="unit_test",
@@ -108,7 +108,7 @@ async def test_build_battle_progress_payload_includes_snapshots_and_events():
     foe = Stats(hp=900)
     foe.id = "foe"
     foe.ensure_permanent_summon_slots(1)
-    foe_summon = SummonManager.create_summon(
+    foe_summon = await SummonManager.create_summon(
         foe,
         summon_type="minion",
         source="unit_test",

--- a/backend/tests/test_character_passives.py
+++ b/backend/tests/test_character_passives.py
@@ -309,7 +309,7 @@ async def test_ally_overload_battle_end_restores_hots():
     assert ally.effect_manager.add_hot is not original_add_hot
 
     blocked_hot = HealingOverTime("blocked", 5, 2, "blocked")
-    ally.effect_manager.add_hot(blocked_hot)
+    await ally.effect_manager.add_hot(blocked_hot)
     assert not ally.effect_manager.hots
     assert not ally.hots
 
@@ -320,7 +320,7 @@ async def test_ally_overload_battle_end_restores_hots():
     assert ally.effect_manager.add_hot.__func__ is original_add_hot.__func__
 
     restored_hot = HealingOverTime("restored", 7, 3, "restored")
-    ally.effect_manager.add_hot(restored_hot)
+    await ally.effect_manager.add_hot(restored_hot)
 
     assert ally.effect_manager.hots == [restored_hot]
     assert ally.hots == [restored_hot.id]

--- a/backend/tests/test_effect_serialization.py
+++ b/backend/tests/test_effect_serialization.py
@@ -1,3 +1,5 @@
+import pytest
+
 from autofighter.effects import DamageOverTime
 from autofighter.effects import EffectManager
 from autofighter.effects import HealingOverTime
@@ -5,7 +7,8 @@ from autofighter.rooms.utils import _serialize
 from autofighter.stats import Stats
 
 
-def test_serialize_effect_details():
+@pytest.mark.asyncio
+async def test_serialize_effect_details():
     target = Stats()
     target.id = "t"
     mgr = EffectManager(target)
@@ -15,7 +18,7 @@ def test_serialize_effect_details():
     source.id = "s"
     mgr.add_dot(DamageOverTime("burn", 5, 2, "burn", source))
     mgr.add_dot(DamageOverTime("burn", 5, 1, "burn", source))
-    mgr.add_hot(HealingOverTime("regen", 3, 1, "regen", source))
+    await mgr.add_hot(HealingOverTime("regen", 3, 1, "regen", source))
 
     target.passives = ["attack_up", "luna_lunar_reservoir", "luna_lunar_reservoir"]
 

--- a/backend/tests/test_lady_light_radiant_aegis.py
+++ b/backend/tests/test_lady_light_radiant_aegis.py
@@ -4,6 +4,7 @@ import pytest
 
 from autofighter.effects import EffectManager
 from autofighter.stats import BUS
+from plugins.event_bus import bus as EVENT_BUS
 from autofighter.stats import Stats
 from plugins.damage_types.light import Light
 from plugins.dots.bleed import Bleed
@@ -36,8 +37,8 @@ async def test_radiant_aegis_hot_event_applies_shields():
     hot = RadiantRegeneration(healer)
     hot.healing = 8  # Boost base healing so scaling is visible
     hot.source = healer
-    ally.effect_manager.add_hot(hot)
-
+    await ally.effect_manager.add_hot(hot)
+    await EVENT_BUS._process_batches_internal()
     await asyncio.sleep(0.05)
 
     expected_hot = int(hot.healing * healer.vitality * ally.vitality)
@@ -67,6 +68,7 @@ async def test_radiant_aegis_dot_cleanse_triggers_on_light_ultimate():
 
     healer.add_ultimate_charge(healer.ultimate_charge_max)
     await healer.damage_type.ultimate(healer, [healer, ally], [])
+    await EVENT_BUS._process_batches_internal()
     await asyncio.sleep(0.05)
 
     expected_attack_bonus = int(healer.atk * 0.02)

--- a/backend/tests/test_status_phase_events.py
+++ b/backend/tests/test_status_phase_events.py
@@ -79,7 +79,7 @@ async def test_status_phase_events_emit_with_pacing(monkeypatch):
     hot = HealingOverTime("regen", healing=10, turns=1, id="hot_1", source=target)
     dot = DamageOverTime("burn", damage=10, turns=1, id="dot_1", source=target)
 
-    manager.add_hot(hot)
+    await manager.add_hot(hot)
     manager.add_dot(dot)
 
     captured_events: list[tuple[str, tuple[object, ...]]] = []
@@ -285,7 +285,7 @@ async def test_status_phase_events_update_snapshot_queue(monkeypatch):
     hot = HealingOverTime("regen", healing=10, turns=1, id="hot_1", source=target)
     dot = DamageOverTime("burn", damage=10, turns=1, id="dot_1", source=target)
 
-    manager.add_hot(hot)
+    await manager.add_hot(hot)
     manager.add_dot(dot)
 
     set_battle_active(True)
@@ -346,7 +346,7 @@ async def test_status_phase_events_update_snapshot_queue(monkeypatch):
         "chance": 25,
         "roll": 99,
     }
-    BUS.emit_batched("effect_resisted", "burn", target, attacker, resist_details)
+    await BUS.emit_batched_async("effect_resisted", "burn", target, attacker, resist_details)
     await bus._process_batches_internal()
 
     events_after_resist = list(battle_snapshots[run_id]["recent_events"])

--- a/backend/tests/test_summon_decision_logic.py
+++ b/backend/tests/test_summon_decision_logic.py
@@ -23,7 +23,7 @@ async def test_summon_viability_evaluation(monkeypatch):
     summoner._base_defense = 50
     summoner.ensure_permanent_summon_slots(1)
 
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -80,7 +80,7 @@ async def test_resummon_decision_logic(monkeypatch):
     assert decision['viable_count'] == 0
 
     # Create a healthy summon
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -119,7 +119,7 @@ async def test_smart_summon_creation(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create first summon (should succeed)
-    summon1 = SummonManager.create_summon(
+    summon1 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test1",
         source="test_source",
@@ -128,7 +128,7 @@ async def test_smart_summon_creation(monkeypatch):
     summon1.hp = summon1.max_hp  # Ensure healthy
 
     # Try to create second summon with healthy first summon (should fail due to smart logic)
-    summon2 = SummonManager.create_summon(
+    summon2 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test2",
         source="test_source",
@@ -139,7 +139,7 @@ async def test_smart_summon_creation(monkeypatch):
     summon1.hp = int(summon1.max_hp * 0.1)  # 10% health
 
     # Try to create second summon with damaged first summon (should succeed and replace)
-    summon3 = SummonManager.create_summon(
+    summon3 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test3",
         source="test_source",
@@ -167,7 +167,7 @@ async def test_force_create_bypasses_logic(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create first summon
-    summon1 = SummonManager.create_summon(
+    summon1 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test1",
         source="test_source",
@@ -176,7 +176,7 @@ async def test_force_create_bypasses_logic(monkeypatch):
     summon1.hp = summon1.max_hp  # Ensure healthy
 
     # Force create second summon even with healthy first summon
-    summon2 = SummonManager.create_summon(
+    summon2 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test2",
         source="test_source",
@@ -205,7 +205,7 @@ async def test_health_threshold_customization(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create summon with 40% health
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source"

--- a/backend/tests/test_summon_manager_no_event_loop_warning.py
+++ b/backend/tests/test_summon_manager_no_event_loop_warning.py
@@ -20,7 +20,7 @@ async def test_on_entity_killed_no_event_loop_warning(monkeypatch, caplog):
     summoner = Stats()
     summoner.id = "test_summoner"
     summoner.ensure_permanent_summon_slots(1)
-    SummonManager.create_summon(summoner, summon_type="test")
+    await SummonManager.create_summon(summoner, summon_type="test")
     summon = SummonManager.get_summons("test_summoner")[0]
 
     with caplog.at_level(logging.WARNING, logger="plugins.event_bus"):

--- a/backend/tests/test_summon_safeguards.py
+++ b/backend/tests/test_summon_safeguards.py
@@ -29,7 +29,7 @@ async def test_summons_cannot_create_more_summons(monkeypatch):
     original_summoner.ensure_permanent_summon_slots(1)
 
     # Create a summon from the original summoner
-    first_summon = SummonManager.create_summon(
+    first_summon = await SummonManager.create_summon(
         summoner=original_summoner,
         summon_type="first_summon",
         source="test_source"
@@ -39,7 +39,7 @@ async def test_summons_cannot_create_more_summons(monkeypatch):
     assert isinstance(first_summon, Summon)
 
     # Now try to create a summon from the first summon (this should be blocked)
-    second_summon = SummonManager.create_summon(
+    second_summon = await SummonManager.create_summon(
         summoner=first_summon,  # Summon trying to create another summon
         summon_type="second_summon",
         source="test_source"
@@ -72,13 +72,13 @@ async def test_regular_entities_can_still_create_summons(monkeypatch):
     player2.ensure_permanent_summon_slots(1)
 
     # Both should be able to create summons
-    summon1 = SummonManager.create_summon(
+    summon1 = await SummonManager.create_summon(
         summoner=player1,
         summon_type="summon1",
         source="test_source"
     )
 
-    summon2 = SummonManager.create_summon(
+    summon2 = await SummonManager.create_summon(
         summoner=player2,
         summon_type="summon2",
         source="test_source"
@@ -107,7 +107,7 @@ async def test_summon_identification_works(monkeypatch):
     player.id = "player"
     player.ensure_permanent_summon_slots(1)
 
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=player,
         summon_type="test_summon",
         source="test_source"
@@ -143,7 +143,7 @@ async def test_summon_safeguard_logging(monkeypatch, caplog):
     player.id = "test_player"
     player.ensure_permanent_summon_slots(1)
 
-    first_summon = SummonManager.create_summon(
+    first_summon = await SummonManager.create_summon(
         summoner=player,
         summon_type="first_summon",
         source="test_source"
@@ -152,7 +152,7 @@ async def test_summon_safeguard_logging(monkeypatch, caplog):
     assert first_summon is not None
 
     # Try to create summon from summon (should be blocked and logged)
-    second_summon = SummonManager.create_summon(
+    second_summon = await SummonManager.create_summon(
         summoner=first_summon,
         summon_type="second_summon",
         source="test_source"

--- a/backend/tests/test_summons_system.py
+++ b/backend/tests/test_summons_system.py
@@ -55,7 +55,7 @@ async def test_summon_creation_basic(monkeypatch):
     summoner._base_defense = 50
 
     # Create summon
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -88,7 +88,7 @@ async def test_summon_manager_creation_and_tracking(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create summon via manager
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source"
@@ -117,7 +117,7 @@ async def test_summon_manager_limits(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create first summon (should succeed)
-    summon1 = SummonManager.create_summon(
+    summon1 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test1",
         source="test_source",
@@ -125,7 +125,7 @@ async def test_summon_manager_limits(monkeypatch):
     assert summon1 is not None
 
     # Try to create second summon (should fail due to limit)
-    summon2 = SummonManager.create_summon(
+    summon2 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test2",
         source="test_source",
@@ -149,7 +149,7 @@ async def test_summon_battle_lifecycle(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create temporary summon
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="temporary",
         source="test_source",
@@ -179,7 +179,7 @@ async def test_summon_turn_expiration(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create summon with 2 turn duration
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="timed",
         source="test_source",
@@ -464,7 +464,7 @@ async def test_damage_type_inheritance(monkeypatch):
     total_summons = 20
 
     for i in range(total_summons):
-        summon = Summon.create_from_summoner(
+        summon = await Summon.create_from_summoner(
             summoner=summoner,
             summon_type=f"test_{i}",
             source="test"
@@ -491,7 +491,7 @@ async def test_summon_party_integration(monkeypatch):
     party = Party(members=[ally])
 
     # Create summon
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=ally,
         summon_type="test",
         source="test_source"
@@ -518,7 +518,7 @@ async def test_summon_defeat_cleanup(monkeypatch):
     summoner.hp = 1
 
     # Create summon
-    SummonManager.create_summon(
+    await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source"
@@ -551,7 +551,7 @@ async def test_summons_reset_before_new_battle(monkeypatch):
     summoner = Ally()
     summoner.id = "test_summoner"
 
-    SummonManager.create_summon(
+    await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -608,7 +608,7 @@ async def test_summon_inheritance_with_effects(monkeypatch):
     assert summoner.vitality == 2.0  # 1.5 base + 0.5 effect
 
     # Create summon with 50% stat inheritance
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -665,7 +665,7 @@ async def test_summon_inherits_beneficial_effects(monkeypatch):
         id="test_hot_id",
         source=summoner
     )
-    summoner.effect_manager.add_hot(hot)
+    await summoner.effect_manager.add_hot(hot)
 
     # Add beneficial StatModifier
     stat_mod = StatModifier(
@@ -676,10 +676,10 @@ async def test_summon_inherits_beneficial_effects(monkeypatch):
         deltas={"crit_rate": 0.1},  # +10% crit rate - beneficial
         multipliers={"crit_damage": 1.5}  # 1.5x crit damage - beneficial
     )
-    summoner.effect_manager.add_modifier(stat_mod)
+    await summoner.effect_manager.add_modifier(stat_mod)
 
     # Create summon with 50% stat inheritance
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -773,10 +773,10 @@ async def test_summon_does_not_inherit_harmful_effects(monkeypatch):
         deltas={"crit_rate": -0.1},  # -10% crit rate - harmful
         multipliers={"crit_damage": 0.5}  # 0.5x crit damage - harmful
     )
-    summoner.effect_manager.add_modifier(harmful_mod)
+    await summoner.effect_manager.add_modifier(harmful_mod)
 
     # Create summon
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -838,7 +838,7 @@ async def test_summon_inherits_mixed_effects_correctly(monkeypatch):
     summoner.effect_manager = EffectManager(summoner)
 
     # Create summon
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",

--- a/backend/tests/test_turn_loop_summon_updates.py
+++ b/backend/tests/test_turn_loop_summon_updates.py
@@ -45,10 +45,10 @@ class DummyEffectManager:
     def maybe_inflict_dot(self, *_):  # pragma: no cover - simple stub
         return None
 
-    def add_hot(self, *_):  # pragma: no cover - simple stub
+    async def add_hot(self, *_):  # pragma: no cover - simple stub
         return None
 
-    def add_modifier(self, *_):  # pragma: no cover - simple stub
+    async def add_modifier(self, *_):  # pragma: no cover - simple stub
         return None
 
 
@@ -457,7 +457,7 @@ async def test_summon_instance_ids_used_in_progress_and_events(monkeypatch):
                 base_action_value=0.0,
             )
 
-    def _fake_create_from_summoner(cls, summoner, summon_type, *_, **__):
+    async def _fake_create_from_summoner(cls, summoner, summon_type, *_, **__):
         summoner_id = getattr(summoner, "id", str(id(summoner)))
         return _FakeSummon(summoner_id, summon_type)
 
@@ -466,13 +466,13 @@ async def test_summon_instance_ids_used_in_progress_and_events(monkeypatch):
     summoner = SimpleEntity("luna")
     summoner.summon_slot_capacity = 4
 
-    sword_one = SummonManager.create_summon(
+    sword_one = await SummonManager.create_summon(
         summoner,
         summon_type="luna_sword_lightstream",
         source="test",
         force_create=True,
     )
-    sword_two = SummonManager.create_summon(
+    sword_two = await SummonManager.create_summon(
         summoner,
         summon_type="luna_sword_lightstream",
         source="test",
@@ -607,7 +607,7 @@ async def test_luna_glitched_lightstream_snapshot_ids():
     )
     registry = PassiveRegistry()
 
-    luna.prepare_for_battle(node, registry)
+    await luna.prepare_for_battle(node, registry)
 
     swords = SummonManager.get_summons(luna.id)
     assert len(swords) == 2, "Glitched Luna should summon two Lightstream swords"


### PR DESCRIPTION
## Summary
- convert summon creation helpers to async so HoTs/modifiers are awaited and SummonManager emits async events
- await the new async summon/effect helpers across battle setup, plugins, and tests
- make Casno Phoenix Respite schedule its rest helper via awaited EffectManager operations

## Testing
- [x] Backend tests (uv run pytest tests/test_summons_system.py)
- [ ] Frontend tests
- [x] Linting (uv run ruff check plugins/passives/normal/casno_phoenix_respite.py)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

------
https://chatgpt.com/codex/tasks/task_b_68eab46be49c832cbee25885dc87a563