### PR TITLE
Update Echoing Drum description to highlight first-attack restriction

### DIFF
--- a/backend/plugins/relics/echoing_drum.py
+++ b/backend/plugins/relics/echoing_drum.py
@@ -166,6 +166,8 @@ class EchoingDrum(RelicBase):
             else "no overflow chance"
         )
 
+        intro_sentence = "Only the first attack each battle can trigger this relic."
+
         chance_sentence = (
             "Aftertaste: "
             f"{total_chance}% total chance (25% per stack, {stacks} {stack_text}); "
@@ -178,4 +180,4 @@ class EchoingDrum(RelicBase):
             f"+{buff_percentage}% base ATK for 5 turns after it triggers."
         )
 
-        return f"{chance_sentence} {buff_sentence}"
+        return f"{intro_sentence} {chance_sentence} {buff_sentence}"


### PR DESCRIPTION
## Summary
- clarify the Echoing Drum `describe()` text by leading with the first-attack limitation before the chance and buff details

## Testing
- uv run pytest tests/test_echo_fix.py

------
https://chatgpt.com/codex/tasks/task_b_68ec66e46d60832ca02867c18278fad1