### PR TITLE
Add priority guidance for chars and items task subfolders

### DIFF
--- a/.codex/tasks/AGENTS.md
+++ b/.codex/tasks/AGENTS.md
@@ -1,0 +1,3 @@
+# Task Priority Guidance
+
+Tasks placed directly in this folder are **high priority** and should be addressed before tasks in subfolders.

--- a/.codex/tasks/cards/AGENTS.md
+++ b/.codex/tasks/cards/AGENTS.md
@@ -1,0 +1,3 @@
+# Task Priority Guidance
+
+Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.

--- a/.codex/tasks/chars/AGENTS.md
+++ b/.codex/tasks/chars/AGENTS.md
@@ -1,0 +1,3 @@
+# Task Priority Guidance
+
+Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.

--- a/.codex/tasks/items/AGENTS.md
+++ b/.codex/tasks/items/AGENTS.md
@@ -1,0 +1,3 @@
+# Task Priority Guidance
+
+Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.

--- a/.codex/tasks/passives/AGENTS.md
+++ b/.codex/tasks/passives/AGENTS.md
@@ -1,0 +1,3 @@
+# Task Priority Guidance
+
+Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.

--- a/.codex/tasks/relics/AGENTS.md
+++ b/.codex/tasks/relics/AGENTS.md
@@ -1,0 +1,3 @@
+# Task Priority Guidance
+
+Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.


### PR DESCRIPTION
## Summary
- add new `chars` and `items` task subdirectories under `.codex/tasks`
- document that tasks in the new subdirectories remain lower priority than root tasks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68ef0f7189c4832c90e4f38581a8516a