### PR TITLE
Add task plan to improve battle pacing and reward previews

### DIFF
--- a/.codex/tasks/185897b3-trim-event-bus-yields.md
+++ b/.codex/tasks/185897b3-trim-event-bus-yields.md
@@ -1,0 +1,15 @@
+# Trim EventBus cooperative sleeps to unblock combat pacing
+
+## Summary
+The EventBus injects 2 ms `asyncio.sleep` calls for every batched event and every subscriber callback, so large combat bursts accumulate tens of seconds of idle time before actions render. We need to keep cooperative scheduling without throttling the loop on hot paths.
+
+## Details
+* Batched dispatch spends 2 ms per queued event when flattening and again after each gathered batch, even before any subscriber work runs.【F:backend/plugins/event_bus.py†L202-L237】
+* Each subscriber invocation in `send_async` sleeps for 2 ms after the callback, so decks/relics with dozens of listeners stall the loop by >100 ms per emission.【F:backend/plugins/event_bus.py†L267-L284】
+* Setup sequences emit hundreds of events (card/relic applications, extra turns, rewards), so the forced sleeps expand the “battle start” delay into 45 s–3 min when the queue is busy.
+
+## Requirements
+- Replace the fixed 2 ms sleeps with an adaptive strategy (e.g., yielding only after X ms of actual work or when the loop is saturated) that keeps responsiveness but eliminates unnecessary idle time for bursts under typical load.
+- Preserve cooperative behavior for pathological cases (no tight loops pegging the CPU) and document the new pacing policy.
+- Provide benchmarks or instrumentation snippets demonstrating the before/after latency for a representative battle setup.
+- Update or add tests covering batched dispatch and async subscribers so CI exercises the new pacing rules.

--- a/.codex/tasks/64309131-cache-battle-setup-modifiers.md
+++ b/.codex/tasks/64309131-cache-battle-setup-modifiers.md
@@ -1,0 +1,15 @@
+# Cache battle setup modifiers to remove redundant reapplication
+
+## Summary
+Every battle deep-copies the party, re-applies every learned card and relic, and then triggers each member’s `prepare_for_battle` hook. The combination with EventBus overhead makes battle setup balloon into multi-minute stalls. We need to cache persistent modifiers or incrementally apply changes so repeated battles don’t redo identical work.
+
+## Details
+* `setup_battle` clones party members and immediately calls `apply_cards` and `apply_relics`, forcing every plugin to emit setup events before combat can start.【F:backend/autofighter/rooms/battle/setup.py†L98-L138】
+* `apply_cards`/`apply_relics` iterate the entire deck/relic list on every invocation, instantiating plugins afresh and calling `apply`, even when nothing changed since the previous fight.【F:backend/autofighter/cards.py†L26-L38】【F:backend/autofighter/relics.py†L19-L50】
+* Reward selection simply appends IDs to `party.cards`/`party.relics`, so the same modifiers are recomputed on the next battle instead of being cached once when selected.【F:backend/services/reward_service.py†L20-L148】
+
+## Requirements
+- Design a caching or diff-based system (e.g., persist resolved stat modifiers or pre-built EffectManagers) so unchanged cards/relics don’t fully reapply each battle.
+- Ensure stateful plugins that expect per-battle hooks still fire correctly (document how to opt into “always re-run” behavior if needed).
+- Benchmark setup time before/after on a mid-game deck and record the improvement target (e.g., reduce setup to <5 s).
+- Update documentation in `.codex/implementation` describing the new lifecycle, and add regression coverage that a newly acquired card still applies its effect the next fight.

