### PR TITLE
Add card follow-up tasks for low-HP buffs and bleed hooks

### DIFF
--- a/.codex/tasks/cards/37124393-thick-skin-effect-hook.md
+++ b/.codex/tasks/cards/37124393-thick-skin-effect-hook.md
@@ -1,0 +1,14 @@
+# Fix Thick Skin's bleed duration reduction hook
+
+## Summary
+Thick Skin still listens to the legacy `effect_applied(target, effect_name, duration, source)` signature and inspects a non-existent `effect_manager.modifiers` list, so its bleed-shortening effect never triggers under the current EffectManager API.
+
+## Details
+* `EffectManager.add_modifier` now emits `effect_applied(effect_name, entity, details)` and stores stat modifiers in `mods`, not `modifiers`.【F:backend/autofighter/effects.py†L397-L433】
+* The card's handler expects the old argument order and loops over `effect_manager.modifiers`, which no longer exists, so the body exits without touching DoTs.【F:backend/plugins/cards/thick_skin.py†L17-L39】
+* As a result, bleed applications never see their duration reduced, and the `card_effect` event never fires.
+
+## Requirements
+- Update the subscription to match the current `effect_applied` payload, including checking `details` to confirm a bleed DoT.
+- Inspect the correct EffectManager collections (e.g., `dots`) to locate active bleed effects and safely adjust their `turns` counters.
+- Emit the card effect event after a successful reduction and add automated coverage demonstrating that at least one bleed stack loses a turn when the 50% roll succeeds.

--- a/.codex/tasks/cards/c021615e-enduring-charm-turn-sync.md
+++ b/.codex/tasks/cards/c021615e-enduring-charm-turn-sync.md
@@ -1,0 +1,14 @@
+# Rework Enduring Charm's low-HP buff cleanup
+
+## Summary
+Enduring Charm mirrors Vital Core's low-HP vitality buff but still uses a hard-coded 20-second timer to remove `active_boosts`. This wall-clock delay can desynchronise with turn-based battles, preventing the buff from re-triggering when it should or lingering across fights.
+
+## Details
+* The card tracks `active_boosts` and schedules `loop.call_later(20, _remove_boost)` to clear entries after two turns.【F:backend/plugins/cards/enduring_charm.py†L23-L74】
+* Because the timer is wall-clock based, quick battles may finish before the timer fires, leaving `active_boosts` populated and blocking reapplication in the next combat.
+* Conversely, long encounters risk the boost re-enabling late (or not at all) if combat pacing differs from the 20-second assumption.
+
+## Requirements
+- Replace the wall-clock cleanup with logic tied to the modifier lifecycle (e.g., remove from `active_boosts` when the 2-turn stat buff expires, on `battle_end`, or via event callbacks).
+- Ensure the vitality bonus can reapply promptly once the effect expires or a new battle begins.
+- Add regression coverage showing the boost re-triggers correctly across rapid and prolonged fights without relying on `call_later`.


### PR DESCRIPTION
## Summary
- add a Task Master follow-up for Enduring Charm to replace its 20s timer with turn-based cleanup
- add a task for Thick Skin so its bleed duration reduction uses the current effect_applied payload and EffectManager APIs

## Testing
- uv venv
- uv pip install -e backend
- python -m compileall backend/plugins/cards

------
https://chatgpt.com/codex/tasks/task_b_68ee475e7054832cb3d995317e56012d