### PR TITLE
docs: track fixes needed for passive healing and crit hooks

### DIFF
--- a/.codex/tasks/passives/118c4f7a-kboshi-hot-stack.md
+++ b/.codex/tasks/passives/118c4f7a-kboshi-hot-stack.md
@@ -1,0 +1,17 @@
+# Task: Give Flux Cycle Its Promised HoT
+
+## Background
+`KboshiFluxCycle` awards a damage bonus and a "small HoT" whenever his element fails to change. The passive increments `_hot_stacks` and creates a stat effect named `kboshi_flux_cycle_hot_heal_*`.
+
+## Problem
+The effect contains an empty `stat_modifiers` dict, so nothing ever heals. There is no call to the HoT manager or healing APIs, making the advertised sustain nonexistent. See `backend/plugins/passives/normal/kboshi_flux_cycle.py` lines 90-111.
+
+## Requested Changes
+- Implement the HoT using `EffectManager.add_hot` (or an equivalent helper) tied to the current stack count so the heal matches the intended magnitude.
+- Remove or refactor the placeholder `StatEffect` stub.
+- Add tests confirming that when Kboshi fails to change elements he receives heal ticks, and that switching elements clears the HoT.
+
+## Acceptance Criteria
+- Flux Cycle produces visible healing during turns where the element does not change.
+- Resetting stacks by changing elements cancels any pending HoT as expected.
+- Automated tests cover both the healing and reset paths.

--- a/.codex/tasks/passives/15340045-lady-fire-burn-hot.md
+++ b/.codex/tasks/passives/15340045-lady-fire-burn-hot.md
@@ -1,0 +1,18 @@
+# Task: Replace Dummy HP Effects in Infernal Momentum
+
+## Background
+`LadyOfFireInfernalMomentum` is intended to burn attackers after she takes damage and grant herself a HoT when she suffers self-inflicted fire drain.
+
+## Problem
+Both the burn and HoT rely on `StatEffect` modifiers targeting `"hp"`. The stats system ignores that key, so no damage or healing is applied. The passive therefore only grants the temporary attack boost while the reactive pieces never trigger. See `backend/plugins/passives/normal/lady_of_fire_infernal_momentum.py` lines 45-78.
+
+## Requested Changes
+- Implement proper damage-over-time application for the burn retaliation (e.g., via `EffectManager.maybe_inflict_dot` or direct `apply_damage`).
+- Convert the self-damage HoT into a real heal-over-time effect through the established HoT pipeline.
+- Ensure both effects respect existing mitigation/element rules where applicable.
+- Add regression tests verifying attackers take burn damage and that self-inflicted drain grants a HoT tick.
+
+## Acceptance Criteria
+- Attacking Lady of Fire while the passive is active inflicts damage consistent with the description.
+- Fire drain produces healing ticks that actually restore HP.
+- Automated tests cover both retaliation and self-heal paths.

--- a/.codex/tasks/passives/4bf8857c-lady-darkness-event-hooks.md
+++ b/.codex/tasks/passives/4bf8857c-lady-darkness-event-hooks.md
@@ -1,0 +1,18 @@
+# Task: Wire Eclipsing Veil Into DoT & Debuff Events
+
+## Background
+`LadyDarknessEclipsingVeil` is designed to siphon healing on every DoT tick and grant permanent attack bonuses when she resists debuffs. The passive defines `on_dot_tick` and `on_debuff_resist` helpers, but the core `apply()` body only drops stat effects.
+
+## Problem
+No event subscriptions exist for the passive, and `PassiveRegistry` never calls these helpers by default. As a result, the siphon HoT and resist-based attack buffs never fire. See `backend/plugins/passives/normal/lady_darkness_eclipsing_veil.py` lines 24-75 alongside the lack of any `BUS.subscribe` calls.
+
+## Requested Changes
+- Subscribe to the relevant battle bus events (e.g., `dot_tick`, `debuff_resisted` or whichever signal the combat system emits) when the passive initializes, and clean up the handlers on defeat/battle end.
+- Ensure `on_dot_tick` receives the actual DoT damage value and applies healing through the standard heal pipeline.
+- Verify debuff resistance events propagate to the passive and correctly stack the +5% attack bonus.
+- Add targeted tests demonstrating healing triggers on DoT ticks and attack bonuses appear after resisting debuffs.
+
+## Acceptance Criteria
+- Lady Darkness passively heals when any DoT ticks on the battlefield and gains stacking attack buffs when she resists debuffs.
+- Event subscriptions are cleaned up to avoid leaks when battles end.
+- Automated tests cover both the DoT siphon and resist bonus flows.

