### PR TITLE
Fix Thick Skin bleed reduction hook

### DIFF
--- a/.codex/tasks/cards/37124393-thick-skin-effect-hook.md
+++ b/.codex/tasks/cards/37124393-thick-skin-effect-hook.md
@@ -12,3 +12,5 @@ Thick Skin still listens to the legacy `effect_applied(target, effect_name, dura
 - Update the subscription to match the current `effect_applied` payload, including checking `details` to confirm a bleed DoT.
 - Inspect the correct EffectManager collections (e.g., `dots`) to locate active bleed effects and safely adjust their `turns` counters.
 - Emit the card effect event after a successful reduction and add automated coverage demonstrating that at least one bleed stack loses a turn when the 50% roll succeeds.
+
+ready for review

--- a/backend/plugins/cards/thick_skin.py
+++ b/backend/plugins/cards/thick_skin.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from dataclasses import field
+import logging
 import random
 
 from autofighter.stats import BUS
@@ -17,27 +18,56 @@ class ThickSkin(CardBase):
     async def apply(self, party) -> None:  # type: ignore[override]
         await super().apply(party)
 
-        async def _on_effect_applied(target, effect_name, duration, source):
-            # Check if target is one of our party members and effect is bleed
-            if target in party.members and "bleed" in effect_name.lower():
-                # 50% chance to reduce bleed duration by 1
-                if random.random() < 0.50:
-                    # Try to reduce the effect duration if it exists
-                    effect_manager = getattr(target, 'effect_manager', None)
-                    if effect_manager and hasattr(effect_manager, 'modifiers'):
-                        for modifier in effect_manager.modifiers:
-                            if hasattr(modifier, 'name') and "bleed" in modifier.name.lower():
-                                if hasattr(modifier, 'turns') and modifier.turns > 1:
-                                    modifier.turns -= 1
-                                    import logging
-                                    log = logging.getLogger(__name__)
-                                    log.debug("Thick Skin reduced bleed duration by 1 turn for %s", target.id)
-                                    await BUS.emit_async("card_effect", self.id, target, "duration_reduction", 1, {
-                                        "effect_reduced": effect_name,
-                                        "turns_reduced": 1,
-                                        "trigger_chance": 0.50
-                                    })
-                                    break
+        log = logging.getLogger(__name__)
+
+        async def _on_effect_applied(effect_name, entity, details=None):
+            if entity not in party.members:
+                return
+
+            if not details or details.get("effect_type") != "dot":
+                return
+
+            effect_id = (details.get("effect_id") or "").lower()
+            if "bleed" not in effect_name.lower() and "bleed" not in effect_id:
+                return
+
+            if random.random() >= 0.50:
+                return
+
+            effect_manager = getattr(entity, "effect_manager", None)
+            if effect_manager is None:
+                return
+
+            bleed_effect = next(
+                (
+                    eff
+                    for eff in reversed(getattr(effect_manager, "dots", []))
+                    if "bleed" in getattr(eff, "id", "").lower()
+                    or "bleed" in getattr(eff, "name", "").lower()
+                ),
+                None,
+            )
+
+            if bleed_effect is None or getattr(bleed_effect, "turns", 0) <= 0:
+                return
+
+            bleed_effect.turns = max(bleed_effect.turns - 1, 0)
+
+            log.debug(
+                "Thick Skin reduced bleed duration by 1 turn for %s", getattr(entity, "id", None)
+            )
+            await BUS.emit_async(
+                "card_effect",
+                self.id,
+                entity,
+                "duration_reduction",
+                1,
+                {
+                    "effect_reduced": effect_name,
+                    "turns_reduced": 1,
+                    "trigger_chance": 0.50,
+                },
+            )
 
         self.subscribe("effect_applied", _on_effect_applied)
 

--- a/backend/tests/test_thick_skin.py
+++ b/backend/tests/test_thick_skin.py
@@ -1,0 +1,72 @@
+import asyncio
+from unittest.mock import patch
+
+from autofighter.cards import apply_cards
+from autofighter.cards import award_card
+from autofighter.party import Party
+from autofighter.stats import BUS
+from autofighter.stats import set_battle_active
+from plugins.characters._base import PlayerBase
+from plugins.damage_types.generic import Generic
+from plugins.dots.bleed import Bleed
+from plugins.event_bus import bus as _bus
+
+
+def setup_event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    return loop
+
+
+def flush_bus_tasks(loop):
+    batch_task = getattr(_bus, "_batch_timer", None)
+    if isinstance(batch_task, asyncio.Task):
+        loop.run_until_complete(batch_task)
+
+
+def test_thick_skin_reduces_bleed_duration_on_trigger():
+    loop = setup_event_loop()
+    BUS.set_loop(loop)
+    set_battle_active(True)
+
+    party = Party()
+    defender = PlayerBase()
+    defender.id = "defender"
+    defender.damage_type = Generic()
+    defender.set_base_stat("max_hp", 1000)
+    defender.hp = defender.max_hp
+
+    party.members.append(defender)
+    award_card(party, "thick_skin")
+    loop.run_until_complete(apply_cards(party))
+
+    effect_manager = defender.effect_manager
+    assert effect_manager is not None
+
+    bleed = Bleed(damage=10, turns=3)
+    bleed.source = defender
+
+    try:
+        with patch("plugins.cards.thick_skin.random.random", return_value=0.25):
+            loop.run_until_complete(effect_manager.add_dot(bleed))
+            flush_bus_tasks(loop)
+            loop.run_until_complete(asyncio.sleep(0))
+
+        assert bleed.turns == 2
+
+        new_bleed = Bleed(damage=10, turns=4)
+        new_bleed.source = defender
+
+        with patch("plugins.cards.thick_skin.random.random", return_value=0.75):
+            loop.run_until_complete(effect_manager.add_dot(new_bleed))
+            flush_bus_tasks(loop)
+            loop.run_until_complete(asyncio.sleep(0))
+
+        assert new_bleed.turns == 4
+    finally:
+        loop.run_until_complete(BUS.emit_async("battle_end", defender))
+        flush_bus_tasks(loop)
+        loop.run_until_complete(asyncio.sleep(0.05))
+        set_battle_active(False)
+        BUS.set_loop(None)
+        loop.close()


### PR DESCRIPTION
## Summary
- update Thick Skin's event subscription to match the current effect_applied payload and trim bleed duration stacks correctly
- add unit test verifying the card reduces bleed duration only when the 50% roll succeeds
- mark the Thick Skin task as ready for review

## Testing
- `uv run pytest tests/test_thick_skin.py`


------
https://chatgpt.com/codex/tasks/task_b_68ee53d60b88832c95d5cfe578878197