### PR TITLE
docs: clarify reward staging task expectations

### DIFF
--- a/.codex/tasks/898b9d40-reward-preview-metadata.md
+++ b/.codex/tasks/898b9d40-reward-preview-metadata.md
@@ -3,10 +3,21 @@
 ## Summary
 Design the data contracts that describe how a staged card or relic will affect the party so the UI can render previews. This includes mapping stat deltas, triggers, and any textual cues into a stable payload consumed by the frontend.
 
+### Existing data surfaces to inspect
+- `RewardOverlay.svelte` currently renders `card_choices` / `relic_choices` using only `{id, name, stars}`. It expects to receive the raw reward bundle from `battle_snapshots[run_id]` (see `.codex/implementation/post-fight-loot-screen.md`) and will need an additional, well-typed `preview` field to render staged deltas without changing the base schema.
+- Card implementations inherit from `plugins.cards._base.CardBase`. Simple cards expose their multipliers via the `effects` dict (e.g. `Micro Blade` adds `{"atk": 0.03}`) while advanced cards override `apply()` to register BUS handlers. Relics follow a similar pattern under `plugins/relics/`.
+- The combat engine already emits contextual signals: `DamageOverTime.tick` fires `dot_tick` events with `{ "dot_id", "remaining_turns", "original_damage" }`, `EffectManager` emits `effect_resisted`, etc. These are canonical sources for trigger previews instead of hard-coding prose.
+
+### Implementation notes
+- Define a preview schema that can represent both deterministic stat changes (`stats.max_hp.multiplier`, `stats.attack.delta`, etc.) and event-driven hooks (`triggers.on_dot_tick`, `triggers.on_effect_resisted`). Document the JSON shape in `.codex/implementation/battle-endpoint-payload.md` and mirror it in the frontend types.
+- Extend the staging payload emitted by the previous task so `/ui` responses, `/rewards/cards/<run_id>`, and `/rewards/relics/<run_id>` return `{ "card": {...}, "preview": {...} }`. Make sure the snapshot stored in `battle_snapshots` contains the same structure so reconnecting clients still see previews.
+- Frontend changes should live alongside the existing overlay system (`frontend/src/lib/components/RewardOverlay.svelte`, `frontend/src/lib/systems/uiApi.js`). Provide helper mappers that translate the backend schema into UI-friendly tooltip text and numerical deltas.
+- Capture at least one example per reward type (flat stat buff, conditional trigger, passive-style subscription) in the documentation so plugin authors know how to populate preview metadata from their card/relic definitions.
+
 ## Deliverables
 - Extend reward staging APIs to emit detailed preview metadata for each pending card or relic.
-- Update the backend/frontend integration (REST or socket payloads) so clients receive the preview bundle immediately after staging.
-- Provide example responses and contract documentation so UI developers know how to visualize upcoming effects.
+- Update the backend/frontend integration (REST or socket payloads) so clients receive the preview bundle immediately after staging, and wire the frontend overlay/components to consume it without regressing the existing reward UI.
+- Provide example responses and contract documentation (including updates to `.codex/implementation/reward-overlay.md` and `.codex/implementation/battle-endpoint-payload.md`) so UI developers know how to visualize upcoming effects.
 
 ## Why this matters for players
 Players want to understand what a reward does before committing. Rich preview metadata unlocks instant feedback—showing HP gains, trigger counts, or passive effects—so choices feel informed instead of blind.

--- a/.codex/tasks/923ab8b5-reward-activation-guardrails.md
+++ b/.codex/tasks/923ab8b5-reward-activation-guardrails.md
@@ -3,10 +3,17 @@
 ## Summary
 Once a player accepts a staged reward, we need deterministic activation and guardrails that prevent duplicate applications or lingering staged entries. This task covers the confirmation pipeline, cleanup, and regression tests around both battle setup and backtracking scenarios.
 
+### Where the guardrails must hook in
+- The run map keeps `awaiting_card`, `awaiting_relic`, `awaiting_loot`, and `reward_progression` (see `_run_battle` in `backend/runs/lifecycle.py`). `advance_room` in `backend/services/run_service.py` currently refuses to progress if any `awaiting_*` flag is still true, but it has no awareness of staged-but-unapplied data.
+- `reward_service.select_card` / `select_relic` mutate the party immediately today. After staging lands, these entry points must atomically flip `reward_progression` from `current_step -> completed` while keeping the staged payload until the player confirms.
+- `battle_snapshots[run_id]` mirrors the latest reward state for reconnecting clients, and `cleanup_battle_state` / `purge_run_state` tear down live battle context. Guardrails have to ensure staged records survive reconnects but disappear once applied or cancelled.
+- UI flows such as `backend/tests/test_reward_gate.py` simulate choose/advance loops; expand those tests (and add new ones) so they cover race conditions like double-submit, reconnect, or manual `/rewards/cards` retries.
+
 ## Deliverables
 - Update reward activation logic so staged entries are applied exactly once and cleared afterward, even across reconnects or retries.
