### PR TITLE
[DOCS] Clarify Lady Darkness DoT references

### DIFF
--- a/.codex/tasks/passives/4bf8857c-lady-darkness-event-hooks.md
+++ b/.codex/tasks/passives/4bf8857c-lady-darkness-event-hooks.md
@@ -1,10 +1,10 @@
 # Task: Wire Eclipsing Veil Into DoT & Debuff Events
 
 ## Background
-`LadyDarknessEclipsingVeil` is designed to siphon healing on every DoT tick and grant permanent attack bonuses when she resists debuffs. The passive defines `on_dot_tick` and `on_debuff_resist` helpers, but the core `apply()` body only drops stat effects.
+`LadyDarknessEclipsingVeil` is designed to siphon healing on every DoT tick and grant permanent attack bonuses when she resists debuffs. The passive defines `on_dot_tick` and `on_debuff_resist` helpers, but the core `apply()` body only drops stat effects. For a refresher on how our DoT/debuff events are emitted, check the battle plug-in modules under `backend/plugins/`—particularly `backend/plugins/event_bus.py` for subscription patterns and the existing DoT definitions in `backend/plugins/dots/`.
 
 ## Problem
-No event subscriptions exist for the passive, and `PassiveRegistry` never calls these helpers by default. As a result, the siphon HoT and resist-based attack buffs never fire. See `backend/plugins/passives/normal/lady_darkness_eclipsing_veil.py` lines 24-75 alongside the lack of any `BUS.subscribe` calls.
+No event subscriptions exist for the passive, and `PassiveRegistry` never calls these helpers by default. As a result, the siphon HoT and resist-based attack buffs never fire. See `backend/plugins/passives/normal/lady_darkness_eclipsing_veil.py` lines 24-75 alongside the lack of any `BUS.subscribe` calls, then mirror the hook-up patterns used by other plug-ins inside `backend/plugins/passives/` when wiring the handlers.
 
 ## Requested Changes
 - Subscribe to the relevant battle bus events (e.g., `dot_tick`, `debuff_resisted` or whichever signal the combat system emits) when the passive initializes, and clean up the handlers on defeat/battle end.


### PR DESCRIPTION
## Summary
- clarify the Eclipsing Veil task instructions with direct references to the battle plug-in folder
- point coders to the event bus and DoT plug-in modules for context when wiring handlers

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68efa0b9493c832ca56a22d4238a29b6