### PR TITLE
Fix: await summon manager cleanup flows

### DIFF
--- a/backend/plugins/cards/phantom_ally.py
+++ b/backend/plugins/cards/phantom_ally.py
@@ -43,7 +43,7 @@ class PhantomAlly(CardBase):
             if phantom_viable:
                 return
             for phantom in active_phantoms:
-                SummonManager.remove_summon(phantom, "phantom_ally_replaced")
+                await SummonManager.remove_summon(phantom, "phantom_ally_replaced")
                 if phantom in party.members:
                     party.members.remove(phantom)
 
@@ -155,7 +155,7 @@ class PhantomAlly(CardBase):
                 )
                 if not remaining_phantoms:
                     setattr(original, phantom_slot_tracker, 0)
-            SummonManager.remove_summon(summon, "phantom_ally_cleanup")
+            await SummonManager.remove_summon(summon, "phantom_ally_cleanup")
             self.cleanup_subscriptions()
 
         self.subscribe("battle_end", _cleanup)

--- a/backend/plugins/passives/normal/becca_menagerie_bond.py
+++ b/backend/plugins/passives/normal/becca_menagerie_bond.py
@@ -228,7 +228,7 @@ class BeccaMenagerieBond:
         if jellyfish_summons and jellyfish_type != self._last_summon.get(entity_key):
             # Remove old summon and create spirit
             for old_summon in jellyfish_summons:
-                SummonManager.remove_summon(old_summon, "replaced")
+                await SummonManager.remove_summon(old_summon, "replaced")
             await self._create_spirit(target)
 
         # Determine damage type based on jellyfish type


### PR DESCRIPTION
## Summary
- make SummonManager removal and cleanup handlers async so batched bus events and effect manager calls are awaited
- update Phantom Ally and Becca's passive to await the new asynchronous summon removal helpers

## Testing
- uv run pytest tests/test_summons_system.py tests/test_summon_decision_logic.py tests/test_summon_manager_no_event_loop_warning.py tests/test_summon_safeguards.py tests/test_battle_progress_helpers.py tests/test_five_star_cards.py tests/test_turn_loop_summon_updates.py tests/test_luna_swords.py

------
https://chatgpt.com/codex/tasks/task_b_68eaded2044c832ca8ccb33604282497