### PR TITLE
Add task briefs for new relic concepts across star tiers

### DIFF
--- a/.codex/tasks/relics/3b72eff2-safeguard-prism-2star-relic.md
+++ b/.codex/tasks/relics/3b72eff2-safeguard-prism-2star-relic.md
@@ -1,0 +1,16 @@
+# Safeguard Prism: reactive 2★ sustain spike
+
+## Summary
+Two-star relics emphasize counterattacks (Vengeful Pendant), first-action repeats (Echo Bell), or conditional damage spikes, but none shore up mid-battle survival spikes once Threadbare Cloak's shield is gone. We need a mid-tier option that prevents lethal swings when allies cross dangerous HP thresholds without overshadowing high-rank lifesavers.【F:.codex/implementation/relic-inventory.md†L21-L40】【F:.codex/planning/archive/bd48a561-relic-plan.md†L39-L50】
+
+## Details
+* Design **Safeguard Prism**: when an ally drops below 60% Max HP for the first time in a battle (per stack), immediately grant a shield worth ~15% Max HP per stack and a one-turn mitigation bonus (~12% per stack). Additional stacks should allow multiple trigger charges per ally (one per stack) to reward investment.
+* Track per-ally trigger counts using the party state, reset on `battle_start`/`battle_end`, and piggyback on `damage_taken` events like other reactive relics do. Remember to enable overheal before applying shield healing so the barrier persists.【F:backend/plugins/relics/threadbare_cloak.py†L18-L38】【F:backend/plugins/relics/ember_stone.py†L27-L90】
+* Surface detailed telemetry (`relic_effect`) capturing the HP threshold, shield size, and mitigation applied to aid debugging and replay logs.【F:backend/plugins/relics/guardian_charm.py†L20-L37】
+
+## Requirements
+- Implement `backend/plugins/relics/safeguard_prism.py` with the behavior above, including helper cleanup and a thorough `describe(stacks)` explaining trigger counts, shield size, and mitigation.
+- Expand backend tests to cover multi-stack triggers, single-battle limits, shield application (verifying overheal), and mitigation expiry. Add cases to `backend/tests/test_relic_effects.py` or a new focused module if clearer.
+- Update `.codex/implementation/relic-inventory.md` and the relic design plan with Safeguard Prism's final numbers and intent.【F:.codex/implementation/relic-inventory.md†L21-L43】【F:.codex/planning/archive/bd48a561-relic-plan.md†L37-L63】
+- Provide a placeholder icon under `frontend/src/lib/assets/relics/2star/` and ensure the catalog/tooltip surfaces the description via the usual metadata plumbing (no custom frontend code expected beyond verifying the asset loads).【F:frontend/src/lib/systems/assetRegistry.js†L174-L1353】
+- Document any tuning rationale in `.codex/docs/relics/` if the mitigation math needs future reference.

--- a/.codex/tasks/relics/4b0c0d58-featherweight-anklet-1star-relic.md
+++ b/.codex/tasks/relics/4b0c0d58-featherweight-anklet-1star-relic.md
@@ -1,0 +1,16 @@
+# Featherweight Anklet: early tempo relic (1★)
+
+## Summary
+Our 1★ pool leans on sustain, mitigation, and incremental offense but lacks a relic that nudges turn tempo or early gauge pressure. Players who want fast openings must jump to higher-star options like Traveler's Charm or Timekeeper's Hourglass, leaving a pacing gap in the common pool.【F:.codex/implementation/relic-inventory.md†L9-L40】【F:.codex/planning/archive/bd48a561-relic-plan.md†L10-L37】
+
+## Details
+* Introduce **Featherweight Anklet**, a 1★ relic that grants a small permanent SPD multiplier (≈+2% per stack) and awards a short burst (+6% SPD per stack for 1 turn) the first time each ally acts in a battle. This mirrors the immediate impact of cards like quick buffs while staying inside 1★ power bounds.
+* Use the existing `RelicBase` helpers for multiplicative stat adjustments and subscribe to `battle_start`/`action_used` events so each ally only receives the one-time burst per battle. Clear subscriptions on battle end just like other reactive relics.【F:backend/plugins/relics/lucky_button.py†L18-L61】【F:backend/plugins/relics/echo_bell.py†L34-L95】
+* Emit rich `relic_effect` telemetry that reports which ally received the burst and how big the SPD swing was so battle logs capture the effect.【F:backend/plugins/relics/shiny_pebble.py†L29-L63】
+
+## Requirements
+- Add `backend/plugins/relics/featherweight_anklet.py` implementing the behavior above, including cleanup helpers and `describe(stacks)` copy that clarifies both the permanent SPD boost and the first-action burst.
+- Extend backend tests to cover: permanent SPD stacking, single-trigger burst per ally per battle, and telemetry emission (asserting `relic_effect` payload). Reuse the async BUS fixtures already present in `backend/tests/test_relic_effects.py` or create a dedicated test module if easier.【F:backend/tests/test_relic_effects.py†L1-L420】
+- Update `.codex/implementation/relic-inventory.md` and the archived relic plan to document Featherweight Anklet with the final numbers and behavior.【F:.codex/implementation/relic-inventory.md†L9-L47】【F:.codex/planning/archive/bd48a561-relic-plan.md†L10-L53】
+- Provide a placeholder icon under `frontend/src/lib/assets/relics/1star/` (24×24 PNG) and ensure it resolves through the asset registry (no manual import needed thanks to globbing, but include the asset in git).【F:frontend/src/lib/systems/assetRegistry.js†L174-L1353】
+- Add a release note blurb to `.codex/docs/relics/` if additional mechanical rationale is useful; otherwise ensure existing docs stay consistent.