--- a/.codex/tasks/passives/7c88b424-lady-fire-ice-hot.md
+++ b/.codex/tasks/passives/7c88b424-lady-fire-ice-hot.md
@@ -1,0 +1,18 @@
+# Task: Implement Real Healing for Duality Engine Stack Consumption
+
+## Background
+`LadyFireAndIceDualityEngine` should heal allies and debuff foes whenever the character reuses the same element twice. The current implementation creates a `StatEffect` with an `"hp"` modifier to simulate a HoT.
+
+## Problem
+`StatEffect` modifiers feed into `_calculate_stat_modifier`, which does not understand `"hp"`. Adding the effect therefore does nothing; no healing occurs and the UI does not reflect a HoT. The code also directly manipulates `_active_effects` to clear potency stacks. See `backend/plugins/passives/normal/lady_fire_and_ice_duality_engine.py` lines 85-121.
+
+## Requested Changes
+- Replace the fake HoT with real healing over time using `EffectManager.add_hot` (or the appropriate helper) so stacks produce visible healing.
+- Avoid manual mutation of `_active_effects`; rely on `remove_effect_by_name` or other supported APIs when clearing potency bonuses.
+- Confirm foe mitigation debuffs still apply when stacks are consumed.
+- Add coverage that builds flux stacks, consumes them, and verifies healing ticks plus mitigation debuffs actually occur.
+
+## Acceptance Criteria
+- Consuming Flux stacks produces tangible healing through the battle healing system and debuffs enemies as described.
+- Internal state cleanup uses supported effect APIs (no direct `_active_effects` surgery).
+- Automated tests exercise the stack gain/consumption path.

--- a/.codex/tasks/passives/a2c66553-lady-echo-hit-tracking.md
+++ b/.codex/tasks/passives/a2c66553-lady-echo-hit-tracking.md
@@ -1,0 +1,17 @@
+# Task: Restore Lady Echo's Consecutive Hit Tracking
+
+## Background
+The `LadyEchoResonantStatic` passive is supposed to scale party crit rate when Lady Echo chains hits on the same foe. The plugin relies on tracking consecutive hits and stacking bonuses via `on_hit_target`.
+
+## Problem
+`PassiveRegistry` only calls special hooks named `on_hit_landed` for hit events. `LadyEchoResonantStatic` implements `on_hit_target` instead, so the tracking branch never executes and the party crit stacks stay at zero. Only the base DoT-scaling buff in `apply()` ever runs. See `backend/plugins/passives/normal/lady_echo_resonant_static.py` lines 18-100.
+
+## Requested Changes
+- Update the passive to respond to the actual hook emitted by `PassiveRegistry` (either rename to `on_hit_landed` or provide an adapter that delegates to the existing logic).
+- Ensure the helper receives damage/target context just like other passives (e.g., compare with `lady_lightning_stormsurge`).
+- Add regression coverage proving that consecutive hits on the same enemy now increment `get_party_crit_stacks` and that switching targets resets the stacks.
+
+## Acceptance Criteria
+- Automated tests cover the crit stack growth and reset behavior for Lady Echo's passive.
+- No regressions to the existing DoT scaling effect (chain bonus should still apply based on DoTs present).
+- Documentation or in-file docstring updated if behavior notes change.


### PR DESCRIPTION
## Summary
- add a task to restore Lady Echo's consecutive hit crit stacking logic
- add a task to hook Lady Darkness' passive into DoT/debuff events
- add tasks covering broken healing/damage implementations in the fire/ice and Kboshi passives

## Testing
- not run (documentation/task updates only)


------
https://chatgpt.com/codex/tasks/task_b_68ece4e90078832c9b52e359966e8d46