### PR TITLE
Clarify Rusty Buckle threshold documentation

### DIFF
--- a/.codex/tasks/relics/1e2c2fc3-fix-rusty-buckle-threshold.md
+++ b/.codex/tasks/relics/1e2c2fc3-fix-rusty-buckle-threshold.md
@@ -12,3 +12,5 @@ Rusty Buckle intentionally multiplies party Max HP by `50.0` per stack when dete
 - Update the relevant relic documentation (create or extend the appropriate `.codex/implementation` reference) to explicitly call out that Rusty Buckle's thresholds are expressed as 50× / 5000% of party Max HP per stack.
 - Add in-line comments or docstrings near `_threshold_multiplier` clarifying that the large percentage is intentional and by design.
 - Note the rationale in any applicable design notes or changelog so future contributors understand that 5000% is not a bug.
+
+ready for review

--- a/backend/.codex/implementation/relics/rusty-buckle.md
+++ b/backend/.codex/implementation/relics/rusty-buckle.md
@@ -1,0 +1,30 @@
+# Rusty Buckle Relic Tuning
+
+Rusty Buckle is a tension-building relic that rewards the party for surviving
+long engagements. Each stack applies a fixed bleed (5% Max HP per turn) while
+tracking how much total Max HP has been lost by the entire party. When the
+accumulated loss crosses a threshold the relic unleashes an Aftertaste volley at
+random foes.
+
+## HP-loss thresholds
+- The threshold multiplier intentionally starts at **50×** party Max HP. Losing
+  100 combined HP with a 50× multiplier equates to a 5000% progress bar; the
+  volley triggers only after the run has bled out 5000% of the party's Max HP in
+  total.
+- Additional stacks increase the threshold by **10×** (1000%) each. Two stacks
+  therefore require 60×, three stacks 70×, and so on.
+
+These values look extreme if interpreted as conventional percentages, but they
+are by design. The high multipliers prevent chip damage from spamming Aftertaste
+while still allowing long boss fights to build momentum and eventually detonate
+a large volley.
+
+## Player-facing description
+The in-game description mirrors the same multiplier (e.g., "Each 5000% party HP
+lost…"). This phrasing is intentional and should not be converted to 50%.
+
+## Implementation notes
+- `_threshold_multiplier` in `backend/plugins/relics/rusty_buckle.py` returns
+  `50.0 + 10.0 * max(stacks - 1, 0)`.
+- Comments in the module document the intent so future edits keep the 50× base
+  multiplier intact.

--- a/backend/plugins/relics/rusty_buckle.py
+++ b/backend/plugins/relics/rusty_buckle.py
@@ -204,6 +204,13 @@ class RustyBuckle(RelicBase):
 
     @staticmethod
     def _threshold_multiplier(stacks: int) -> float:
+        """Return the HP-loss multiplier required to fire Aftertaste."""
+
+        # Rusty Buckle is intentionally tuned around enormous thresholds: one
+        # stack requires losing 50× (5000%) of the party's combined Max HP
+        # before a volley releases, and each extra stack adds another 10×
+        # (1000%). The inflated percentage prevents chip damage from chaining
+        # triggers while still letting marathon fights build momentum.
         return 50.0 + 10.0 * max(stacks - 1, 0)
 
     def describe(self, stacks: int) -> str:


### PR DESCRIPTION
## Summary
- add an inline note to Rusty Buckle's threshold multiplier explaining the 50× baseline design
- document the relic's HP-loss thresholds and rationale in backend/.codex/implementation
- relocate the Rusty Buckle implementation note into `backend/.codex/implementation/relics/`

## Testing
- [x] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [x] Doc sync updates (README and `.codex/implementation` docs; link tasks below)
- [x] Environment setup (`uv sync`)

## Checklist
- [x] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68eeee3bb954832ca54384a2c9e5c477