### PR TITLE
Add follow-up tasks for broken card logic

### DIFF
--- a/.codex/tasks/cards/5ecab3dc-guiding-compass-run-start.md
+++ b/.codex/tasks/cards/5ecab3dc-guiding-compass-run-start.md
@@ -1,0 +1,15 @@
+# Make Guiding Compass bonus truly run-limited
+
+## Summary
+Guiding Compass is intended to grant a one-time XP bonus on the first battle of a run, but its current implementation triggers every battle because the "used" flag resets on each battle end and the card instance is recreated per fight.
+
+## Details
+* `GuidingCompass.apply()` tracks `first_battle_bonus_used` inside the card instance and clears it on `battle_end`.【F:backend/plugins/cards/guiding_compass.py†L19-L55】
+* Cards are re-instantiated whenever `apply_cards()` runs for a new combat, so the local boolean resets to `False` before every battle even without the explicit reset.
+* As a result, every battle grants the "first battle" bonus, inflating XP gains.
+
+## Requirements
+- Persist a per-run flag (e.g., on the party or run state) so the bonus fires only once per run.
+- Ensure multiple party members with the card don't double-award the bonus.
+- Add regression coverage proving the bonus does **not** trigger on the second battle of the same run but does on a brand new run.
+- Update any relevant documentation that mentions the Guiding Compass bonus behavior.

--- a/.codex/tasks/cards/67dae4f6-vital-core-buff-reset.md
+++ b/.codex/tasks/cards/67dae4f6-vital-core-buff-reset.md
@@ -1,0 +1,17 @@
+# Replace Vital Core's wall-clock cooldown
+
+## Summary
+Vital Core prevents reapplying its low-HP vitality buff by storing member IDs in `active_boosts` and scheduling a hard-coded 20-second timer to clear the set. This means:
+- The boost may fail to reapply even after the 2-turn buff expires if the battle resolves faster than 20 seconds.
+- Long battles may re-enable the buff late because the timer fires regardless of remaining duration.
+- The logic depends on the event loop running and is detached from the actual turn system.
+
+## Details
+* The card adds a member ID to `active_boosts` when the party member drops below 30% HP and starts a `loop.call_later(20, ...)` callback to remove the ID later.【F:backend/plugins/cards/vital_core.py†L23-L68】
+* Buff expiration is controlled by `create_stat_buff(..., turns=2)`, so the effect manager already knows when the modifier should end. The 20-second timer is redundant and desynchronised from the turn counter.
+
+## Requirements
+- Track the vitality boost using battle events or modifier callbacks rather than a fixed wall-clock delay (e.g., remove the entry when the stat modifier expires, on heal/turn checks, or at battle end).
+- Ensure the buff can reapply promptly if a member dips below 30% HP again after the original buff duration.
+- Avoid leaking tasks or depending on `call_later` so the logic stays deterministic under asyncio.
+- Add automated coverage demonstrating that the buff re-applies after expiring and that no wall-clock assumptions remain.

--- a/.codex/tasks/cards/d66727fc-farsight-scope-before-attack.md
+++ b/.codex/tasks/cards/d66727fc-farsight-scope-before-attack.md
@@ -1,0 +1,18 @@
+# Fix Farsight Scope trigger event
+
+## Summary
+Farsight Scope listens for a `before_attack` BUS event that is never emitted during real combat. As a result, the card's +6% crit rate bonus for low-HP targets never activates outside of unit tests.
+
+## Details
+* The card subscribes to `before_attack` inside `FarsightScope.apply()` and only grants the temporary buff from that callback.【F:backend/plugins/cards/farsight_scope.py†L22-L71】
+* Combat flow around damage application emits `dodge`, `hit_landed`, and other events, but there is no `before_attack` emission anywhere in the runtime battle loop.【F:backend/autofighter/stats.py†L780-L820】
+* A unit test fakes the missing event (`tests/test_farsight_scope.py`), so the failure does not surface during testing.
+
+This leaves the card functionally inert in real matches.
+
+## Requirements
+- Update the backend so the Farsight Scope effect can trigger during actual battles.
+  - Either emit the missing `before_attack` event at an appropriate point in the combat sequence, **or** adjust the card to hook into an existing event that occurs before damage is resolved while still satisfying the design intent (granting the bonus before an attack is resolved).
+- Ensure the temporary crit buff still cleans up correctly after the acting unit uses its action.
+- Add or update automated coverage to prove the fix (e.g., integration test that runs a real battle frame and confirms the buff applies when a target is under 50% HP).
+- Document any combat event changes (if added) in the relevant `.codex/implementation` docs.


### PR DESCRIPTION
## Summary
- note that Farsight Scope listens for a battle event that is never fired and document the fix-up task
- add a task to persist Guiding Compass' first-battle XP bonus across the whole run instead of every combat
- flag Vital Core's wall-clock cooldown so it can be reworked to track modifier expiry reliably

## Testing
- not run (documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_b_68ece4cb1490832caae0a4cbf83218b7