### PR TITLE
Fix foe speed metadata to use speed stat

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -17,6 +17,7 @@ DIMINISHING_RETURNS_CONFIG = {
     'hp': {'threshold': 500, 'scaling_factor': 1.05, 'base_offset': 50000},
 
     'atk': {'threshold': 100, 'scaling_factor': 2.0, 'base_offset': 1000},
+    'spd': {'threshold': 100, 'scaling_factor': 2.0, 'base_offset': 1000},
     'defense': {'threshold': 100, 'scaling_factor': 2.0, 'base_offset': 1000},
 
     'mitigation': {'threshold': 0.01, 'scaling_factor': 100.0, 'base_offset': 2},
@@ -35,6 +36,7 @@ def get_current_stat_value(stats: Stats, stat_name: str) -> Union[int, float]:
         'hp': lambda s: s.max_hp,  # Use max_hp for HP calculations
         'atk': lambda s: s.atk,
         'defense': lambda s: s.defense,
+        'spd': lambda s: s.spd,
         'crit_rate': lambda s: s.crit_rate,
         'crit_damage': lambda s: s.crit_damage,
         'mitigation': lambda s: s.mitigation,

--- a/backend/services/run_configuration.py
+++ b/backend/services/run_configuration.py
@@ -197,13 +197,13 @@ _MODIFIER_DEFINITIONS: dict[str, dict[str, Any]] = {
         "grants_reward_bonus": True,
         "description": "Boosts foe action speed and initiative by +0.01× per stack before diminishing returns.",
         "effects_metadata": {
-            "stat": "atk",
+            "stat": "spd",
             "per_stack": 0.01,
             "scaling_type": "additive",
         },
         "diminishing_returns": {
             "applies": True,
-            "stat": "atk",
+            "stat": "spd",
             "source": "autofighter.effects.calculate_diminishing_returns",
         },
         "reward_bonuses": {
@@ -212,7 +212,7 @@ _MODIFIER_DEFINITIONS: dict[str, dict[str, Any]] = {
         },
         "preview_stacks": [0, 1, 5, 10],
         "effects": lambda stacks: _percent_modifier_effect(0.01, stacks),
-        "diminishing_stat": "atk",
+        "diminishing_stat": "spd",
     },
     "foe_hp": {
         "id": "foe_hp",

--- a/frontend/src/lib/components/RunChooser.svelte
+++ b/frontend/src/lib/components/RunChooser.svelte
@@ -62,6 +62,7 @@ import WizardNavigation from './WizardNavigation.svelte';
     mitigation: 'Mitigation',
     vitality: 'Vitality',
     atk: 'Attack',
+    spd: 'Speed',
     max_hp: 'Max HP',
     glitched_chance: 'Glitched odds',
     prime_chance: 'Prime odds'


### PR DESCRIPTION
## Summary
- update foe speed modifier metadata to report the speed stat consistently
- extend diminishing returns configuration to include speed values
- expose a Speed label in the run chooser to match the backend metadata

## Testing
- uv run pytest tests/test_run_configuration_service.py
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68ec4aa49288832ca11c2fff5cdddee1