### PR TITLE
Adjust defense mitigation scaling curve

### DIFF
--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -820,7 +820,7 @@ class Stats:
         src_vit = attacker_obj.vitality if attacker_obj is not None else 1.0
         original_damage_before_mitigation = amount
         # Guard against division by zero if vitality/mitigation are driven to 0 by effects
-        defense_term = max(self.defense ** 5, 1)
+        defense_term = max(self.defense ** 2, 1)
         vit = float(self.vitality) if isinstance(self.vitality, (int, float)) else 1.0
         mit = float(self.mitigation) if isinstance(self.mitigation, (int, float)) else 1.0
         # Clamp to a tiny positive epsilon to avoid zero/NaN

--- a/backend/tests/test_damage_reduction_passes.py
+++ b/backend/tests/test_damage_reduction_passes.py
@@ -8,7 +8,7 @@ from plugins.characters.carly import Carly
 def _calculate_expected_damage(stats: Carly, raw_amount: float, passes: int) -> int:
     src_vit = 1.0
     eps = 1e-6
-    defense_term = max(stats.defense ** 5, 1)
+    defense_term = max(stats.defense ** 2, 1)
     vit = float(stats.vitality)
     vit = vit if vit > eps else eps
     mit = float(stats.mitigation)


### PR DESCRIPTION
## Summary
- reduce the defense mitigation curve to use a squared term instead of a fifth power to avoid runaway reduction
- update the damage reduction test helper to reflect the new mitigation curve

## Testing
- pytest tests/test_damage_reduction_passes.py

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68ecf1319294832c93c4fbfcf0916813