### PR TITLE
[AUDIT] Request changes for Vital Core buff reset task

### DIFF
--- a/.codex/tasks/cards/67dae4f6-vital-core-buff-reset.md
+++ b/.codex/tasks/cards/67dae4f6-vital-core-buff-reset.md
@@ -16,3 +16,11 @@ Vital Core prevents reapplying its low-HP vitality buff by storing member IDs in
 - Avoid leaking tasks or depending on `call_later` so the logic stays deterministic under asyncio.
 - Add automated coverage demonstrating that the buff re-applies after expiring and that no wall-clock assumptions remain.
 ready for review
+
+## Audit (2025-10-14)
+
+- ❌ `uv run pytest tests/test_vital_core.py`
+  - The Vital Core listener raises a `NameError` because `member_id` is undefined and `active_boosts` is treated like a set despite being declared as a dictionary, so the emergency vitality modifier never applies.【F:backend/plugins/cards/vital_core.py†L23-L87】【144758†L1-L41】
+  - The test therefore fails to observe the expected temporary buff reapplication, leaving the task incomplete.【144758†L1-L41】
+
+status: changes requested


### PR DESCRIPTION
## Summary
- record audit findings on the Vital Core cooldown replacement task
- document the failing pytest run caused by the card's NameError

## Testing
- ❌ `uv run pytest tests/test_vital_core.py`


------
https://chatgpt.com/codex/tasks/task_b_68ee50d7a958832c95e25093d05ce20e