-- Add automated tests covering double-accept attempts, battle setup integration, and cancellation flows.
+- Add automated tests covering double-accept attempts, battle setup integration, cancellation/rollback flows, and reconnect scenarios (battle snapshot reload, `/ui` polling while a staged item exists, etc.).
 - Instrument logging or metrics to flag unexpected duplicate activations for live ops follow-up.
+- Ensure `advance_room` and any other callers that depend on `awaiting_*` also verify the staging bucket is empty before allowing progression, and document the guardrail behaviour in `.codex/implementation/battle-endpoint-payload.md` / `.codex/implementation/post-fight-loot-screen.md`.
 
 ## Why this matters for players
 Without strong guardrails, players risk losing rewards or gaining unintended double buffs when staging is introduced. Reliable activation keeps progression fair and predictable, maintaining trust in the reward system.

--- a/.codex/tasks/c416b9f4-reward-staging-state.md
+++ b/.codex/tasks/c416b9f4-reward-staging-state.md
@@ -3,10 +3,23 @@
 ## Summary
 Establish a dedicated staging container for newly awarded cards and relics so their modifiers are queued rather than applied immediately. The state should persist alongside the party record and expose lifecycle hooks for when a player previews, confirms, or cancels a reward.
 
+### Current behaviour to replace
+- `select_card` / `select_relic` in `backend/services/reward_service.py` currently call `award_card` / `award_relic` immediately, append the id to `party.cards` or `party.relics`, and flush the whole `Party` back to disk via `save_party` before returning the reward payload. That flow permanently mutates the party, which is why the frontend cannot render "preview only" state today.
+- `_run_battle` in `backend/runs/lifecycle.py` stores the resolved reward payload in `battle_snapshots[run_id]` and sets the `awaiting_*` flags plus `reward_progression` on the run map. Advancing the run (`advance_room` in `backend/services/run_service.py`) refuses to move forward until every `awaiting_*` flag is false.
+- `save_party` and `load_party` serialise the full party (members, `cards`, `relics`, EXP, etc.) straight into the `runs` table; there is no parallel storage for staged rewards.
+
+### Implementation notes
+- Introduce a dedicated staging structure (e.g., `state["reward_staging"] = {"cards": [...], "relics": [...], "items": [...]}`) that is persisted with the run map/state rather than the party blob so staged entries survive reconnects without affecting `Party.cards` or `Party.relics` until confirmed.
+- Ensure `battle_snapshots[run_id]` continues to expose the raw reward choices so the frontend overlay logic (see `.codex/implementation/post-fight-loot-screen.md`) keeps working, but augment those snapshots with the staged metadata so that later tasks can render previews without mutating the live party.
+- Update the reward lifecycle APIs so that:
+  * `choose_card` / `choose_relic` enqueue into the staging record, mark `reward_progression.completed`, and only commit to `Party` + `save_party` when the player confirms the staged set.
+  * Confirmation clears the staging bucket and toggles `awaiting_next` exactly once; cancellation removes the staged entry and re-opens the relevant step.
+- Revisit battle cleanup helpers (`purge_run_state`, `cleanup_battle_state`) to make sure staged data is cleared when a run terminates or rewinds.
+
 ## Deliverables
-- Schema or data structure additions that persist pending rewards independently of the active card/relic pools.
-- Service-level APIs (or updates to `reward_service`) that enqueue rewards into the staging state and surface their pending status to callers.
-- Clear lifecycle handling covering preview start, confirmation, and cancellation, including persistence tests.
+- Schema or data structure additions that persist pending rewards independently of the active card/relic pools (include migration/backfill logic for existing save blobs).
+- Service-level APIs (or updates to `reward_service`) that enqueue rewards into the staging state, expose staged entries over `/ui` + `/rewards/*`, and gate confirmation so `advance_room` still only succeeds once staged rewards are applied or explicitly dismissed.
+- Clear lifecycle handling covering preview start, confirmation, rollback/cancellation, and reconnect flows, backed by persistence and concurrency regression tests (cover battle snapshots, map reloads, and `advance_room`).
 
 ## Why this matters for players
 Players currently receive no feedback at pick time because modifiers only land during the next battle setup. Staging the rewards unlocks immediate previews while keeping the actual party deck untouched until they commit, eliminating surprise stat swings between fights.

--- a/.codex/tasks/docs/11e73db5-reward-flow-docs-refresh.md
+++ b/.codex/tasks/docs/11e73db5-reward-flow-docs-refresh.md
@@ -3,10 +3,21 @@
 ## Summary
 Document the new staged reward pipeline so plugin authors, designers, and QA understand how to supply preview data and when effects finalize. Capture state diagrams, API hooks, and best practices in the relevant `.codex/instructions/` and implementation notes.
 
