### PR TITLE
Fix Ryne stack getter to keep surge progress display

### DIFF
--- a/backend/plugins/passives/normal/ryne_oracle_of_balance.py
+++ b/backend/plugins/passives/normal/ryne_oracle_of_balance.py
@@ -459,7 +459,10 @@ class RyneOracleOfBalance:
 
     @classmethod
     def get_stacks(cls, owner: "Stats") -> int:
-        return cls.get_total_balance(owner)
+        total = cls.get_total_balance(owner)
+        if total <= cls.SOFT_CAP:
+            return cls.get_balance(owner)
+        return total
 
     @classmethod
     def get_display(cls, owner: "Stats") -> str:


### PR DESCRIPTION
## Summary
- return current balance stacks for the surge progress indicator while under the soft cap
- fall back to cumulative stacks only after the display switches to numeric overflow

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68ee9ba2b114832c8d66581c4efb66d1