### PR TITLE
Fix extra turn cleanup for departing actors

### DIFF
--- a/backend/autofighter/rooms/battle/pacing.py
+++ b/backend/autofighter/rooms/battle/pacing.py
@@ -89,6 +89,20 @@ def _grant_extra_turn(entity: Stats) -> None:
         pass
 
 
+def clear_extra_turns_for(entity: Stats | None) -> None:
+    """Remove pacing entries for a departing entity."""
+
+    try:
+        ident = id(entity)
+    except Exception:
+        return
+
+    try:
+        _EXTRA_TURNS.pop(ident, None)
+    except Exception:
+        pass
+
+
 def _clear_extra_turns(_entity: Stats) -> None:
     _EXTRA_TURNS.clear()
     set_visual_queue(None)

--- a/backend/autofighter/rooms/battle/turn_helpers.py
+++ b/backend/autofighter/rooms/battle/turn_helpers.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from autofighter.stats import BUS
 
+from .pacing import clear_extra_turns_for
+
 if TYPE_CHECKING:
     from ...party import Party
     from .core import BattleRoom
@@ -69,6 +71,7 @@ def remove_dead_foes(
 
     for index in range(len(foes) - 1, -1, -1):
         if getattr(foes[index], "hp", 1) <= 0:
-            foes.pop(index)
+            foe = foes.pop(index)
             foe_effects.pop(index)
             enrage_mods.pop(index)
+            clear_extra_turns_for(foe)

--- a/backend/autofighter/rooms/battle/turn_loop/player_turn.py
+++ b/backend/autofighter/rooms/battle/turn_loop/player_turn.py
@@ -15,6 +15,7 @@ from ..logging import queue_log
 from ..pacing import _EXTRA_TURNS
 from ..pacing import YIELD_MULTIPLIER
 from ..pacing import _pace
+from ..pacing import clear_extra_turns_for
 from ..pacing import impact_pause
 from ..pacing import pace_sleep
 from ..targeting import select_aggro_target
@@ -188,6 +189,7 @@ async def _run_player_turn_iteration(
 ) -> PlayerTurnIterationResult:
     action_start = asyncio.get_event_loop().time()
     if member.hp <= 0:
+        clear_extra_turns_for(member)
         await pace_sleep(YIELD_MULTIPLIER)
         return PlayerTurnIterationResult(repeat=False, battle_over=False)
 
@@ -313,6 +315,7 @@ async def _run_player_turn_iteration(
         return PlayerTurnIterationResult(repeat=False, battle_over=True)
 
     if member.hp <= 0:
+        clear_extra_turns_for(member)
         await context.registry.trigger(
             "turn_end",
             member,

--- a/backend/autofighter/summons/manager.py
+++ b/backend/autofighter/summons/manager.py
@@ -209,6 +209,9 @@ class SummonManager:
     async def remove_summon(cls, summon: Summon, reason: str = "unknown") -> bool:
         sid = summon.summoner_id
         if sid in cls._active_summons and summon in cls._active_summons[sid]:
+            from autofighter.rooms.battle.pacing import clear_extra_turns_for
+
+            clear_extra_turns_for(summon)
             cls._active_summons[sid].remove(summon)
             await BUS.emit_batched_async("summon_removed", summon, reason)
             if not cls._active_summons[sid]:

--- a/backend/tests/test_extra_turn_cleanup.py
+++ b/backend/tests/test_extra_turn_cleanup.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from autofighter.rooms.battle import pacing as battle_pacing
+from autofighter.rooms.battle.turn_helpers import remove_dead_foes
+from autofighter.rooms.battle.turn_loop import player_turn
+from autofighter.stats import BUS
+from autofighter.summons.manager import SummonManager
+import plugins.event_bus as event_bus_module
+
+
+def test_remove_dead_foes_clears_extra_turns() -> None:
+    battle_pacing._EXTRA_TURNS.clear()
+
+    foe = SimpleNamespace(hp=0)
+    foe_effect = object()
+    enrage_mod = object()
+    battle_pacing._EXTRA_TURNS[id(foe)] = 2
+
+    remove_dead_foes(
+        foes=[foe],
+        foe_effects=[foe_effect],
+        enrage_mods=[enrage_mod],
+    )
+
+    assert battle_pacing._EXTRA_TURNS.get(id(foe)) is None
+
+
+@pytest.mark.asyncio
+async def test_player_iteration_dead_member_clears_extra_turns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    battle_pacing._EXTRA_TURNS.clear()
+
+    member = SimpleNamespace(hp=0)
+    member_effect = object()
+    battle_pacing._EXTRA_TURNS[id(member)] = 3
+
+    async def _noop(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr(player_turn, "pace_sleep", _noop)
+
+    result = await player_turn._run_player_turn_iteration(
+        SimpleNamespace(),
+        member,
+        member_effect,
+    )
+
+    assert result.repeat is False
+    assert result.battle_over is False
+    assert battle_pacing._EXTRA_TURNS.get(id(member)) is None
+
+
+@pytest.mark.asyncio
+async def test_remove_summon_clears_extra_turns(monkeypatch: pytest.MonkeyPatch) -> None:
+    event_bus_module.bus._subs.clear()
+    SummonManager.cleanup()
+    battle_pacing._EXTRA_TURNS.clear()
+
+    async def _noop_emit(*_: object, **__: object) -> None:
+        return None
+
+    monkeypatch.setattr(BUS, "emit_batched_async", _noop_emit)
+
+    summoner = SimpleNamespace(id="summoner")
+    summon = SimpleNamespace(id="summon", summoner_id="summoner", is_temporary=True)
+    SummonManager._active_summons[summoner.id] = [summon]
+    SummonManager._summoner_refs[summoner.id] = summoner
+    battle_pacing._EXTRA_TURNS[id(summon)] = 1
+
+    removed = await SummonManager.remove_summon(summon, "test_reason")
+
+    assert removed is True
+    assert battle_pacing._EXTRA_TURNS.get(id(summon)) is None
+    SummonManager.cleanup()


### PR DESCRIPTION
## Summary
- add a pacing helper to remove any stored extra turns for a departing actor
- invoke the helper when foes, player party members, or summons leave battle
- cover the new cleanup points with targeted tests

## Testing
- uv run pytest backend/tests/test_extra_turn_cleanup.py

ready for review

------
https://chatgpt.com/codex/tasks/task_b_68ee0dfc13a0832ca7446749c4a5f186