### PR TITLE
[TASK] Add relic design tasks for each star tier

### DIFF
--- a/.codex/tasks/relics/71e8aa8e-event-horizon-relic.md
+++ b/.codex/tasks/relics/71e8aa8e-event-horizon-relic.md
@@ -1,0 +1,17 @@
+# Add 5★ Event Horizon relic for turn-start gravity pulses
+
+## Summary
+Ship **Event Horizon**, a 5★ relic that detonates a gravity pulse at the start of every ally turn. Each pulse should rip chunks of HP from every living foe while draining the acting ally, creating an all-or-nothing tempo engine worthy of top-tier relics.
+
+## Details
+* Subscribe to the global `turn_start` event; it fires for every combatant each time they begin a turn.【F:backend/autofighter/rooms/battle/turn_loop/player_turn.py†L226-L239】
+* Maintain a cached list of current foes (populate it when `turn_start` fires for foes, similar to Rusty Buckle) so ally pulses always know whom to strike.【F:backend/plugins/relics/rusty_buckle.py†L98-L203】 Ignore pulses triggered by foes.
+* When an ally begins a turn with positive HP, deal gravity damage to every tracked foe equal to 6% of that foe’s current HP per Event Horizon stack (minimum 1). Use `safe_async_task(target.apply_damage(..., attacker=ally))` so mitigation and on-hit hooks still apply, and emit telemetry summarizing the pulse for each foe.【F:backend/plugins/relics/omega_core.py†L34-L91】
+* After the pulse, drain the acting ally for 3% of their Max HP per stack using `apply_cost_damage` so shields and mitigation cannot blunt the backlash.【F:backend/plugins/relics/greed_engine.py†L57-L68】 Emit a second `relic_effect` record for the self-damage.
+* Clear the foe cache and unsubscribe on `battle_end` so no references leak between encounters.
+
+## Requirements
+- Implement the `EventHorizon` relic (`stars = 5`) under `backend/plugins/relics/` with turn-start pulses, foe tracking, telemetry, and self-drain as described.
+- Ensure pulses handle extra turns (the event fires again) and gracefully skip if no foes are alive.
+- Add unit tests covering AoE damage math, self-drain scaling, extra-turn handling, and per-battle cleanup.
+- Update relic documentation with Event Horizon’s gravity pulse behavior so high-tier options are documented.【F:.codex/implementation/relic-system.md†L1-L16】

--- a/.codex/tasks/relics/72b2f866-copper-siphon-relic.md
+++ b/.codex/tasks/relics/72b2f866-copper-siphon-relic.md
@@ -1,0 +1,16 @@
+# Add 1★ Copper Siphon relic for lifesteal turns
+
+## Summary
+Design and implement a new 1★ relic, **Copper Siphon**, that grants mild lifesteal whenever party members land damage. The relic should funnel a small percentage of dealt damage back to the attacker (overflow becomes shielding) and emit telemetry so combat logs surface the siphoned healing.
+
+## Details
+* Hook into the existing `action_used` event so the relic reacts to both basic attacks and ability damage, mirroring how Echo Bell listens for combat actions.【F:backend/plugins/relics/echo_bell.py†L96-L125】
+* When an ally deals positive damage, heal them for 2% of the raw damage per Copper Siphon stack (minimum 1 HP). If the ally is at full HP, convert the excess into shields by enabling overheal before applying the heal so it flows into the shield pipeline.【F:backend/plugins/relics/threadbare_cloak.py†L21-L32】【F:backend/autofighter/stats.py†L1046-L1068】
+* Emit a `relic_effect` event describing the siphoned amount, similar to how Bent Dagger reports its attack boosts, so downstream tooling can surface the effect in logs.【F:backend/plugins/relics/bent_dagger.py†L40-L57】
+* Keep the relic stateless between battles; rely on battle-end cleanup only for subscription removal. No long-term party attributes should be mutated beyond the applied healing.
+
+## Requirements
+- Create a new `CopperSiphon` relic plugin under `backend/plugins/relics/` with `stars = 1`, appropriate `about`/`describe` strings, event subscriptions, and shield-aware lifesteal logic as outlined above.
+- Ensure relic registration works with the existing loader (`backend/autofighter/relics.py`) without manual wiring and that repeated stacks scale multiplicatively as described.【F:backend/autofighter/relics.py†L10-L37】
+- Add targeted unit tests (e.g., in `backend/tests/test_relic_effects.py`) covering: healing proportional to damage, overflow shielding when HP is full, stacking behavior, and event emission hooks.
+- Update relic documentation to include Copper Siphon and note the lifesteal/shield interaction so docs stay in sync with gameplay.【F:.codex/implementation/relic-system.md†L1-L16】

