### PR TITLE
Make enrage test effect manager awaitable

### DIFF
--- a/backend/tests/backend/rooms/battle/test_enrage.py
+++ b/backend/tests/backend/rooms/battle/test_enrage.py
@@ -35,8 +35,9 @@ class DummyEffectManager:
     async def add_modifier(self, mod: Any) -> None:
         self.mods.append(mod)
 
-    def add_dot(self, dot: Any) -> None:
+    async def add_dot(self, dot: Any) -> None:
         self.dots.append(dot)
+        return
 
 
 class DummyCombatant:


### PR DESCRIPTION
## Summary
- make the enrage test dummy effect manager's add_dot helper awaitable so it matches async usage

## Testing
- [x] Backend tests (uv run pytest tests/backend/rooms/battle/test_enrage.py)
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68ead9585a4c832c9621824ca188c170