--- a/.codex/tasks/relics/72c67e47-siege-banner-3star-relic.md
+++ b/.codex/tasks/relics/72c67e47-siege-banner-3star-relic.md
@@ -1,0 +1,16 @@
+# Siege Banner: attrition-focused 3★ relic
+
+## Summary
+Our 3★ relics reward economy (Greed Engine), crit scaling (Stellar Compass), or first-attack repeats (Echoing Drum). None lean into attrition battles where the party methodically removes foes and wants the fight to snowball defensively afterward. A 3★ option that softens enemy defenses upfront while paying off on every kill would diversify mid-tier relic drafting.【F:.codex/implementation/relic-inventory.md†L24-L35】【F:.codex/planning/archive/bd48a561-relic-plan.md†L45-L55】
+
+## Details
+* Introduce **Siege Banner**: on `battle_start`, inflict a 2-turn DEF debuff (~15% per stack) on all enemies. Each time a foe dies, the party gains a permanent stacking buff (≈+4% ATK and +4% DEF per stack) for the rest of the combat, reinforcing long fights.
+* Use `battle_start` subscriptions to loop through active enemies and apply stat modifiers through their effect managers. Follow patterns from Traveler's Charm and Echoing Drum for enemy iteration / cleanup, ensuring modifiers are removed once fights end.【F:backend/plugins/relics/travelers_charm.py†L23-L86】【F:backend/plugins/relics/echoing_drum.py†L24-L118】
+* Track death events via `damage_taken` and guard against double triggers from overkill, similar to Bent Dagger's kill handling. Emit telemetry describing both the initial debuff and each stacking buff increment.【F:backend/plugins/relics/bent_dagger.py†L23-L58】
+
+## Requirements
+- Implement `backend/plugins/relics/siege_banner.py` with helper cleanup and `describe(stacks)` copy that explains the opening debuff and per-kill scaling.
+- Add focused tests validating: enemy debuff application on battle start, stacking buffs per kill (including multiple stacks), and cleanup after battle end. Extend `backend/tests/test_relic_effects_advanced.py` or create a new suite.
+- Update `.codex/implementation/relic-inventory.md` and the archival relic design plan with Siege Banner's final tuning.【F:.codex/implementation/relic-inventory.md†L24-L41】【F:.codex/planning/archive/bd48a561-relic-plan.md†L45-L60】
+- Provide a placeholder icon under `frontend/src/lib/assets/relics/3star/` and confirm it loads via the existing asset registry globs.【F:frontend/src/lib/systems/assetRegistry.js†L174-L1353】
+- Document any notable pacing math (e.g., kill stack percentages) in `.codex/docs/relics/` if future balancing is expected.

