### PR TITLE
Fix stat modifier cleanup when reapplying during tick

### DIFF
--- a/backend/autofighter/effects.py
+++ b/backend/autofighter/effects.py
@@ -796,9 +796,10 @@ class EffectManager:
                 "expired_naturally": True
             })
 
-            self.mods.remove(mod)
-            if mod.id in self.stats.mods:
-                self.stats.mods.remove(mod.id)
+            if mod in self.mods:
+                self.mods.remove(mod)
+                if mod.id in self.stats.mods:
+                    self.stats.mods.remove(mod.id)
 
         mod_phase_payload.update(
             {


### PR DESCRIPTION
## Summary
- guard stat modifier cleanup in `EffectManager.tick` so removal only happens when the modifier is still tracked
- add a regression test covering modifier reapplication within the same tick to ensure the battle loop keeps running

## Testing
- [x] Backend tests (`uv run pytest tests/test_effects.py::test_stat_modifier_reapplied_during_tick_is_preserved`, `uv run pytest tests/test_effects.py -k stat_modifier`)
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68ec6731a5b0832c814667b35f1efbff