### PR TITLE
Fix Charged Decay DOT coroutine await

### DIFF
--- a/backend/plugins/dots/charged_decay.py
+++ b/backend/plugins/dots/charged_decay.py
@@ -8,8 +8,8 @@ class ChargedDecay(DamageOverTime):
     def __init__(self, damage: int, turns: int) -> None:
         super().__init__("Charged Decay", damage, turns, self.id)
 
-    def tick(self, target, *_):
-        alive = super().tick(target)
+    async def tick(self, target, *_):
+        alive = await super().tick(target, *_)
         if not alive:
             target.stunned = True
         return alive


### PR DESCRIPTION
## Summary
- declare `ChargedDecay.tick` as `async` and await the base damage-over-time implementation
- preserve the stun application when the DOT finishes ticking

## Testing
- uv run pytest tests/test_lightning_ultimate.py
- ./backend/.venv/bin/pytest backend/tests/test_lightning_ultimate.py

------
https://chatgpt.com/codex/tasks/task_b_68ead96f9384832c814b63d7da7f5454