### PR TITLE
Address feedback: fade prime outline black streaks with opacity

### DIFF
--- a/frontend/src/lib/battle/BattleFighterCard.svelte
+++ b/frontend/src/lib/battle/BattleFighterCard.svelte
@@ -85,7 +85,10 @@
     const segments = [];
     let cursor = 0;
 
-    const primeColorStop = 'color-mix(in oklab, var(--prime-outline-color) var(--prime-outline-opacity, 90%), transparent calc(100% - var(--prime-outline-opacity, 90%)))';
+    const primeOpacityValue = 'var(--prime-outline-opacity, 90%)';
+    const primeOpacityInverse = 'calc(100% - var(--prime-outline-opacity, 90%))';
+    const primeColorStop = `color-mix(in oklab, var(--prime-outline-color) ${primeOpacityValue}, transparent ${primeOpacityInverse})`;
+    const primeBlackStop = `color-mix(in oklab, var(--prime-outline-black) ${primeOpacityValue}, transparent ${primeOpacityInverse})`;
 
     for (let i = 0; i < streakCount; i += 1) {
       const colorStart = cursor;
@@ -101,7 +104,7 @@
       cursor += blackWidths[i];
       const blackEnd = cursor;
       segments.push({
-        color: 'var(--prime-outline-black)',
+        color: primeBlackStop,
         start: blackStart,
         end: blackEnd
       });


### PR DESCRIPTION
## Summary
- apply the prime outline opacity variable to the black streak gradient stops so subdued states dim the entire border

## Testing
- bun run lint

------
https://chatgpt.com/codex/tasks/task_b_68ecea0dccd8832c85636806143ce5a9