### PR TITLE
Add lower-star fallback for reward cards

### DIFF
--- a/backend/autofighter/rooms/battle/resolution.py
+++ b/backend/autofighter/rooms/battle/resolution.py
@@ -78,7 +78,24 @@ async def resolve_rewards(
         log.debug("  card_choices returned %d options", len(choices))
         if not choices:
             log.debug("  No cards available for star level %d", card_stars)
-            continue
+            for fallback_stars in range(card_stars - 1, 0, -1):
+                log.debug(
+                    "  Attempting fallback star level %d for card selection",
+                    fallback_stars,
+                )
+                choices = card_choices(combat_party, fallback_stars, count=1)
+                log.debug(
+                    "    card_choices returned %d options for fallback",
+                    len(choices),
+                )
+                if choices:
+                    break
+                log.debug(
+                    "    No cards available for fallback star level %d",
+                    fallback_stars,
+                )
+            else:
+                continue
         candidate = choices[0]
         log.debug(
             "  Candidate card: %s (%s) - %d stars",


### PR DESCRIPTION
## Summary
- retry card reward selection with progressively lower star levels when higher tiers are empty
- keep FallbackEssence logic intact when no cards can be found
- add a regression test covering mixed star rewards when the high-star pool is exhausted

## Testing
- uv run pytest backend/tests/test_rdr.py::test_card_rewards_fall_back_to_lower_stars

------
https://chatgpt.com/codex/tasks/task_b_68ecf17626dc832caffdbbd0fe86b56c