### PR TITLE
Fix normal battle music fallback selection

### DIFF
--- a/frontend/src/lib/systems/assetRegistry.js
+++ b/frontend/src/lib/systems/assetRegistry.js
@@ -719,8 +719,15 @@ const pickMusicPlaylist = (entry, category) => {
   if (!entry) return [];
   const normalized = normalizeMusicCategory(category, 'normal');
   const candidates = [normalized];
-  if (entry.defaultCategory && !candidates.includes(entry.defaultCategory)) {
-    candidates.push(entry.defaultCategory);
+  const defaultCategory = entry.defaultCategory
+    ? normalizeMusicCategory(entry.defaultCategory, 'normal')
+    : null;
+  if (
+    defaultCategory &&
+    !candidates.includes(defaultCategory) &&
+    (normalized === 'boss' || defaultCategory !== 'boss')
+  ) {
+    candidates.push(defaultCategory);
   }
   if (!candidates.includes('normal')) {
     candidates.push('normal');


### PR DESCRIPTION
## Summary
- guard music playlist selection so normal/other categories do not fall back to boss defaults
- rewrite the viewport music weighting tests to use asset registry overrides and cover boss-only combatants

## Testing
- bun test frontend/tests/viewport-music-weight.test.js

------
https://chatgpt.com/codex/tasks/task_b_68ed89084890832c91c8cde151f250c5