### PR TITLE
Fix critical overdrive active target bookkeeping

### DIFF
--- a/backend/plugins/cards/critical_overdrive.py
+++ b/backend/plugins/cards/critical_overdrive.py
@@ -76,8 +76,12 @@ class CriticalOverdrive(CardBase):
                     crit_rate=extra_rate,
                     crit_damage=excess * 2,
                 )
-                await mgr.add_modifier(new_mod)
                 active_targets.add(pid)
+                try:
+                    await mgr.add_modifier(new_mod)
+                except Exception:
+                    active_targets.discard(pid)
+                    raise
                 await BUS.emit_async(
                     "card_effect",
                     self.id,


### PR DESCRIPTION
## Summary
- add the target to the active set before awaiting modifier registration so cleanup does not unsubscribe too early
- discard the target from the active set if modifier registration fails to keep tracking consistent

## Testing
- `uv run --project backend pytest backend/tests/test_critical_overdrive.py` *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_b_68ed04fbcf10832c9c2f3e69baeed799