--- a/.codex/tasks/relics/84e6f46d-plague-harp-relic.md
+++ b/.codex/tasks/relics/84e6f46d-plague-harp-relic.md
@@ -1,0 +1,17 @@
+# Add 3★ Plague Harp relic for DoT propagation with backlash
+
+## Summary
+Create **Plague Harp**, a 3★ relic that weaponizes the party’s damage-over-time effects. Whenever a party-inflicted DoT ticks on a foe, the relic should echo that rot into another enemy while the caster pays a small health tithe, reinforcing the high-risk, high-reward identity of mid-tier relics.
+
+## Details
+* Subscribe to the global `dot_tick` bus event so the relic can react every time a damage-over-time effect resolves, using the existing emission point in `DamageOverTime.tick` as your trigger reference.【F:backend/autofighter/effects.py†L260-L291】
+* Only trigger when the attacker is a party member and the target is a foe. Track active foes similar to Rusty Buckle so you always have a valid secondary target, falling back to the original foe if only one remains.【F:backend/plugins/relics/rusty_buckle.py†L98-L203】
+* Spawn an `Aftertaste` effect against a random eligible foe equal to 40% of the ticking DoT’s damage per Plague Harp stack (round down, minimum 1). Use the existing Aftertaste helper so damage types randomize correctly.【F:backend/plugins/effects/aftertaste.py†L1-L124】 Emit telemetry describing the echo.
+* Charge the original attacker a health tithe to balance the power: inflict self-damage equal to 2% of their Max HP per Plague Harp stack using the cost-damage helper that bypasses shields.【F:backend/plugins/relics/greed_engine.py†L57-L68】 Emit a second `relic_effect` event summarizing the backlash.
+* Store all state on the party object and clean it up on `battle_end` so streaks and foe caches never leak between encounters.
+
+## Requirements
+- Add the `PlagueHarp` relic under `backend/plugins/relics/` with `stars = 3`, handling foe tracking, Aftertaste propagation, and self-damage backfire as specified.
+- Ensure the relic gracefully handles edge cases: single remaining foe, attacker already defeated, and simultaneous multiple DoTs ticking in the same frame.
+- Write automated tests verifying DoT propagation sizing, self-damage scaling, random-target selection stability, and cleanup after battles.
+- Update relic documentation to record Plague Harp’s DoT echo and health tithe behavior.【F:.codex/implementation/relic-system.md†L1-L16】

--- a/.codex/tasks/relics/ca81df50-blood-debt-tithe-relic.md
+++ b/.codex/tasks/relics/ca81df50-blood-debt-tithe-relic.md
@@ -1,0 +1,16 @@
+# Add 4★ Blood Debt Tithe relic for escalating loot and foe power
+
+## Summary
+Design **Blood Debt Tithe**, a 4★ relic that trades harder enemies for accelerating rare-drop growth. Every defeated foe should increase the party’s rare drop rate for the rest of the run, but future encounters begin with foes empowered proportionally to the number of sacrifices already collected.
+
+## Details
+* Listen for `entity_defeat` and only count genuine foe deaths. Track defeated foe IDs in a per-battle set so duplicates from multiple defeat emissions don’t inflate the total, then roll the unique count into a persistent counter on the party when the fight ends.【F:backend/autofighter/rooms/battle/events.py†L61-L83】【F:backend/autofighter/stats.py†L935-L935】
+* Increase `party.rdr` by 0.2 percentage points per Blood Debt Tithe stack for each new foe defeat, mirroring how Greed Engine mutates the run-wide rare drop rate.【F:backend/plugins/relics/greed_engine.py†L23-L39】 Persist the cumulative total on the party so the bonus survives future battles.
+* Before each battle, apply a scaling buff to foes based on the stored defeat count: subscribe to `battle_start`, filter foe entities, and add a permanent combat modifier that grants +3% ATK and +2% SPD per stored defeat per relic stack (multiplicative with other buffs). Use the same foe-buff pattern as Null Lantern and remove modifiers cleanly after the encounter ends.【F:backend/plugins/relics/null_lantern.py†L37-L118】
+* Emit `relic_effect` telemetry when kills are banked and when foe buffs are applied so combat logs communicate the current tithe level.
+* Reset only per-battle bookkeeping (`seen_foes`, temporary modifiers) on `battle_end`; the accumulated defeat counter and `rdr` boost should persist for the run.
+
+## Requirements
+- Implement the `BloodDebtTithe` relic plugin (`stars = 4`) under `backend/plugins/relics/` handling foe defeat tracking, run-wide `rdr` growth, foe buff application, and cleanup as described.
+- Add regression-safe tests covering: duplicate defeat suppression, `rdr` accumulation between battles, foe buff scaling math, and teardown of buffs after combat.
+- Document the relic trade-off in the relic system reference so players understand the reward-for-risk loop.【F:.codex/implementation/relic-system.md†L1-L16】

