### PR TITLE
Add Ryne character plugin

### DIFF
--- a/.codex/implementation/player-foe-reference.md
+++ b/.codex/implementation/player-foe-reference.md
@@ -67,6 +67,7 @@ first spawn and reuse it for future sessions unless customized.
 | Mimic | C | 0★ | Any (randomized) | `mimic_player_copy` mirrors allied passives and stat gains. | Mirrors an active party member during scripted mirror fights; non-selectable. |
 | PersonaIce | A | 5★ | Ice | `persona_ice_cryo_cycle` layers mitigation and thaws stored frost into end-of-turn healing barriers. | Standard gacha recruit. |
 | PersonaLightAndDark | A | 6★ | Light / Dark (alternating) | `persona_light_and_dark_duality` flips elements every action, pulsing Light-form heals before Dark-form crit bursts that strip defenses. | 6★ gacha headliner. |
+| Ryne | B | 6★ | Light | `ryne_oracle_of_balance` channels the Oracle of Light's senses to stabilize aetheric anomalies while her twin-blade style shields allies through agile counterplay. | 6★ gacha headliner. |
 | Player | C | Story | Chosen (player-selected) | `player_level_up_bonus` scales with run progress, representing the customizable avatar. | Always available starter. |
 | Slime | C | 0★ | Any (randomized) | Baseline stat template that tags in as a helper for foe lineups, including boss slots. | Non-selectable foe support unit that appears when encounters need a fallback combatant. |
 

--- a/backend/plugins/characters/ryne.py
+++ b/backend/plugins/characters/ryne.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass
+from dataclasses import field
+
+from autofighter.character import CharacterType
+from plugins.characters._base import PlayerBase
+from plugins.damage_types import load_damage_type
+from plugins.damage_types._base import DamageTypeBase
+
+
+@dataclass
+class Ryne(PlayerBase):
+    id = "ryne"
+    name = "Ryne"
+    about = (
+        "Ryne Waters is a 6★ Oracle of Light who chose her own name and future after escaping"
+        " Eulmore. She now leads restoration missions across the Empty with calm resolve,"
+        " balancing empathy with a scout's edge learned alongside her mentor Thancred."
+        " Her partnership with Luna Midori keeps both grounded—Luna tempers Ryne's habit of"
+        " carrying every burden alone while Ryne helps Luna open up to the communities they"
+        " protect. In battle she channels light through twin blades or a borrowed gunblade,"
+        " moving with agile precision to cleanse aetheric storms and shield her friends."
+    )
+    char_type: CharacterType = CharacterType.B
+    gacha_rarity = 6
+    damage_type: DamageTypeBase = field(default_factory=lambda: load_damage_type("Light"))
+    passives: list[str] = field(default_factory=lambda: ["ryne_oracle_of_balance"])
+    actions_display: str = "number"


### PR DESCRIPTION
## Summary
- add a Ryne player plugin that loads Light damage typing, numeric action display, and oracle passive hooks
- document Ryne in the player and foe roster reference so the gacha catalog stays up to date

## Testing
- uv run pytest tests/test_gacha.py

------
https://chatgpt.com/codex/tasks/task_b_68ee8f8676c8832cb896ad6e0360387a