--- a/.codex/tasks/6f3d0a42-stage-reward-modifiers.md
+++ b/.codex/tasks/6f3d0a42-stage-reward-modifiers.md
@@ -1,0 +1,14 @@
+# Stage reward modifiers so card/relic effects preview before activation
+
+## Summary
+Reward selections append card/relic IDs to the party immediately, but their effects only apply when the next battle calls `apply_cards`/`apply_relics`. Players see nothing happen at selection time, missing the “Slay the Spire” style preview. We need a staging layer that previews the effect before commitment and then activates it cleanly.
+
+## Details
+* Selecting a card or relic writes the ID into the persisted party right away via `award_card`/`award_relic`, without invoking the corresponding `apply_*` logic.【F:backend/services/reward_service.py†L20-L148】【F:backend/autofighter/cards.py†L26-L38】【F:backend/autofighter/relics.py†L19-L50】
+* Because modifiers activate during the next `setup_battle` call, players have no UI feedback that e.g. a relic granted HP or a card adjusted stats until they enter another fight.【F:backend/autofighter/rooms/battle/setup.py†L98-L138】
+
+## Requirements
+- Introduce a reward staging state that records pending card/relic effects separately from the active deck until the player confirms or preview animations complete.
+- Emit rich metadata (stat deltas, upcoming triggers) so the frontend can show the preview before activation; coordinate with UI/UX for layout.
+- Ensure activation happens exactly once when the player confirms (or when the next battle starts) and add tests covering duplicate prevention and persistence.
+- Update documentation describing the new reward flow and how plugins can supply preview data.

--- a/.codex/tasks/adfe4d59-align-turn-pacing-defaults.md
+++ b/.codex/tasks/adfe4d59-align-turn-pacing-defaults.md
@@ -1,0 +1,14 @@
+# Harmonize turn pacing defaults and intro delay
+
+## Summary
+The backend uses a 0.2 s `TURN_PACING` while the config route and Settings UI assume 0.5 s. Combined with a hardcoded `pace_sleep(3 / TURN_PACING)` call, battle intros stall for 15 s by default (and even longer when pacing is lowered). We should align defaults and make the intro pause conditional.
+
+## Details
+* The pacing helper sets `DEFAULT_TURN_PACING = 0.2`, but API consumers expose a 0.5 default, so refreshing options snaps to different baselines depending on caller.【F:backend/autofighter/rooms/battle/pacing.py†L16-L57】【F:backend/routes/config.py†L16-L108】【F:frontend/src/lib/components/SettingsMenu.svelte†L25-L118】
+* Turn-loop initialization sleeps for `3 / TURN_PACING` after the first progress update, which is 15 s at the 0.2 backend default and scales inversely with faster pacing (e.g., 30 s if a player dials pacing to 0.1).【F:backend/autofighter/rooms/battle/turn_loop/initialization.py†L139-L153】
+
+## Requirements
+- Decide on a single canonical default pacing value (with product input) and update backend constants, API payloads, and the Settings UI to match.
+- Replace the fixed `3 / TURN_PACING` pause with a smarter gating mechanism (e.g., skip when no cinematic/intro assets exist, or cap the wait to a small constant).
+- Add regression coverage that the `/config/turn_pacing` endpoint and frontend slider display the same default, and document the intro pacing behavior.
+- Verify that existing options migrations/tests still pass with the new default.

--- a/.codex/tasks/cbd083cc-expand-snapshot-event-history.md
+++ b/.codex/tasks/cbd083cc-expand-snapshot-event-history.md
@@ -1,0 +1,14 @@
+# Expand combat snapshot event history to prevent missing actions
+
+## Summary
+The snapshot overlay only keeps the six most recent events per run. When pacing lags, new events overwrite older ones before the frontend polls, so attacks and relic triggers vanish from the UI. We should retain a deeper history (or stream deltas) so the overlay reflects everything that happened.
+
+## Details
+* `_RECENT_EVENT_LIMIT` is hardcoded to 6 and the per-run deque is cleared on prepare, so a burst of more than six events drops earlier entries outright.【F:backend/autofighter/rooms/battle/snapshots.py†L12-L37】
+* Battle setup and the first turn easily emit dozens of events (extra turns, buffs, heals), which means the frontend only ever sees the tail end of the burst when it finally renders.
+
+## Requirements
+- Decide on a richer retention strategy (larger deque size, per-event type buckets, or streamed pagination) that keeps enough context for normal combats.
+- Update the overlay mutation logic and any consumers to handle the deeper history efficiently (avoid ballooning payloads for marathon runs).
+- Add regression coverage ensuring at least N events survive a burst (e.g., simulate 20 quick emits and assert the client-visible list keeps them).
+- Document the new retention policy for UI developers.


### PR DESCRIPTION
## Summary
- add a task to rework event bus cooperative sleeps that stall battle pacing
- add tasks covering battle setup caching, pacing default alignment, and snapshot history depth
- add a task to stage card and relic rewards so their effects can preview before activation

## Testing
- uv sync

------
https://chatgpt.com/codex/tasks/task_b_68ee1b58c84c832ca1321488f823dfa2