### PR TITLE
[FIX] Prevent Vital Core boost reapplying to defeated units

### DIFF
--- a/backend/plugins/cards/vital_core.py
+++ b/backend/plugins/cards/vital_core.py
@@ -31,6 +31,10 @@ class VitalCore(CardBase):
                 current_hp = getattr(member, "hp", 0)
                 max_hp = getattr(member, "max_hp", 1)
 
+                if current_hp <= 0:
+                    active_boosts.discard(member_id)
+                    continue
+
                 if current_hp / max_hp < 0.30 and member_id not in active_boosts:
                     active_boosts.add(member_id)
 


### PR DESCRIPTION
## Summary
- avoid re-registering Vital Core's vitality modifier for characters at 0 HP
- ensure defeated members are removed from the active boost tracking set

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ee4d29b9b4832c882566eb895093d9