### PR TITLE
[FIX] Clean up stat modifier deduplication

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -422,8 +422,15 @@ class EffectManager:
 
         if effect in self.mods:
             self.mods.remove(effect)
-        else:
-            self.mods[:] = [existing for existing in self.mods if existing.id != effect.id]
+
+        duplicates = [
+            existing for existing in self.mods if existing.id == effect.id
+        ]
+        for existing in duplicates:
+            existing.remove()
+
+        if duplicates:
+            self.mods[:] = [mod for mod in self.mods if mod not in duplicates]
 
         while effect.id in self.stats.mods:
             self.stats.mods.remove(effect.id)


### PR DESCRIPTION
## Summary
- ensure `EffectManager.add_modifier` removes any existing stat modifiers sharing the same id before deduplicating
- prevent stale `StatEffect` instances from persisting when a modifier is re-applied

## Testing
- `uv run pytest backend/tests/test_effects.py::test_stat_modifier_applies_and_expires` *(fails: ModuleNotFoundError: No module named 'cryptography')*

------
https://chatgpt.com/codex/tasks/task_b_68ead5704340832c951131081c589be1