--- a/.codex/tasks/relics/8b9d1bbb-eclipse-reactor-5star-relic.md
+++ b/.codex/tasks/relics/8b9d1bbb-eclipse-reactor-5star-relic.md
@@ -1,0 +1,16 @@
+# Eclipse Reactor: burst-for-blood 5★ relic
+
+## Summary
+Our 5★ set covers high-risk ally sacrifice (Paradox Hourglass), attrition-focused revives (Soul Prism), and long-duration stat overclocks (Omega Core). We still lack a relic that trades a chunk of HP for an explosive short-term power spike before decaying into a drain, giving aggressive players a distinct pacing lever.【F:.codex/implementation/relic-inventory.md†L40-L47】【F:.codex/planning/archive/bd48a561-relic-plan.md†L52-L70】
+
+## Details
+* Create **Eclipse Reactor**: on `battle_start`, drain 18% Max HP per stack from every ally (non-lethal) and apply a 3-turn buff (+180% ATK, +180% SPD, +60% crit damage per stack) representing the eclipse surge. When the buff expires, allies begin taking 2% Max HP damage per stack each turn for the remainder of the battle until combat ends.
+* Use RelicBase helpers to apply the temporary stat multipliers via `create_stat_buff`, then schedule a follow-up hook that swaps to the post-surge HP drain. Follow Omega Core's pacing for long-duration buffs and Greed Engine's HP drain approach for the aftermath.【F:backend/plugins/relics/omega_core.py†L14-L120】【F:backend/plugins/relics/greed_engine.py†L18-L68】
+* Emit telemetry for both the initial drain and the buff activation/expiration so the battle log clearly reflects the trade-offs.【F:backend/plugins/relics/omega_core.py†L61-L102】
+
+## Requirements
+- Implement `backend/plugins/relics/eclipse_reactor.py` with clear state tracking (storing remaining surge duration, hooking `turn_start` to apply the post-surge drain) and a descriptive `describe(stacks)` documenting both phases.
+- Add comprehensive tests covering: initial HP drain clamping at 1 HP, buff duration stacking, transition into the post-surge drain, and cleanup on battle end. Extend `backend/tests/test_relic_effects_advanced.py` or add a new module.
+- Update `.codex/implementation/relic-inventory.md` and the relic plan with Eclipse Reactor's final parameters.【F:.codex/implementation/relic-inventory.md†L40-L47】【F:.codex/planning/archive/bd48a561-relic-plan.md†L52-L73】
+- Supply a placeholder asset under `frontend/src/lib/assets/relics/5star/` and ensure the description surfaces correctly through existing catalog endpoints.【F:frontend/src/lib/systems/assetRegistry.js†L174-L1353】
+- Capture balancing notes (HP drain math, buff multipliers) in `.codex/docs/relics/` for future tuning discussions.

--- a/.codex/tasks/relics/ff95fa3c-graviton-locket-4star-relic.md
+++ b/.codex/tasks/relics/ff95fa3c-graviton-locket-4star-relic.md
@@ -1,0 +1,16 @@
+# Graviton Locket: high-risk 4★ battlefield control relic
+
+## Summary
+Null Lantern dramatically changes routing, while Traveler's Charm and Timekeeper's Hourglass lean on defensive tempo buffs. We still lack a high-star relic that aggressively cripples enemy tempo at a health cost to the party. A gravity-themed relic can create that trade-off, giving veterans a reason to embrace HP drain for explosive openings.【F:.codex/implementation/relic-inventory.md†L33-L40】【F:.codex/planning/archive/bd48a561-relic-plan.md†L47-L60】
+
+## Details
+* Define **Graviton Locket**: on `battle_start`, apply a "gravity" debuff to every enemy for 2 turns +1 per additional stack that reduces SPD by ~30% per stack and increases damage taken by ~12% per stack. While any enemy is under gravity, the party loses 1% Max HP per stack at `turn_start` (mirroring Greed Engine's drain cadence).
+* Store active debuffs in party state so we know when all gravity effects have expired and can stop draining HP. Remove any lingering modifiers at `battle_end` to avoid leaking across fights.【F:backend/plugins/relics/greed_engine.py†L18-L68】【F:backend/plugins/relics/travelers_charm.py†L23-L86】
+* Emit telemetry detailing both the debuff (per target) and each HP drain tick to keep combat logs honest.【F:backend/plugins/relics/guardian_charm.py†L20-L37】【F:backend/plugins/relics/greed_engine.py†L34-L63】
+
+## Requirements
+- Implement `backend/plugins/relics/graviton_locket.py` with helper cleanup, duration tracking, and a thorough `describe(stacks)` covering debuff values, duration scaling, and HP drain cost.
+- Add backend tests ensuring: enemies receive the debuff with correct magnitude/duration, HP drain only runs while gravity is active (and scales with stacks), and all modifiers clear after battle. Extend `backend/tests/test_relic_effects_advanced.py` or create a new dedicated module.
+- Update `.codex/implementation/relic-inventory.md` and the relic design plan to include Graviton Locket with final tuning notes.【F:.codex/implementation/relic-inventory.md†L33-L48】【F:.codex/planning/archive/bd48a561-relic-plan.md†L45-L65】
+- Supply a placeholder icon in `frontend/src/lib/assets/relics/4star/` and verify the asset resolves through the registry globs.【F:frontend/src/lib/systems/assetRegistry.js†L174-L1353】
+- Capture balancing rationale (gravity duration vs. HP drain) in `.codex/docs/relics/` so future tuning has a paper trail.


### PR DESCRIPTION
## Summary
- add Task Master follow-ups for five new relic concepts covering the 1★–5★ reward tiers

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [x] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68ef32f60b30832cbbfdb3bb8aab6cea