### PR TITLE
Async defers DoT application from turn loops

### DIFF
--- a/backend/autofighter/rooms/battle/enrage.py
+++ b/backend/autofighter/rooms/battle/enrage.py
@@ -132,7 +132,7 @@ async def update_enrage_state(
                 atk_mult=mult,
                 turns=9999,
             )
-            mgr.add_modifier(mod)
+            await asyncio.to_thread(mgr.add_modifier, mod)
             enrage_mods[idx] = mod
         state.stacks = new_stacks
         if turn > catastrophic_turn_threshold:
@@ -177,25 +177,27 @@ async def apply_enrage_bleed(
         max_hp = max(getattr(mgr.stats, "max_hp", 1), 1)
         for _ in range(stacks_to_add):
             dmg_per_tick = int(max_hp * party_bleed_ratio)
-            mgr.add_dot(
+            await asyncio.to_thread(
+                mgr.add_dot,
                 damage_over_time_factory(
                     "Enrage Bleed",
                     dmg_per_tick,
                     10,
                     "enrage_bleed",
-                )
+                ),
             )
     for mgr, foe_obj in zip(foe_effects, foes, strict=False):
         max_hp = max(getattr(foe_obj, "max_hp", 1), 1)
         for _ in range(stacks_to_add):
             dmg_per_tick = int(max_hp * foe_bleed_ratio)
-            mgr.add_dot(
+            await asyncio.to_thread(
+                mgr.add_dot,
                 damage_over_time_factory(
                     "Enrage Bleed",
                     dmg_per_tick,
                     10,
                     "enrage_bleed",
-                )
+                ),
             )
     state.bleed_applies += 1
 

--- a/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/foe_turn.py
@@ -281,7 +281,7 @@ async def _run_foe_turn_iteration(
             f"foe_{damage_type_id}_attack",
         )
 
-    target_effect.maybe_inflict_dot(acting_foe, damage)
+    await asyncio.to_thread(target_effect.maybe_inflict_dot, acting_foe, damage)
     targets_hit = 1
     await BUS.emit_async("action_used", acting_foe, target, damage)
     duration = calc_animation_time(acting_foe, targets_hit)

--- a/backend/autofighter/rooms/battle/turn_loop/player_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/player_turn.py
@@ -419,7 +419,7 @@ async def _run_player_turn_iteration(
             foes=context.foes,
         )
 
-    target_manager.maybe_inflict_dot(member, damage)
+    await asyncio.to_thread(target_manager.maybe_inflict_dot, member, damage)
     targets_hit = 1
     if getattr(member.damage_type, "id", "").lower() == "wind":
         targets_hit += await _handle_wind_spread(
@@ -676,7 +676,11 @@ async def _handle_wind_spread(
                 party=context.combat_party.members,
                 foes=context.foes,
             )
-        extra_manager.maybe_inflict_dot(member, extra_damage)
+        await asyncio.to_thread(
+            extra_manager.maybe_inflict_dot,
+            member,
+            extra_damage,
+        )
         context.exp_reward, context.temp_rdr = await credit_if_dead(
             foe_obj=extra_foe,
             exp_reward=context.exp_reward,


### PR DESCRIPTION
## Summary
- run DoT applications off the event loop during player and foe turns so pacing waits on damage-over-time rolls
- await enrage modifier and bleed applications via `asyncio.to_thread` to keep battle state updates asynchronous friendly

## Testing
- uv run pytest backend/tests/test_effects.py backend/tests/test_wind_spread_regression.py backend/tests/test_turn_loop_summon_updates.py

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68eac563c850832cbe141f9bec1a0780