### PR TITLE
[TASKS] Outline relic additions across all star ranks

### DIFF
--- a/.codex/tasks/relics/537a96a1-command-beacon.md
+++ b/.codex/tasks/relics/537a96a1-command-beacon.md
@@ -1,0 +1,28 @@
+# Add 3★ "Command Beacon" relic for party-wide speed coordination
+
+## Summary
+Ship a rare relic that redistributes speed each turn so slower allies keep pace with the squad at a modest HP cost to the pace-setter. "Command Beacon" should highlight tactical turn-order play: the fastest ally sacrifices a sliver of health so everyone else gains a temporary SPD boost.
+
+## Details
+- Use the standard relic plugin base to manage stat modifiers and bus subscriptions so stacking behaves like existing rare relics.【F:backend/plugins/relics/_base.py†L39-L155】
+- SPD is computed via the stats layer; leverage the `spd` property and `create_stat_buff` helpers to apply temporary bonuses without mutating base stats.【F:backend/autofighter/stats.py†L447-L456】
+- Turn lifecycle hooks (`turn_start`, `turn_end`, `battle_end`) are already handled by other relics, providing a template for applying and clearing per-turn buffs safely.【F:backend/plugins/relics/travelers_charm.py†L105-L119】
+- Update docs enumerating 3★ relics so contributors understand Command Beacon’s trade-off compared to Greed Engine, Stellar Compass, and Echoing Drum.【F:.codex/implementation/relic-inventory.md†L30-L33】
+
+## Requirements
+- Add a `CommandBeacon` relic under `backend/plugins/relics/` that:
+  - On each `turn_start`, identifies the ally with the highest current SPD.
+  - Applies a temporary SPD buff (e.g., +15% per stack) to every other ally for that turn, using the effect manager to expire it on `turn_end`/`battle_end`.
+  - Applies a small self-damage pulse (e.g., 3% Max HP per stack) to the pace-setter to represent the strain of coordinating the team.
+  - Emits `relic_effect` events summarizing which allies gained SPD and how much HP was sacrificed for battle logs.
+- Ensure multiple stacks scale both the SPD bonus and the HP cost multiplicatively rather than linearly to stay consistent with other relics.
+- Add tests covering single- and multi-stack cases, verifying SPD changes revert after the turn and HP loss scales correctly.【F:backend/tests/test_relic_effects.py†L24-L116】
+- Document the relic in `.codex/implementation/relic-inventory.md` and update planning references for 3★ relic design coverage.
+
+## Validation
+- `uv run pytest backend/tests/test_relic_effects.py::test_command_beacon_*`
+- `uv run pytest backend/tests/test_relic_effects_advanced.py`
+
+## Documentation
+- `.codex/implementation/relic-inventory.md`
+- `.codex/planning/archive/bd48a561-relic-plan.md`

--- a/.codex/tasks/relics/861de8ec-cataclysm-engine.md
+++ b/.codex/tasks/relics/861de8ec-cataclysm-engine.md
@@ -1,0 +1,26 @@
+# Add 5★ "Cataclysm Engine" relic for mutually assured destruction runs
+
+## Summary
+Design an endgame relic that supercharges the party at a steep vitality cost. "Cataclysm Engine" should detonate at battle start, shredding HP from both sides, granting massive stat multipliers to allies, and continuing to drain HP each turn. The relic should feel as run-defining as Omega Core or Paradox Hourglass while enabling fast, high-damage clears for teams that can survive the attrition.
+
+## Details
+- Follow the existing relic plugin infrastructure so stacking, stat multipliers, and cleanup match other legendary relics.【F:backend/plugins/relics/_base.py†L39-L155】
+- Use `apply_cost_damage` and similar helpers to inflict unavoidable HP loss on allies (and optionally foes) without conflicting with shields or mitigation, mirroring how Omega Core handles its drain.【F:backend/plugins/relics/omega_core.py†L80-L106】
+- Update relic documentation covering 5★ effects so Cataclysm Engine sits alongside Paradox Hourglass, Soul Prism, and Omega Core in contributor references.【F:.codex/implementation/relic-inventory.md†L36-L38】
+
+## Requirements
+- Implement a `CataclysmEngine` plugin that:
+  - On `battle_start`, applies large multiplicative buffs to ally core stats (ATK/DEF/SPD, etc.) and simultaneously deals an unavoidable HP blast (e.g., 15% Max HP per stack) to both allies and foes.
+  - On each `turn_start`, continues draining ally HP (e.g., 5% per stack) while granting escalating bonuses such as Aftertaste hits or mitigation to offset the damage, ensuring stacking remains multiplicative.
+  - Tracks and removes its stat modifiers when the battle ends to prevent lingering buffs.
+  - Emits descriptive `relic_effect` events for the initial blast and each subsequent drain tick so battle logs and overlays communicate the risk/reward profile.
+- Expand backend tests to cover initial detonation, per-turn drains, stacking behavior, and interaction with existing drain-heavy relics to prevent runaway double-counting.【F:backend/tests/test_relic_effects.py†L24-L116】
+- Refresh `.codex/implementation/relic-inventory.md` and related planning notes to document the new 5★ relic.
+
+## Validation
+- `uv run pytest backend/tests/test_relic_effects.py::test_cataclysm_engine_*`
+- `uv run pytest backend/tests/test_relic_effects_advanced.py`
+
+## Documentation
+- `.codex/implementation/relic-inventory.md`
+- `.codex/planning/archive/bd48a561-relic-plan.md`

