### PR TITLE
[TASK] Add backlog coverage for relic gaps

### DIFF
--- a/.codex/tasks/relics/6832684f-update-relic-inventory-docs.md
+++ b/.codex/tasks/relics/6832684f-update-relic-inventory-docs.md
@@ -1,0 +1,16 @@
+# Task: Sync Relic Inventory Documentation with Current Implementations
+
+## Background
+The implementation guide at `.codex/implementation/relic-inventory.md` is out of sync with several relic behaviors. Notably, it still claims Killer Instinct grants extra turns on kills, Timekeeper's Hourglass grants extra turns, and Soul Prism remains a placeholder.【F:.codex/implementation/relic-inventory.md†L12-L38】 The codebase has since replaced those behaviors with specific buff logic and a fully realized revival flow.【F:backend/plugins/relics/killer_instinct.py†L11-L155】【F:backend/plugins/relics/timekeepers_hourglass.py†L11-L113】【F:backend/plugins/relics/soul_prism.py†L11-L101】 Keeping the documentation accurate is critical for player tooling and for onboarding contributors.
+
+## Objectives
+1. Update the relic entries in `.codex/implementation/relic-inventory.md` to describe the actual mechanics of Killer Instinct, Timekeeper's Hourglass, and Soul Prism, removing obsolete mentions of extra turns and placeholder text.
+2. Verify the rest of the relic list for any other drift from the current implementations and refresh descriptions as needed.
+3. If any additional mechanical nuances are discovered while reviewing, cross-link or update related implementation docs so the knowledge stays coherent.
+4. Note any follow-on work (e.g., missing frontend tooltip updates) as separate tasks if required.
+
+## Acceptance Criteria
+- The relic inventory documentation matches the mechanics implemented in the backend relic plugins.
+- All outdated claims about extra turns or placeholder status are removed or corrected.
+- Any supplementary docs touched by the changes remain internally consistent.
+- The update passes repository documentation checks (linting/formatting, if applicable).

--- a/.codex/tasks/relics/e8e3b85a-soul-prism-effect-manager-guard.md
+++ b/.codex/tasks/relics/e8e3b85a-soul-prism-effect-manager-guard.md
@@ -1,0 +1,18 @@
+# Task: Harden Soul Prism Revival Flow Against Missing Effect Managers
+
+## Background
+`SoulPrism` iterates over fallen allies at battle end, removing any lingering relic modifiers before reviving them. The implementation assumes every ally exposes `member.effect_manager` and tries to iterate `member.effect_manager.mods` before checking whether an effect manager exists. If an ally never received an `EffectManager` (for example, a fresh recruit who died before any buffs landed), the code raises an `AttributeError`, preventing the relic from reviving anyone.
+
+See the direct access in `backend/plugins/relics/soul_prism.py` lines 43-55.【F:backend/plugins/relics/soul_prism.py†L43-L66】
+
+## Objectives
+1. Guard all interactions with `member.effect_manager` inside `SoulPrism` so that allies without one are handled safely (e.g., lazily instantiate an `EffectManager` before removal/creation of modifiers).
+2. Make sure the cleanup branch that prunes existing modifiers continues to work for allies who already had an effect manager.
+3. Add a regression test covering a fallen ally who lacks `effect_manager` at battle end to confirm revival proceeds without raising.
+4. Update any relevant documentation to clarify the revival behavior if needed.
+
+## Acceptance Criteria
+- `SoulPrism` revives allies reliably even when they lacked an `EffectManager` prior to the relic trigger.
+- Unit tests capture the previously crashing scenario.
+- Existing functionality (max HP penalty, defense/mitigation buffs, telemetry) remains intact.
+- Documentation references stay accurate.

--- a/.codex/tasks/relics/e957a839-timekeepers-hourglass-effect-manager.md
+++ b/.codex/tasks/relics/e957a839-timekeepers-hourglass-effect-manager.md
@@ -1,0 +1,18 @@
+# Task: Ensure Timekeeper's Hourglass Applies Speed Buffs to All Eligible Allies
+
+## Background
+`TimekeepersHourglass` currently skips allies that do not already have an `effect_manager` instance when handing out its per-turn speed buff. Because the relic calls `getattr(member, "effect_manager", None)` and simply `continue`s when it finds `None`, any party member who has not previously received a modifier (for example a freshly spawned ally or a unit without passive buffs) will never get the Timekeeper haste effect. This contradicts the relic description and makes the relic appear inert for parts of the party.
+
+See the guard in the relic implementation: `backend/plugins/relics/timekeepers_hourglass.py` lines 57-84.【F:backend/plugins/relics/timekeepers_hourglass.py†L57-L84】
+
+## Objectives
+1. Update `TimekeepersHourglass` so it instantiates an `EffectManager` for allies lacking one before applying the speed modifier.
+2. Ensure the cleanup path still removes any modifiers that were added through the relic to prevent leaks across battles.
+3. Add regression coverage that demonstrates an ally without an `effect_manager` receives the buff after the fix.
+4. Refresh any relevant documentation or developer notes if the behavior description changes.
+
+## Acceptance Criteria
+- Allies without a pre-existing `effect_manager` receive the Timekeeper speed buff when the relic procs.
+- Unit tests cover the case where a brand-new ally is buffed successfully.
+- No orphaned modifiers remain on party members after battle end.
+- Documentation accurately reflects the corrected behavior.


### PR DESCRIPTION
## Summary
- add Timekeeper's Hourglass follow-up task to ensure the speed buff reaches all allies
- add Soul Prism follow-up task to guard against missing effect manager instances during revives
- add documentation sync task to update the relic inventory guide

## Testing
- not run (task authoring only)


------
https://chatgpt.com/codex/tasks/task_b_68ece498dce4832c9e27b0a5d2c306db