### PR TITLE
[TASKMASTER] Add cleanup tasks for passives

### DIFF
--- a/.codex/tasks/passives/6a3ea15b-hilander-bus-cleanup.md
+++ b/.codex/tasks/passives/6a3ea15b-hilander-bus-cleanup.md
@@ -1,0 +1,27 @@
+# Hilander Critical Ferment bus cleanup
+
+## Summary
+Hilander's `Critical Ferment` passive subscribes to the global `critical_hit`
+event but never unregisters when Hilander is defeated while stacks remain. The
+callback persists for the rest of the run, leaking listeners and leaving the
+`_hilander_crit_cb` attribute on the defeated unit.
+
+## Details
+* The passive registers a callback the first time it applies stacks and only
+  unsubscribes if all stacks are consumed or the weakref target disappears. There
+  is no defeat/battle-end cleanup. 【F:backend/plugins/passives/normal/hilander_critical_ferment.py†L67-L123】
+* The passive registry already invokes `on_defeat` hooks, so we can hook into
+  that to remove the subscription and clear the helper attribute.
+  【F:backend/autofighter/passives.py†L152-L172】
+
+## Tasks
+1. Add a defeat (and/or battle-end) handler to `HilanderCriticalFerment` that
+   unsubscribes `_hilander_crit_cb` if present and removes the stored attribute.
+2. Ensure the handler is safe to call when no listener has been registered and
+   does not raise if called multiple times.
+3. Add a regression test that equips the passive, triggers it, then simulates
+   defeat to confirm the bus listener and attribute are cleared.
+
+## Definition of Done
+* Hilander no longer leaves behind a `critical_hit` subscription after defeat.
+* Automated test coverage confirming the cleanup.

--- a/.codex/tasks/passives/6b88213e-lady-echo-cleanup.md
+++ b/.codex/tasks/passives/6b88213e-lady-echo-cleanup.md
@@ -1,0 +1,29 @@
+# Lady Echo passive cleanup
+
+## Summary
+The `LadyEchoResonantStatic` passive keeps class-level dictionaries of hit/crit
+state but never clears them when Lady Echo leaves battle. This leaves stale
+entries that can leak into later fights and never releases the `party_crit`
+effect if the combatant is defeated while stacks remain.
+
+## Details
+* `backend/plugins/passives/normal/lady_echo_resonant_static.py` stores
+  `_current_target`, `_consecutive_hits`, and `_party_crit_stacks` keyed by the
+  entity id, but there is no `on_defeat`/`battle_end` hook to remove those
+  entries or to strip the applied crit buff effect. 【F:backend/plugins/passives/normal/lady_echo_resonant_static.py†L22-L115】
+* The passive registry will call an `on_defeat` hook when provided, so we can
+  free state when the unit is knocked out. 【F:backend/autofighter/passives.py†L152-L172】
+
+## Tasks
+1. Add a defeat/battle-end cleanup path for `LadyEchoResonantStatic` that removes
+   stored dictionary entries and strips the `party_crit` effect from the defeated
+   unit.
+2. Ensure any added cleanup is safe to call multiple times and does not raise if
+   the dictionaries lack the key.
+3. Cover the new behavior with a focused test (or extend an existing one) that
+   asserts state is cleared after defeat.
+
+## Definition of Done
+* Lady Echo’s passive no longer retains state after defeat and the crit buff
+  effect is removed.
+* Tests exercising the cleanup pass.


### PR DESCRIPTION
## Summary
- add a task to clean up Lady Echo's passive state after defeat
- add a task to remove Hilander's lingering critical hit listener when he falls

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [x] Linting (`uv run ruff check plugins/passives/normal`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [x] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68ee474fcc70832ca530b1706beb5e22