+### Documentation targets
+- `.codex/implementation/post-fight-loot-screen.md` and `.codex/implementation/battle-endpoint-payload.md` describe the payload emitted by `_run_battle`/`battle_snapshots`; they need updated field tables for `reward_staging`, preview metadata, and the acceptance workflow.
+- `.codex/implementation/reward-overlay.md` plus the related UI docs (`frontend` overlay components) must be expanded so frontend contributors know where preview text, stat deltas, and confirmation prompts appear.
+- `.codex/implementation/card-reward-system.md`, `.codex/implementation/relic-picker.md`, and the plugin author guides should explain how cards/relics surface preview metadata (e.g., mapping `CardBase.effects` and BUS triggers into the new schema).
+- Add a concise state-machine diagram (staged → previewed → confirmed → applied) covering both happy path and cancellation/retry loops, with notes about how `reward_progression` and `awaiting_*` flags map to UI states.
+
+### Implementation notes
+- Document the API contract for `/rewards/cards/<run_id>`, `/rewards/relics/<run_id>`, `/rewards/loot/<run_id>`, and `/ui` so QA can diff payloads before/after staging.
+- Provide QA checklists that cover reconnect/resume scenarios (battle snapshots, `/ui` polling) and regression checks for `advance_room` guardrails.
+- Include cross-links to any new telemetry/logging fields introduced by the guardrail task so live ops can trace reward activation anomalies.
+
 ## Deliverables
 - Update backend reward service documentation to describe staging, preview metadata, and confirmation steps.
-- Add guidance for card/relic plugin authors on declaring preview output and activation hooks.
-- Provide QA checklists covering preview display, confirmation, and rollback behaviors.
+- Add guidance for card/relic plugin authors on declaring preview output and activation hooks (update `.codex/instructions/` guidance plus plugin reference docs).
+- Provide QA checklists covering preview display, confirmation, rollback/retry behaviors, and reconnect flows (document expected REST payloads and UI transitions).
 
 ## Why this matters for players
 Clear documentation speeds up adoption of the staging system, meaning more rewards arrive with accurate previews and fewer bugs. Faster iteration keeps the game feeling polished and responsive to player feedback.

--- a/.codex/tasks/passives/4bf8857c-lady-darkness-event-hooks.md
+++ b/.codex/tasks/passives/4bf8857c-lady-darkness-event-hooks.md
@@ -6,11 +6,20 @@
 ## Problem
 No event subscriptions exist for the passive, and `PassiveRegistry` never calls these helpers by default. As a result, the siphon HoT and resist-based attack buffs never fire. See `backend/plugins/passives/normal/lady_darkness_eclipsing_veil.py` lines 24-75 alongside the lack of any `BUS.subscribe` calls, then mirror the hook-up patterns used by other plug-ins inside `backend/plugins/passives/` when wiring the handlers.
 
+### Event reference
+- `DamageOverTime.tick` (`backend/autofighter/effects.py`) emits `BUS.emit_async("dot_tick", attacker_or_none, target, dmg, dot_name, metadata)` before damage is applied. `on_dot_tick` should subscribe to that signature and check whether either `attacker` or `target` belongs to Lady Darkness' party.
+- Debuff resistance flows emit `effect_resisted` events (see `EffectManager.add_dot` and the various card/relic handlers). We do not currently fire a dedicated `debuff_resisted` signal, so subscribe to `effect_resisted` and filter by `target`/`details` instead of waiting for a nonexistent event.
+- Follow cleanup patterns from passives like `lady_light_radiant_aegis` (stores teardown callbacks in class dictionaries and unsubscribes on `battle_end`).
+
 ## Requested Changes
 - Subscribe to the relevant battle bus events (e.g., `dot_tick`, `debuff_resisted` or whichever signal the combat system emits) when the passive initializes, and clean up the handlers on defeat/battle end.
 - Ensure `on_dot_tick` receives the actual DoT damage value and applies healing through the standard heal pipeline.
 - Verify debuff resistance events propagate to the passive and correctly stack the +5% attack bonus.
 - Add targeted tests demonstrating healing triggers on DoT ticks and attack bonuses appear after resisting debuffs.
+
+### Implementation notes
+- `apply()` already adds a permanent `StatEffect` for DoT duration; extend it so, after instantiating the effect, it resolves the owning `Stats` object, registers BUS callbacks, and stores teardown lambdas in a class-level dict keyed by `id(target)`. Use `BUS.unsubscribe` inside the teardown to avoid leaking handlers across battles.
+- Tests can live alongside existing passive suites (`backend/tests/test_advanced_passive_behaviors.py` or a new dedicated file). Simulate DoT ticks via `await BUS.emit_async("dot_tick", attacker, target, dmg, "Bleed", {...})` and emit `effect_resisted` to confirm attack stacking works.
 
 ## Acceptance Criteria
 - Lady Darkness passively heals when any DoT ticks on the battlefield and gains stacking attack buffs when she resists debuffs.


### PR DESCRIPTION
## Summary
- add current-state references and implementation notes to the reward staging and activation guardrail tasks
- outline backend/frontend data sources so preview metadata work has concrete payload requirements
- expand the Lady Darkness passive task and reward flow documentation task with event signatures, affected files, and QA expectations

## Testing
- ./run-tests.sh *(fails: existing suite reports numerous errors in backend tests)*

------
https://chatgpt.com/codex/tasks/task_b_68efa5997000832ca8c4b983723f537d