### PR TITLE
[FIX] Make Vital Core low HP buff event-driven

### DIFF
--- a/.codex/tasks/cards/67dae4f6-vital-core-buff-reset.md
+++ b/.codex/tasks/cards/67dae4f6-vital-core-buff-reset.md
@@ -15,3 +15,4 @@ Vital Core prevents reapplying its low-HP vitality buff by storing member IDs in
 - Ensure the buff can reapply promptly if a member dips below 30% HP again after the original buff duration.
 - Avoid leaking tasks or depending on `call_later` so the logic stays deterministic under asyncio.
 - Add automated coverage demonstrating that the buff re-applies after expiring and that no wall-clock assumptions remain.
+ready for review

--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -1,8 +1,6 @@
-import asyncio
 from dataclasses import dataclass
 from dataclasses import field
 import logging
-
 from autofighter.effects import EffectManager
 from autofighter.effects import create_stat_buff
 from autofighter.stats import BUS
@@ -20,37 +18,42 @@ class VitalCore(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        loop = asyncio.get_running_loop()
-
         # Track which members have the vitality boost active to avoid stacking
-        active_boosts = set()
+        active_boosts: dict[int, str] = {}
 
         async def _check_low_hp() -> None:
             for member in party.members:
-                member_id = id(member)
                 current_hp = getattr(member, "hp", 0)
-                max_hp = getattr(member, "max_hp", 1)
+                max_hp = getattr(member, "max_hp", 0)
 
-                if current_hp / max_hp < 0.30 and member_id not in active_boosts:
-                    active_boosts.add(member_id)
+                member_key = id(member)
 
+                if max_hp <= 0:
+                    active_boosts.pop(member_key, None)
+                    continue
+
+                if current_hp / max_hp < 0.30 and member_key not in active_boosts:
                     effect_manager = getattr(member, "effect_manager", None)
                     if effect_manager is None:
                         effect_manager = EffectManager(member)
                         member.effect_manager = effect_manager
 
+                    effect_id = f"{self.id}_low_hp_vit_{id(member)}"
                     vit_mod = create_stat_buff(
                         member,
                         name=f"{self.id}_low_hp_vit",
+                        id=effect_id,
                         turns=2,
                         vitality_mult=1.03,
                     )
                     await effect_manager.add_modifier(vit_mod)
 
+                    active_boosts[member_key] = effect_id
+
                     log = logging.getLogger(__name__)
                     log.debug(
                         "Vital Core activated vitality boost for %s: +3% vitality for 2 turns",
-                        member.id,
+                        getattr(member, "id", "member"),
                     )
                     await BUS.emit_async(
                         "card_effect",
@@ -61,14 +64,29 @@ class VitalCore(CardBase):
                         {"vitality_boost": 3, "duration": 2, "trigger_threshold": 0.30},
                     )
 
-                    def _remove_boost() -> None:
-                        if member_id in active_boosts:
-                            active_boosts.remove(member_id)
-
-                    loop.call_soon_threadsafe(lambda: loop.call_later(20, _remove_boost))
-
         async def _on_damage_taken(target, attacker, damage, *_: object):
             await _check_low_hp()
 
+        async def _on_effect_expired(effect_name, target, payload):
+            if payload.get("effect_type") != "stat_modifier":
+                return
+
+            effect_id = payload.get("effect_id")
+            member_key = id(target)
+            if effect_id is None or member_key not in active_boosts:
+                return
+
+            if active_boosts.get(member_key) == effect_id:
+                active_boosts.pop(member_key, None)
+
+        async def _on_entity_defeat(target, *_: object):
+            active_boosts.pop(id(target), None)
+
+        async def _on_battle_end(*_: object):
+            active_boosts.clear()
+
         self.subscribe("turn_start", _check_low_hp)
         self.subscribe("damage_taken", _on_damage_taken)
+        self.subscribe("effect_expired", _on_effect_expired)
+        self.subscribe("entity_defeat", _on_entity_defeat)
+        self.subscribe("battle_end", _on_battle_end, cleanup_event=None)

--- a/backend/tests/test_vital_core.py
+++ b/backend/tests/test_vital_core.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import asyncio
+
+from autofighter.cards import apply_cards
+from autofighter.cards import award_card
+from autofighter.party import Party
+from autofighter.stats import BUS
+from autofighter.stats import set_battle_active
+from plugins.characters._base import PlayerBase
+from plugins.damage_types.generic import Generic
+from plugins.event_bus import bus as _bus
+
+
+def setup_event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+def flush_bus_tasks(loop):
+    batch_task = getattr(_bus, "_batch_timer", None)
+    if isinstance(batch_task, asyncio.Task):
+        loop.run_until_complete(batch_task)
+
+
+def _active_vital_core_ids(player: PlayerBase) -> set[str]:
+    effect_manager = getattr(player, "effect_manager", None)
+    if effect_manager is None:
+        return set()
+    return {modifier.id for modifier in effect_manager.mods}
+
+
+def test_vital_core_reapplies_after_expiration():
+    loop = setup_event_loop()
+    BUS.set_loop(loop)
+    set_battle_active(True)
+
+    party = Party()
+    defender = PlayerBase()
+    defender.id = "defender"
+    defender.damage_type = Generic()
+    defender.set_base_stat("max_hp", 1000)
+    defender.set_base_stat("vitality", 1.0)
+    defender.hp = defender.max_hp
+
+    party.members.append(defender)
+    award_card(party, "vital_core")
+    loop.run_until_complete(apply_cards(party))
+
+    expected_effect_id = f"vital_core_low_hp_vit_{id(defender)}"
+
+    try:
+        # Drop below 30% HP to trigger the emergency vitality buff.
+        damage = int(defender.max_hp * 0.8)
+        loop.run_until_complete(defender.apply_cost_damage(damage))
+        flush_bus_tasks(loop)
+        loop.run_until_complete(asyncio.sleep(0))
+
+        active_mods = _active_vital_core_ids(defender)
+        assert expected_effect_id in active_mods
+
+        # Advance two turns so the temporary buff expires naturally.
+        effect_manager = defender.effect_manager
+        assert effect_manager is not None
+        loop.run_until_complete(effect_manager.tick())
+        loop.run_until_complete(effect_manager.tick())
+        flush_bus_tasks(loop)
+        loop.run_until_complete(asyncio.sleep(0))
+
+        active_mods = _active_vital_core_ids(defender)
+        assert expected_effect_id not in active_mods
+
+        # Heal back up and drop below 30% HP again—the buff should reapply.
+        defender.hp = defender.max_hp
+        loop.run_until_complete(defender.apply_cost_damage(damage))
+        flush_bus_tasks(loop)
+        loop.run_until_complete(asyncio.sleep(0))
+
+        active_mods = _active_vital_core_ids(defender)
+        assert expected_effect_id in active_mods
+    finally:
+        loop.run_until_complete(BUS.emit_async("battle_end", defender))
+        flush_bus_tasks(loop)
+        loop.run_until_complete(asyncio.sleep(0.05))
+        set_battle_active(False)
+        BUS.set_loop(None)
+        loop.close()


### PR DESCRIPTION
## Summary
- replace Vital Core's 20s low-HP timer with event-driven tracking tied to modifier lifecycle
- clear boost state on defeat/battle end and reuse modifier IDs for clean reapplication
- add regression coverage ensuring the vitality buff reapplies after expiring

## Testing
- uv run pytest tests/test_vital_core.py

------
https://chatgpt.com/codex/tasks/task_b_68ee47244514832ca9d28788ad518369