### PR TITLE
Fix turn end pacing multiplier

### DIFF
--- a/backend/autofighter/rooms/battle/turn_loop/turn_end.py
+++ b/backend/autofighter/rooms/battle/turn_loop/turn_end.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import Any
 
 from ..pacing import _EXTRA_TURNS
-from ..pacing import TURN_PACING
 from ..pacing import YIELD_MULTIPLIER
 from ..pacing import _pace
 from ..pacing import pace_sleep
@@ -78,5 +77,6 @@ async def finish_turn(
     )
     if cycle_count:
         context.turn += cycle_count
-    await pace_sleep(2.2 * TURN_PACING)
+    # ``pace_sleep`` multiplies the provided value by ``TURN_PACING`` internally.
+    await pace_sleep(2.2)
     await pace_sleep(YIELD_MULTIPLIER)


### PR DESCRIPTION
## Summary
- call the turn end pacing helper with the intended multiplier and document the expectation
- cover the turn end pacing multiplier with a focused regression test

## Testing
- [x] Backend tests (`uv run pytest tests/test_turn_loop_finish_turn_branches.py::test_finish_turn_uses_multiplier`)
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68ec648ff0c0832cbe839568f8835d7c