### PR TITLE
Fix relic event guards for party members

### DIFF
--- a/backend/plugins/relics/arcane_flask.py
+++ b/backend/plugins/relics/arcane_flask.py
@@ -29,6 +29,8 @@ class ArcaneFlask(RelicBase):
             state["stacks"] = stacks
 
         async def _ultimate(user) -> None:
+            if user is None or user not in getattr(party, "members", ()):  # type: ignore[arg-type]
+                return
             current_state = getattr(party, "_arcane_flask_state", {})
             current_stacks = current_state.get("stacks", 0)
             if current_stacks <= 0:

--- a/backend/plugins/relics/bent_dagger.py
+++ b/backend/plugins/relics/bent_dagger.py
@@ -25,6 +25,8 @@ class BentDagger(RelicBase):
         async def _on_death(target, attacker, amount, *_: object) -> None:
             if target in party.members or target.hp > 0:
                 return
+            if attacker is None or attacker not in getattr(party, "members", ()):  # type: ignore[arg-type]
+                return
 
             # Track the kill trigger
             await BUS.emit_async("relic_effect", "bent_dagger", attacker, "foe_killed", amount, {

--- a/backend/plugins/relics/echo_bell.py
+++ b/backend/plugins/relics/echo_bell.py
@@ -48,6 +48,9 @@ class EchoBell(RelicBase):
             if _echo_processing:
                 return
 
+            if actor is None or actor not in getattr(party, "members", ()):  # type: ignore[arg-type]
+                return
+
             pid = id(actor)
             if pid in used:
                 return

--- a/backend/plugins/relics/echoing_drum.py
+++ b/backend/plugins/relics/echoing_drum.py
@@ -46,6 +46,9 @@ class EchoingDrum(RelicBase):
             if _echo_processing:
                 return
 
+            if attacker is None or attacker not in getattr(party, "members", ()):  # type: ignore[arg-type]
+                return
+
             pid = id(attacker)
             if pid in used:
                 return
@@ -134,9 +137,14 @@ class EchoingDrum(RelicBase):
             if getattr(party, "_echoing_drum_state", None) is state:
                 delattr(party, "_echoing_drum_state")
 
+        def _on_defeat(entity, *_args) -> None:
+            if entity in getattr(party, "members", ()):  # type: ignore[arg-type]
+                used.discard(id(entity))
+
         self.subscribe(party, "battle_start", _battle_start)
         self.subscribe(party, "action_used", _attack)
         self.subscribe(party, "attack_used", _attack)
+        self.subscribe(party, "entity_defeat", _on_defeat)
         self.subscribe(party, "battle_end", _cleanup)
 
     def describe(self, stacks: int) -> str:

--- a/backend/plugins/relics/killer_instinct.py
+++ b/backend/plugins/relics/killer_instinct.py
@@ -53,6 +53,8 @@ class KillerInstinct(RelicBase):
                 _remove_buff(speed_buffs, member_id)
 
         async def _ultimate(user) -> None:
+            if user is None or user not in getattr(party, "members", ()):  # type: ignore[arg-type]
+                return
             current_state = getattr(party, "_killer_instinct_state", state)
             current_stacks = current_state.get("stacks", 0)
             if current_stacks <= 0:
@@ -84,7 +86,7 @@ class KillerInstinct(RelicBase):
             ultimate_buffs[id(user)] = (user, mod)
 
         async def _damage(target, attacker, amount, *_: object) -> None:
-            if attacker is None:
+            if attacker is None or attacker not in getattr(party, "members", ()):  # type: ignore[arg-type]
                 return
             if target.hp <= 0 and id(attacker) in ultimate_buffs:
                 current_state = getattr(party, "_killer_instinct_state", state)

--- a/backend/plugins/relics/lucky_button.py
+++ b/backend/plugins/relics/lucky_button.py
@@ -24,6 +24,8 @@ class LuckyButton(RelicBase):
         active: dict[int, tuple[PlayerBase, CriticalBoost]] = {}
 
         async def _crit_missed(attacker, target) -> None:
+            if attacker is None or attacker not in getattr(party, "members", ()):  # type: ignore[arg-type]
+                return
             pid = id(attacker)
             pending[pid] = pending.get(pid, 0) + 1
 


### PR DESCRIPTION
## Summary
- guard Arcane Flask, Echoing Drum, Echo Bell, Lucky Button, Killer Instinct, and Bent Dagger bus callbacks so only party members receive their effects
- reset Echoing Drum's "used" cache when an ally is defeated to allow reapplication after revives
- add regression tests that spawn foe Luna and Becca to ensure enemy summons no longer inherit player relic buffs

## Testing
- `uv run pytest backend/tests/test_relic_effects.py::test_arcane_flask_ignores_foe_summons backend/tests/test_relic_effects.py::test_echoing_drum_ignores_foe_attack_buffs`


------
https://chatgpt.com/codex/tasks/task_b_68ec3dadadb4832c85082354b5d7ee4c