--- a/.codex/tasks/relics/ceaefef1-field-rations.md
+++ b/.codex/tasks/relics/ceaefef1-field-rations.md
@@ -1,0 +1,26 @@
+# Add 1★ "Field Rations" relic for post-battle recovery
+
+## Summary
+Design and implement a new 1★ relic that rewards survival by topping the party off between encounters. "Field Rations" should provide a light heal and a burst of ultimate charge to all allies after each battle, reinforcing sustain-heavy runs without overpowering in-combat effects.
+
+## Details
+- Leverage the existing relic plugin framework so the new relic stacks multiplicatively with other stat modifiers and can subscribe to battle events for its triggers.【F:backend/plugins/relics/_base.py†L39-L155】
+- Ensure the relic remains part of the 1★ reward pool and shows up in catalogs alongside other low-star relics by registering it through the existing loader and metadata routes.【F:backend/autofighter/relics.py†L27-L43】【F:backend/routes/catalog.py†L40-L62】
+- Update repository docs so the 1★ relic roster reflects the new option and contributors understand its intended role in post-battle sustain loops.【F:.codex/implementation/relic-inventory.md†L12-L22】
+
+## Requirements
+- Create a `FieldRations` relic plugin under `backend/plugins/relics/` that:
+  - Grants each party member a heal equal to ~2–3% Max HP per stack when `battle_end` fires.
+  - Adds a small amount of ultimate charge (e.g., +1 per stack) to each ally after that heal, respecting the existing cap logic.【F:backend/autofighter/stats.py†L680-L704】
+  - Cleans up any subscriptions or temporary state between encounters to avoid stacking extra heals on future fights.
+- Extend relic selection/tests so the new relic can be drawn at 1★ and covered by automated checks (unit test validating the heal + charge behavior when multiple stacks are owned).【F:backend/tests/test_relic_effects.py†L24-L116】
+- Document the relic in `.codex/implementation/relic-inventory.md` with a concise description and note any stacking nuances.
+- Update any planning or reference material that enumerates relics (e.g., relic plans, reward docs) so Field Rations appears with other 1★ entries.
+
+## Validation
+- `uv run pytest backend/tests/test_relic_effects.py::test_field_rations_*`
+- `uv run pytest backend/tests/test_relic_awards.py`
+
+## Documentation
+- `.codex/implementation/relic-inventory.md`
+- Related relic design notes under `.codex/docs/relics/` if needed