--- a/.codex/tasks/relics/f433e580-momentum-gyro-relic.md
+++ b/.codex/tasks/relics/f433e580-momentum-gyro-relic.md
@@ -1,0 +1,17 @@
+# Add 2★ Momentum Gyro relic for focused assault chains
+
+## Summary
+Introduce **Momentum Gyro**, a 2★ relic that rewards repeatedly striking the same foe. Allies should build stacking offensive momentum when they keep pressure on one target, while that target becomes more vulnerable for a short window. Swapping targets or whiffing attacks should reset the chain.
+
+## Details
+* Listen for the `action_used` combat event so both basic attacks and abilities extend the chain, using Echo Bell’s subscription pattern as a reference.【F:backend/plugins/relics/echo_bell.py†L96-L125】
+* Track each attacker’s last successful target and consecutive hit count. When the same foe is hit again for positive damage, increase a per-attacker momentum stack (cap the streak at 5 by default to avoid runaway buffs). Reset the streak if damage is zero/negative or the target changes.
+* Apply a short-lived self buff that grants +5% ATK per relic stack per momentum stack (multiplicative with existing relic bonuses) using the standard `EffectManager` / `create_stat_buff` pattern.【F:backend/plugins/relics/bent_dagger.py†L40-L50】 Emit `relic_effect` telemetry describing the current streak and buffed amount.
+* Simultaneously apply a 1-turn mitigation debuff to the struck foe equal to 5% per relic stack per streak level (stacking multiplicatively if several allies focus the same enemy). Remove or refresh the debuff cleanly when the streak resets; reuse the modifier removal workflow other relics follow when their temporary buffs expire.【F:backend/plugins/relics/travelers_charm.py†L80-L118】
+* Ensure all per-battle bookkeeping (`last_target`, `streaks`, active modifiers) is cleared on `battle_end`.
+
+## Requirements
+- Implement the `MomentumGyro` relic plugin under `backend/plugins/relics/` with `stars = 2`, storing attacker streak state safely on the party object and respecting the chain rules above.
+- Emit structured `relic_effect` payloads for both the attacker buff and the foe debuff so combat logs and analytics can display the momentum flow.【F:backend/plugins/relics/bent_dagger.py†L40-L57】
+- Add comprehensive unit tests that cover: streak growth/reset conditions, buff/debuff magnitude math across multiple relic stacks, debuff cleanup on battle end, and the 5-stack cap behavior.
+- Document the relic and its focused assault mechanic in the relic system docs to keep player-facing references accurate.【F:.codex/implementation/relic-system.md†L1-L16】


### PR DESCRIPTION
## Summary
- add Copper Siphon task describing a new 1★ lifesteal relic concept
- add Momentum Gyro task outlining a 2★ focused target momentum relic
- add Plague Harp, Blood Debt Tithe, and Event Horizon tasks for new 3★–5★ relic ideas with implementation notes and test expectations

## Testing
- Not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68ef32f60b30832cbbfdb3bb8aab6cea