### PR TITLE
Fix summon creation to await effect propagation

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -383,7 +383,7 @@ class EffectManager:
             "current_stacks": len([d for d in self.dots if d.id == effect.id])
         })
 
-    def add_hot(self, effect: HealingOverTime) -> None:
+    async def add_hot(self, effect: HealingOverTime) -> None:
         """Attach a HoT instance to the tracked stats.
 
         Healing effects simply accumulate; each copy heals separately every
@@ -399,13 +399,18 @@ class EffectManager:
         self.stats.hots.append(effect.id)
 
         # Emit effect applied event - batched for performance
-        BUS.emit_batched("effect_applied", effect.name, self.stats, {
-            "effect_type": "hot",
-            "effect_id": effect.id,
-            "healing": effect.healing,
-            "turns": effect.turns,
-            "current_stacks": len([h for h in self.hots if h.id == effect.id])
-        })
+        await BUS.emit_batched_async(
+            "effect_applied",
+            effect.name,
+            self.stats,
+            {
+                "effect_type": "hot",
+                "effect_id": effect.id,
+                "healing": effect.healing,
+                "turns": effect.turns,
+                "current_stacks": len([h for h in self.hots if h.id == effect.id]),
+            },
+        )
 
     def add_modifier(self, effect: StatModifier) -> Awaitable[None]:
         """Attach a stat modifier to the tracked stats and return an awaitable."""

--- a/backend/autofighter/summons/base.py
+++ b/backend/autofighter/summons/base.py
@@ -7,7 +7,6 @@ characters, passives, cards, and relics.
 
 from __future__ import annotations
 
-import asyncio
 from dataclasses import dataclass
 import logging
 import random
@@ -49,7 +48,7 @@ class Summon(Stats):
             self.instance_id = ""
 
     @classmethod
-    def create_from_summoner(
+    async def create_from_summoner(
         cls,
         summoner: Stats,
         summon_type: str = "generic",
@@ -121,14 +120,14 @@ class Summon(Stats):
             summon.passives = [p for p in summoner.passives if any(sp in p for sp in safe_passives)]
 
         # Share beneficial effects (buffs and HOTs) from summoner but not debuffs or DOTs
-        cls._share_beneficial_effects(summoner, summon, stat_multiplier)
+        await cls._share_beneficial_effects(summoner, summon, stat_multiplier)
 
         log.debug(f"Created {summon_type} summon for {summoner.id} with {stat_multiplier*100}% stats")
 
         return summon
 
     @classmethod
-    def _share_beneficial_effects(
+    async def _share_beneficial_effects(
         cls,
         summoner: Stats,
         summon: "Summon",
@@ -162,21 +161,21 @@ class Summon(Stats):
             # Copy all HOTs (healing over time effects are inherently beneficial)
             for hot in effect_mgr.hots:
                 scaled_hot = cls._scale_hot_effect(hot, stat_multiplier)
-                summon.effect_manager.add_hot(scaled_hot)
+                await summon.effect_manager.add_hot(scaled_hot)
                 log.debug(f"Shared HOT '{hot.name}' to summon {summon.id}")
 
             # Copy beneficial StatModifiers (buffs)
+            shared_modifier_ids: set[str] = set()
             for mod in effect_mgr.mods:
                 if cls._is_beneficial_stat_modifier(mod):
+                    mod_id = getattr(mod, "id", None)
+                    if mod_id and mod_id in shared_modifier_ids:
+                        continue
                     scaled_mod = cls._scale_stat_modifier(mod, summon, stat_multiplier)
                     scaled_mod.apply()  # Apply the modifier to ensure it affects the summon's stats
-                    coro = summon.effect_manager.add_modifier(scaled_mod)
-                    try:
-                        loop = asyncio.get_running_loop()
-                    except RuntimeError:
-                        asyncio.run(coro)
-                    else:
-                        loop.create_task(coro)
+                    await summon.effect_manager.add_modifier(scaled_mod)
+                    if mod_id:
+                        shared_modifier_ids.add(mod_id)
                     log.debug(f"Shared beneficial StatModifier '{mod.name}' to summon {summon.id}")
 
     @classmethod

--- a/backend/autofighter/summons/manager.py
+++ b/backend/autofighter/summons/manager.py
@@ -41,7 +41,7 @@ class SummonManager:
         log.debug("SummonManager initialized")
 
     @classmethod
-    def create_summon(
+    async def create_summon(
         cls,
         summoner: Stats,
         summon_type: str = "generic",
@@ -101,7 +101,7 @@ class SummonManager:
 
         active_list = cls._active_summons.setdefault(summoner_id, [])
 
-        summon = Summon.create_from_summoner(
+        summon = await Summon.create_from_summoner(
             summoner,
             summon_type,
             source,
@@ -113,7 +113,7 @@ class SummonManager:
         cls._instance_counters[summoner_id] = counter
         summon.instance_id = f"{summoner_id}#{counter}"
         cls._active_summons[summoner_id].append(summon)
-        BUS.emit_batched("summon_created", summoner, summon, source)
+        await BUS.emit_batched_async("summon_created", summoner, summon, source)
         log.info("Created %s summon for %s from %s", summon_type, summoner_id, source)
         return summon
 

--- a/backend/plugins/cards/phantom_ally.py
+++ b/backend/plugins/cards/phantom_ally.py
@@ -79,7 +79,7 @@ class PhantomAlly(CardBase):
                 override_damage_type = None
         else:
             override_damage_type = original_damage_type
-        summon = SummonManager.create_summon(
+        summon = await SummonManager.create_summon(
             summoner=original,
             summon_type="phantom",
             source=self.id,

--- a/backend/plugins/characters/luna.py
+++ b/backend/plugins/characters/luna.py
@@ -276,7 +276,7 @@ class Luna(PlayerBase):
             return weight * 6.0
         return weight
 
-    def prepare_for_battle(
+    async def prepare_for_battle(
         self,
         node: MapNode,
         registry: "PassiveRegistry",
@@ -320,7 +320,7 @@ class Luna(PlayerBase):
             label_counts[key] = count
             summon_type_base = f"luna_sword_{key}"
             summon_type = summon_type_base if count == 1 else f"{summon_type_base}_{count}"
-            summon = SummonManager.create_summon(
+            summon = await SummonManager.create_summon(
                 self,
                 summon_type=summon_type,
                 source="luna_sword",

--- a/backend/plugins/damage_types/light.py
+++ b/backend/plugins/damage_types/light.py
@@ -27,7 +27,7 @@ class Light(DamageTypeBase):
             if mgr is not None:
                 hot = damage_effects.create_hot(self.id, actor)
                 if hot is not None:
-                    mgr.add_hot(hot)
+                    await mgr.add_hot(hot)
             await pace_sleep(YIELD_MULTIPLIER)
 
         for ally in allies:

--- a/backend/plugins/passives/normal/ally_overload.py
+++ b/backend/plugins/passives/normal/ally_overload.py
@@ -94,7 +94,7 @@ class AllyOverload:
             em.hots.clear()
             target.hots.clear()
 
-            def _block_hot(self_em, *_: object, **__: object) -> None:
+            async def _block_hot(self_em, *_: object, **__: object) -> None:
                 return None
 
             self._add_hot_backup[entity_id] = em.add_hot

--- a/backend/plugins/passives/normal/becca_menagerie_bond.py
+++ b/backend/plugins/passives/normal/becca_menagerie_bond.py
@@ -235,7 +235,7 @@ class BeccaMenagerieBond:
         damage_type = self._get_jellyfish_damage_type(jellyfish_type)
 
         # Create new summon using summons system
-        summon = SummonManager.create_summon(
+        summon = await SummonManager.create_summon(
             summoner=target,
             summon_type=f"jellyfish_{jellyfish_type}",
             source=self.id,

--- a/backend/plugins/passives/normal/casno_phoenix_respite.py
+++ b/backend/plugins/passives/normal/casno_phoenix_respite.py
@@ -64,10 +64,10 @@ class CasnoPhoenixRespite:
             return
 
         cls._action_counts[entity_id] = 0
-        cls._schedule_rest(target)
+        await cls._schedule_rest(target)
 
     @classmethod
-    def _schedule_rest(cls, target: "Stats") -> None:
+    async def _schedule_rest(cls, target: "Stats") -> None:
         if getattr(target, "hp", 0) <= 0:
             return
 
@@ -93,7 +93,7 @@ class CasnoPhoenixRespite:
 
         cls._pending_rest[entity_id] = True
         cls._helper_effect_ids[entity_id] = helper_id
-        effect_manager.add_hot(helper_effect)
+        await effect_manager.add_hot(helper_effect)
         cls._register_battle_end(target)
 
     @classmethod

--- a/backend/plugins/passives/normal/luna_lunar_reservoir.py
+++ b/backend/plugins/passives/normal/luna_lunar_reservoir.py
@@ -247,7 +247,9 @@ class LunaLunarReservoir:
 
         if event == "ultimate_used":
             cls._charge_points[entity_id] += 64 * multiplier
-        elif event != "hit_landed":
+        elif event == "hit_landed":
+            cls._charge_points[entity_id] += 1 * multiplier
+        else:
             cls._charge_points[entity_id] += 1 * multiplier
 
         current_charge = cls._charge_points[entity_id]

--- a/backend/tests/test_battle_progress_helpers.py
+++ b/backend/tests/test_battle_progress_helpers.py
@@ -54,7 +54,7 @@ async def test_collect_summon_snapshots_groups_by_owner():
     summoner = Stats(hp=1_000)
     summoner.id = "summoner"
     summoner.ensure_permanent_summon_slots(1)
-    summon = SummonManager.create_summon(summoner, summon_type="test", source="unit_test")
+    summon = await SummonManager.create_summon(summoner, summon_type="test", source="unit_test")
     assert summon is not None
 
     snapshots = await collect_summon_snapshots([summoner])
@@ -98,7 +98,7 @@ async def test_build_battle_progress_payload_includes_snapshots_and_events():
     party_member = Stats(hp=1_000)
     party_member.id = "hero"
     party_member.ensure_permanent_summon_slots(1)
-    hero_summon = SummonManager.create_summon(
+    hero_summon = await SummonManager.create_summon(
         party_member,
         summon_type="sprite",
         source="unit_test",
@@ -108,7 +108,7 @@ async def test_build_battle_progress_payload_includes_snapshots_and_events():
     foe = Stats(hp=900)
     foe.id = "foe"
     foe.ensure_permanent_summon_slots(1)
-    foe_summon = SummonManager.create_summon(
+    foe_summon = await SummonManager.create_summon(
         foe,
         summon_type="minion",
         source="unit_test",

--- a/backend/tests/test_status_phase_events.py
+++ b/backend/tests/test_status_phase_events.py
@@ -347,7 +347,7 @@ async def test_status_phase_events_update_snapshot_queue(monkeypatch):
         "chance": 25,
         "roll": 99,
     }
-    BUS.emit_batched("effect_resisted", "burn", target, attacker, resist_details)
+    await BUS.emit_batched_async("effect_resisted", "burn", target, attacker, resist_details)
     await bus._process_batches_internal()
 
     events_after_resist = list(battle_snapshots[run_id]["recent_events"])

--- a/backend/tests/test_summon_decision_logic.py
+++ b/backend/tests/test_summon_decision_logic.py
@@ -23,7 +23,7 @@ async def test_summon_viability_evaluation(monkeypatch):
     summoner._base_defense = 50
     summoner.ensure_permanent_summon_slots(1)
 
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -80,7 +80,7 @@ async def test_resummon_decision_logic(monkeypatch):
     assert decision['viable_count'] == 0
 
     # Create a healthy summon
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -119,7 +119,7 @@ async def test_smart_summon_creation(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create first summon (should succeed)
-    summon1 = SummonManager.create_summon(
+    summon1 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test1",
         source="test_source",
@@ -128,7 +128,7 @@ async def test_smart_summon_creation(monkeypatch):
     summon1.hp = summon1.max_hp  # Ensure healthy
 
     # Try to create second summon with healthy first summon (should fail due to smart logic)
-    summon2 = SummonManager.create_summon(
+    summon2 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test2",
         source="test_source",
@@ -139,7 +139,7 @@ async def test_smart_summon_creation(monkeypatch):
     summon1.hp = int(summon1.max_hp * 0.1)  # 10% health
 
     # Try to create second summon with damaged first summon (should succeed and replace)
-    summon3 = SummonManager.create_summon(
+    summon3 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test3",
         source="test_source",
@@ -167,7 +167,7 @@ async def test_force_create_bypasses_logic(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create first summon
-    summon1 = SummonManager.create_summon(
+    summon1 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test1",
         source="test_source",
@@ -176,7 +176,7 @@ async def test_force_create_bypasses_logic(monkeypatch):
     summon1.hp = summon1.max_hp  # Ensure healthy
 
     # Force create second summon even with healthy first summon
-    summon2 = SummonManager.create_summon(
+    summon2 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test2",
         source="test_source",
@@ -205,7 +205,7 @@ async def test_health_threshold_customization(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create summon with 40% health
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source"

--- a/backend/tests/test_summon_manager_no_event_loop_warning.py
+++ b/backend/tests/test_summon_manager_no_event_loop_warning.py
@@ -20,7 +20,7 @@ async def test_on_entity_killed_no_event_loop_warning(monkeypatch, caplog):
     summoner = Stats()
     summoner.id = "test_summoner"
     summoner.ensure_permanent_summon_slots(1)
-    SummonManager.create_summon(summoner, summon_type="test")
+    await SummonManager.create_summon(summoner, summon_type="test")
     summon = SummonManager.get_summons("test_summoner")[0]
 
     with caplog.at_level(logging.WARNING, logger="plugins.event_bus"):

--- a/backend/tests/test_summon_safeguards.py
+++ b/backend/tests/test_summon_safeguards.py
@@ -29,7 +29,7 @@ async def test_summons_cannot_create_more_summons(monkeypatch):
     original_summoner.ensure_permanent_summon_slots(1)
 
     # Create a summon from the original summoner
-    first_summon = SummonManager.create_summon(
+    first_summon = await SummonManager.create_summon(
         summoner=original_summoner,
         summon_type="first_summon",
         source="test_source"
@@ -39,7 +39,7 @@ async def test_summons_cannot_create_more_summons(monkeypatch):
     assert isinstance(first_summon, Summon)
 
     # Now try to create a summon from the first summon (this should be blocked)
-    second_summon = SummonManager.create_summon(
+    second_summon = await SummonManager.create_summon(
         summoner=first_summon,  # Summon trying to create another summon
         summon_type="second_summon",
         source="test_source"
@@ -72,13 +72,13 @@ async def test_regular_entities_can_still_create_summons(monkeypatch):
     player2.ensure_permanent_summon_slots(1)
 
     # Both should be able to create summons
-    summon1 = SummonManager.create_summon(
+    summon1 = await SummonManager.create_summon(
         summoner=player1,
         summon_type="summon1",
         source="test_source"
     )
 
-    summon2 = SummonManager.create_summon(
+    summon2 = await SummonManager.create_summon(
         summoner=player2,
         summon_type="summon2",
         source="test_source"
@@ -107,7 +107,7 @@ async def test_summon_identification_works(monkeypatch):
     player.id = "player"
     player.ensure_permanent_summon_slots(1)
 
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=player,
         summon_type="test_summon",
         source="test_source"
@@ -143,7 +143,7 @@ async def test_summon_safeguard_logging(monkeypatch, caplog):
     player.id = "test_player"
     player.ensure_permanent_summon_slots(1)
 
-    first_summon = SummonManager.create_summon(
+    first_summon = await SummonManager.create_summon(
         summoner=player,
         summon_type="first_summon",
         source="test_source"
@@ -152,7 +152,7 @@ async def test_summon_safeguard_logging(monkeypatch, caplog):
     assert first_summon is not None
 
     # Try to create summon from summon (should be blocked and logged)
-    second_summon = SummonManager.create_summon(
+    second_summon = await SummonManager.create_summon(
         summoner=first_summon,
         summon_type="second_summon",
         source="test_source"

--- a/backend/tests/test_summons_system.py
+++ b/backend/tests/test_summons_system.py
@@ -56,7 +56,7 @@ async def test_summon_creation_basic(monkeypatch):
     summoner._base_defense = 50
 
     # Create summon
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -89,7 +89,7 @@ async def test_summon_manager_creation_and_tracking(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create summon via manager
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source"
@@ -118,7 +118,7 @@ async def test_summon_manager_limits(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create first summon (should succeed)
-    summon1 = SummonManager.create_summon(
+    summon1 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test1",
         source="test_source",
@@ -126,7 +126,7 @@ async def test_summon_manager_limits(monkeypatch):
     assert summon1 is not None
 
     # Try to create second summon (should fail due to limit)
-    summon2 = SummonManager.create_summon(
+    summon2 = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test2",
         source="test_source",
@@ -150,7 +150,7 @@ async def test_summon_battle_lifecycle(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create temporary summon
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="temporary",
         source="test_source",
@@ -180,7 +180,7 @@ async def test_summon_turn_expiration(monkeypatch):
     summoner.ensure_permanent_summon_slots(1)
 
     # Create summon with 2 turn duration
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=summoner,
         summon_type="timed",
         source="test_source",
@@ -465,7 +465,7 @@ async def test_damage_type_inheritance(monkeypatch):
     total_summons = 20
 
     for i in range(total_summons):
-        summon = Summon.create_from_summoner(
+        summon = await Summon.create_from_summoner(
             summoner=summoner,
             summon_type=f"test_{i}",
             source="test"
@@ -492,7 +492,7 @@ async def test_summon_party_integration(monkeypatch):
     party = Party(members=[ally])
 
     # Create summon
-    summon = SummonManager.create_summon(
+    summon = await SummonManager.create_summon(
         summoner=ally,
         summon_type="test",
         source="test_source"
@@ -519,7 +519,7 @@ async def test_summon_defeat_cleanup(monkeypatch):
     summoner.hp = 1
 
     # Create summon
-    SummonManager.create_summon(
+    await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source"
@@ -552,7 +552,7 @@ async def test_summons_reset_before_new_battle(monkeypatch):
     summoner = Ally()
     summoner.id = "test_summoner"
 
-    SummonManager.create_summon(
+    await SummonManager.create_summon(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -609,7 +609,7 @@ async def test_summon_inheritance_with_effects(monkeypatch):
     assert summoner.vitality == 2.0  # 1.5 base + 0.5 effect
 
     # Create summon with 50% stat inheritance
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -681,7 +681,7 @@ async def test_summon_inherits_beneficial_effects(monkeypatch):
     await summoner.effect_manager.add_modifier(stat_mod)
 
     # Create summon with 50% stat inheritance
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -779,7 +779,7 @@ async def test_summon_does_not_inherit_harmful_effects(monkeypatch):
     await summoner.effect_manager.add_modifier(harmful_mod)
 
     # Create summon
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",
@@ -841,7 +841,7 @@ async def test_summon_inherits_mixed_effects_correctly(monkeypatch):
     summoner.effect_manager = EffectManager(summoner)
 
     # Create summon
-    summon = Summon.create_from_summoner(
+    summon = await Summon.create_from_summoner(
         summoner=summoner,
         summon_type="test",
         source="test_source",

--- a/backend/tests/test_turn_loop_summon_updates.py
+++ b/backend/tests/test_turn_loop_summon_updates.py
@@ -457,7 +457,7 @@ async def test_summon_instance_ids_used_in_progress_and_events(monkeypatch):
                 base_action_value=0.0,
             )
 
-    def _fake_create_from_summoner(cls, summoner, summon_type, *_, **__):
+    async def _fake_create_from_summoner(cls, summoner, summon_type, *_, **__):
         summoner_id = getattr(summoner, "id", str(id(summoner)))
         return _FakeSummon(summoner_id, summon_type)
 
@@ -466,13 +466,13 @@ async def test_summon_instance_ids_used_in_progress_and_events(monkeypatch):
     summoner = SimpleEntity("luna")
     summoner.summon_slot_capacity = 4
 
-    sword_one = SummonManager.create_summon(
+    sword_one = await SummonManager.create_summon(
         summoner,
         summon_type="luna_sword_lightstream",
         source="test",
         force_create=True,
     )
-    sword_two = SummonManager.create_summon(
+    sword_two = await SummonManager.create_summon(
         summoner,
         summon_type="luna_sword_lightstream",
         source="test",
@@ -607,7 +607,7 @@ async def test_luna_glitched_lightstream_snapshot_ids():
     )
     registry = PassiveRegistry()
 
-    luna.prepare_for_battle(node, registry)
+    await luna.prepare_for_battle(node, registry)
 
     swords = SummonManager.get_summons(luna.id)
     assert len(swords) == 2, "Glitched Luna should summon two Lightstream swords"


### PR DESCRIPTION
## Summary
- make `Summon.create_from_summoner` asynchronous so cloned HoTs and modifiers are awaited and deduplicated
- await the summon factory and batched events in `SummonManager`/battle setup while converting HoT insertion to async across cards and passives
- update summon-related tests, plugins, and Luna passives (including charge handling) to use the new async APIs

## Testing
- uv run pytest backend/tests/test_summon_decision_logic.py backend/tests/test_summons_system.py backend/tests/test_summon_safeguards.py backend/tests/test_battle_progress_helpers.py backend/tests/test_summon_manager_no_event_loop_warning.py backend/tests/test_turn_loop_summon_updates.py backend/tests/test_character_passives.py backend/tests/test_status_phase_events.py backend/tests/test_light_hot.py

------
https://chatgpt.com/codex/tasks/task_b_68eacb29a138832cbe97e48f2dc572b3