### PR TITLE
Fix prime portrait outline style binding

### DIFF
--- a/frontend/src/lib/battle/BattleFighterCard.svelte
+++ b/frontend/src/lib/battle/BattleFighterCard.svelte
@@ -416,7 +416,7 @@
             class:rank-boss={isBossRank}
             class:reduced={reducedMotion}
             on:click={cyclePortraitIfAvailable}
-            style={`--outline-anim-dur: ${outlineAnimDur}; --outline-anim-delay: ${outlineAnimDelay};`}
+            style={portraitStyle}
           >
             <div
               class="portrait-image"


### PR DESCRIPTION
## Summary
- ensure the battle fighter portrait div uses the computed `portraitStyle` so the prime outline gradient and width variables reach CSS

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [x] Linting (`bun run lint`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

Additional manual checks:
- `VITE_API_BASE=http://localhost bun run build`
- `VITE_API_BASE=http://localhost bunx vitest run` *(fails: TypeError from @sveltejs/vite-plugin-svelte load-custom.js expecting config)*

------
https://chatgpt.com/codex/tasks/task_b_68ec69b54158832c932964851f479299