### PR TITLE
[PASSIVE] Clean up Hilander bus listener on defeat

### DIFF
--- a/.codex/tasks/passives/6a3ea15b-hilander-bus-cleanup.md
+++ b/.codex/tasks/passives/6a3ea15b-hilander-bus-cleanup.md
@@ -25,3 +25,5 @@ callback persists for the rest of the run, leaking listeners and leaving the
 ## Definition of Done
 * Hilander no longer leaves behind a `critical_hit` subscription after defeat.
 * Automated test coverage confirming the cleanup.
+
+ready for review


### PR DESCRIPTION
## Summary
- ensure Hilander Critical Ferment removes its critical_hit listener via a shared helper and defeat hook
- add a regression test covering the defeat cleanup and idempotent behavior
- mark the Hilander bus cleanup task as ready for review

## Testing
- [x] Backend tests (`uv run pytest backend/tests/test_character_passives.py -k hilander_cleanup_on_defeat`)
- [ ] Frontend tests
- [x] Linting (`uv run ruff check backend/plugins/passives/normal/hilander_critical_ferment.py backend/tests/test_character_passives.py`)
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

------
https://chatgpt.com/codex/tasks/task_b_68eee778ede4832c8971ffecac03e0b6