--- a/.codex/tasks/relics/f08bf67f-catalyst-vials.md
+++ b/.codex/tasks/relics/f08bf67f-catalyst-vials.md
@@ -1,0 +1,26 @@
+# Add 2★ "Catalyst Vials" relic to reward allied DoT damage
+
+## Summary
+Create a mid-tier relic that turns existing damage-over-time builds into self-sustaining engines. "Catalyst Vials" should trigger whenever an ally's DoT ticks on an enemy, siphoning a portion of the damage back as healing and a temporary debuffing edge for the attacker.
+
+## Details
+- The DoT system already emits async `dot_tick` events with the attacker, target, and damage payload—hook the relic into this path so it reacts to every qualifying tick without duplicating effect code.【F:backend/autofighter/effects.py†L243-L291】
+- Implement the relic as a standard plugin so it stacks correctly and appears in selection pools and catalog listings for 2★ relics.【F:backend/plugins/relics/_base.py†L39-L155】【F:backend/autofighter/relics.py†L27-L43】【F:backend/routes/catalog.py†L40-L62】
+- Update documentation that enumerates relic abilities so the new DoT-sustain option is reflected in contributor references.【F:.codex/implementation/relic-inventory.md†L23-L32】
+
+## Requirements
+- Introduce `CatalystVials` under `backend/plugins/relics/` that:
+  - Listens for `dot_tick` events, filtering for ticks where the attacker is a party member and the target is a foe.
+  - Heals the attacker for a percentage of the tick damage per stack (e.g., 5%) and grants them a one-turn buff to `effect_hit_rate` to reinforce status-heavy teams. Use the effect manager helpers to add and expire the temporary buff cleanly.
+  - Emits `relic_effect` telemetry with metadata describing healing done and bonus potency so battle logs stay informative.
+  - Clears state on battle end so no stale references leak to future fights.
+- Add focused tests verifying that one and multiple stacks properly convert DoT damage into healing/buffs and that non-party ticks are ignored.【F:backend/tests/test_relic_effects.py†L24-L116】
+- Document the relic in `.codex/implementation/relic-inventory.md` and update planning artifacts that outline 2★ relic coverage.
+
+## Validation
+- `uv run pytest backend/tests/test_relic_effects.py::test_catalyst_vials_*`
+- `uv run pytest backend/tests/test_relic_effects_advanced.py`
+
+## Documentation
+- `.codex/implementation/relic-inventory.md`
+- `.codex/planning/archive/bd48a561-relic-plan.md`

--- a/.codex/tasks/relics/fffbf71c-entropy-mirror.md
+++ b/.codex/tasks/relics/fffbf71c-entropy-mirror.md
@@ -1,0 +1,26 @@
+# Add 4★ "Entropy Mirror" relic that amplifies foes but inflicts recoil
+
+## Summary
+Deliver a high-risk relic that accelerates battles by juicing enemy damage while reflecting some of it back at them. "Entropy Mirror" should give all foes a sizable ATK boost at battle start, then cause them to suffer self-inflicted damage whenever they land hits, letting aggressive parties race opponents before the recoil overwhelms them.
+
+## Details
+- Build on the relic base class so multiplicative stacking, event subscriptions, and cleanup behave consistently with other epic relics.【F:backend/plugins/relics/_base.py†L39-L155】
+- Enemy damage events flow through `apply_damage`, which emits `damage_dealt` for the attacker and exposes helper APIs for self-harm; use this hook to apply recoil that ignores mitigation via `apply_cost_damage`.【F:backend/autofighter/stats.py†L955-L990】
+- Ensure documentation that lists 4★ relics reflects the new entry and contrasts its trade-offs with Null Lantern, Traveler's Charm, and Timekeeper's Hourglass.【F:.codex/implementation/relic-inventory.md†L33-L35】
+
+## Requirements
+- Create an `EntropyMirror` relic plugin that:
+  - On `battle_start`, applies a multiplicative ATK buff (e.g., +30% per stack) to all foes present, using stat buffs or direct multipliers.
+  - Subscribes to `damage_dealt` and, when the attacker is a foe, applies self-damage equal to a percentage of the damage dealt per stack using `apply_cost_damage` so mitigation and shields do not prevent the backlash.
+  - Emits detailed `relic_effect` events for both the buff and each recoil tick to keep battle logs informative.
+  - Cleans up subscriptions on `battle_end`.
+- Update tests to cover foe buffing and recoil logic, including ensuring recoil cannot kill already-defeated enemies twice and that multiple stacks scale both effects correctly.【F:backend/tests/test_relic_effects.py†L24-L116】
+- Document the relic in `.codex/implementation/relic-inventory.md` and align long-form relic design notes/plans with the new 4★ option.
+
+## Validation
+- `uv run pytest backend/tests/test_relic_effects.py::test_entropy_mirror_*`
+- `uv run pytest backend/tests/test_rusty_buckle.py`
+
+## Documentation
+- `.codex/implementation/relic-inventory.md`
+- `.codex/planning/archive/bd48a561-relic-plan.md`


### PR DESCRIPTION
## Summary
- add a task for a new 1★ Field Rations relic that heals and grants ultimate charge between battles
- add a task for a new 2★ Catalyst Vials relic that turns allied DoT ticks into sustain
- add a task for a new 3★ Command Beacon relic that redistributes SPD at an HP cost
- add a task for a new 4★ Entropy Mirror relic that buffs foes while causing recoil
- add a task for a new 5★ Cataclysm Engine relic that trades HP for overwhelming power

## Testing
- not run (task authoring only)


------
https://chatgpt.com/codex/tasks/task_b_68ef32f60b30832cbbfdb3bb8aab6cea