### PR TITLE
fix: emit before_attack events during combat

### DIFF
--- a/.codex/implementation/event-bus.md
+++ b/.codex/implementation/event-bus.md
@@ -56,6 +56,9 @@ The core combat engine emits a few global events that plugins may subscribe to:
 - `damage_taken(target, attacker, amount)`
 - `heal(healer, target, amount)`
 - `heal_received(target, healer, amount)`
+- `before_attack(attacker, target, metadata, action_name)` – emitted immediately before damage is resolved when a combatant
+  attacks a target through the standard battle flow. `metadata` includes the staged `attack_index`, `attack_total`, and unique
+  `attack_sequence` values when available so listeners can correlate against the upcoming hit.
 - `hit_landed(attacker, target, amount, source_type="attack", source_name=None)` – emitted when a successful hit occurs
 
 Plugins can define additional event names as needed.

--- a/.codex/tasks/cards/d66727fc-farsight-scope-before-attack.md
+++ b/.codex/tasks/cards/d66727fc-farsight-scope-before-attack.md
@@ -16,3 +16,4 @@ This leaves the card functionally inert in real matches.
 - Ensure the temporary crit buff still cleans up correctly after the acting unit uses its action.
 - Add or update automated coverage to prove the fix (e.g., integration test that runs a real battle frame and confirms the buff applies when a target is under 50% HP).
 - Document any combat event changes (if added) in the relevant `.codex/implementation` docs.
+ready for review

--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -783,6 +783,14 @@ class Stats:
         attack_metadata["attack_sequence"] = max(sequence_value, 1)
         if attacker_obj is not None:
             setattr(attacker_obj, "_attack_sequence_counter", attack_metadata["attack_sequence"])
+        if attacker_obj is not None and trigger_on_hit:
+            await BUS.emit_async(
+                "before_attack",
+                attacker_obj,
+                self,
+                dict(attack_metadata),
+                action_name or "attack",
+            )
         critical = False
         if attacker_obj is not None:
             if random.random() < self.dodge_odds:

--- a/backend/tests/test_farsight_scope.py
+++ b/backend/tests/test_farsight_scope.py
@@ -1,5 +1,3 @@
-import asyncio
-
 import pytest
 
 from autofighter.cards import apply_cards
@@ -7,17 +5,11 @@ from autofighter.cards import award_card
 from autofighter.party import Party
 from autofighter.stats import BUS
 from autofighter.stats import Stats
-
-
-def setup_event_loop():
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    return loop
+from autofighter.stats import set_battle_active
 
 
 @pytest.mark.asyncio
 async def test_farsight_scope_crit_bonus_applied_and_removed():
-    loop = setup_event_loop()
     party = Party()
     ally = Stats()
     enemy = Stats()
@@ -26,7 +18,7 @@ async def test_farsight_scope_crit_bonus_applied_and_removed():
     enemy.hp = 1000
     party.members.append(ally)
     award_card(party, "farsight_scope")
-    loop.run_until_complete(apply_cards(party))
+    await apply_cards(party)
 
     base_crit = ally.crit_rate
 
@@ -35,4 +27,32 @@ async def test_farsight_scope_crit_bonus_applied_and_removed():
     assert ally.crit_rate == pytest.approx(base_crit + 0.06, abs=1e-6)
 
     await BUS.emit_async("action_used", ally, enemy, ally.atk)
+    assert ally.crit_rate == pytest.approx(base_crit, abs=1e-6)
+
+
+@pytest.mark.asyncio
+async def test_farsight_scope_triggers_during_normal_attack_flow():
+    party = Party()
+    ally = Stats()
+    enemy = Stats()
+    ally.set_base_stat("atk", 150)
+    enemy.set_base_stat("max_hp", 1000)
+    enemy.hp = 1000
+    enemy.dodge_odds = 0.0
+    party.members.append(ally)
+    award_card(party, "farsight_scope")
+    await apply_cards(party)
+
+    base_crit = ally.crit_rate
+    enemy.hp = 400  # Below 50%
+
+    set_battle_active(True)
+    try:
+        damage = await enemy.apply_damage(ally.atk, attacker=ally, action_name="Normal Attack")
+        assert damage > 0
+        assert ally.crit_rate == pytest.approx(base_crit + 0.06, abs=1e-6)
+        await BUS.emit_async("action_used", ally, enemy, damage)
+    finally:
+        set_battle_active(False)
+
     assert ally.crit_rate == pytest.approx(base_crit, abs=1e-6)


### PR DESCRIPTION
## Summary
- emit the `before_attack` combat event from `Stats.apply_damage` so card listeners fire during real battles
- expand the Farsight Scope test suite to cover the live attack flow and clean up async setup
- document the new combat event and mark the scope task as complete

## Testing
- `uv run pytest tests/test_farsight_scope.py`


------
https://chatgpt.com/codex/tasks/task_b_68ee3f4138f0832cac284007c1972dfd