### PR TITLE
[TASK] Queue new card design briefs

### DIFF
--- a/.codex/tasks/cards/34fa0148-oracle-prayer-charm-1star-card.md
+++ b/.codex/tasks/cards/34fa0148-oracle-prayer-charm-1star-card.md
@@ -1,0 +1,15 @@
+# Oracle Prayer Charm: Ryne-flavored 1★ rescue drip
+
+## Summary
+The 1★ catalog leans on flat stat bumps or tiny reactive procs, but none of the low-rank cards provide a Light-style safety net once Sturdy Vest's small HoT runs out.【F:.codex/implementation/card-inventory.md†L12-L47】 Ryne's kit revolves around layering Oracle-of-Light wards and mid-fight stabilizers, so a charm that sprinkles Radiant Regeneration when allies are in danger fits both her theme and the roster fiction.【F:.codex/implementation/player-foe-reference.md†L51-L70】【F:.codex/implementation/damage-healing.md†L12-L36】
+
+## Details
+* Implement **Oracle Prayer Charm** as a 1★ card that grants +3% Effect Resistance and +3% Vitality to emphasize Ryne's protective aura while nudging survivability-focused builds.【F:.codex/implementation/card-inventory.md†L12-L47】【F:.codex/implementation/player-foe-reference.md†L51-L70】
+* Subscribe to the battle event bus so that the first time each party member begins a turn below ~45% HP in a battle, they receive a 2-turn `Radiant Regeneration` HoT. Track per-member triggers to avoid infinite refreshes and reuse the existing HoT plugin instead of inventing a bespoke heal.【F:.codex/implementation/damage-healing.md†L12-L36】【F:.codex/implementation/stats-and-effects.md†L33-L63】
+* Emit rich telemetry on each trigger (who received the HoT, HP threshold, remaining charges) so battle logs surface when the charm saves someone.
+
+## Requirements
+- Add `backend/plugins/cards/oracle_prayer_charm.py` with the stats + trigger logic above, mirroring subscription cleanup patterns used by other 1★ reactive cards like Balanced Diet and Sturdy Vest.
+- Extend backend card tests to cover edge cases: multiple allies dipping under the threshold, ensuring once-per-ally limits reset after `battle_end`, and verifying Radiant Regeneration is applied using the shared HoT class.
+- Update `.codex/implementation/card-inventory.md` and `.codex/planning/archive/726d03ae-card-plan.md` with the new entry and tuning notes.【F:.codex/implementation/card-inventory.md†L12-L69】【F:.codex/planning/archive/726d03ae-card-plan.md†L5-L69】
+- Supply a placeholder icon (`oracleprayercharm.png`) under `frontend/src/lib/assets/cards/Art/` and confirm the asset registry picks it up with the usual glob scan.【F:frontend/src/lib/systems/assetRegistry.js†L245-L253】

--- a/.codex/tasks/cards/c1a05833-tempest-pathfinder-2star-card.md
+++ b/.codex/tasks/cards/c1a05833-tempest-pathfinder-2star-card.md
@@ -1,0 +1,15 @@
+# Tempest Pathfinder: LadyWind 2★ dodge rally
+
+## Summary
+Our 2★ line-up focuses on Critical Boost loops, global DEF pulses, or extra actions—none of the mid-tier rewards encourage dodge-centric squads even though evasion is a core defensive stat and LadyWind's passive thrives on crit-fueled slipstreams.【F:.codex/implementation/card-inventory.md†L49-L56】【F:.codex/planning/archive/726d03ae-card-plan.md†L47-L55】【F:.codex/implementation/player-foe-reference.md†L63-L65】【F:.codex/implementation/stats-and-effects.md†L6-L13】 Adding a card that turns crit bursts into temporary tailwinds diversifies defensive builds without stepping on Iron Guard's stacking armor niche.
+
+## Details
+* Ship **Tempest Pathfinder** as a 2★ card granting +55% Dodge Odds baseline so it anchors evasive parties alongside LadyWind or other crit hunters.【F:.codex/implementation/card-inventory.md†L49-L56】【F:.codex/implementation/player-foe-reference.md†L63-L65】
+* Listen for `crit`/`damage_dealt` events: whenever an ally crits, pulse a 1-turn +12% dodge buff to the whole party and log who triggered it. Add a soft cooldown of one trigger per team turn to prevent permanent uptime while still rewarding rapid-fire crit comps.【F:.codex/implementation/stats-and-effects.md†L33-L63】
+* Include action timeline telemetry (e.g., `card_effect` payload with triggering ally, crit damage, and remaining cooldown) for replay clarity.
+
+## Requirements
+- Implement `backend/plugins/cards/tempest_pathfinder.py` with the stat mod, crit listener, per-turn cooldown reset (hook into `turn_start`), and subscription cleanup mirroring other reactive cards.
+- Expand tests so crit/no-crit branches are covered, including verifying the dodge buff expires after one turn and cooldown resets correctly for multi-turn fights.
+- Document the new card in `.codex/implementation/card-inventory.md` and the card design plan, calling out the crit-triggered dodge rally.【F:.codex/implementation/card-inventory.md†L49-L66】【F:.codex/planning/archive/726d03ae-card-plan.md†L47-L64】
+- Add `tempestpathfinder.png` under `frontend/src/lib/assets/cards/Art/` and confirm the reward selection UI renders it.

--- a/.codex/tasks/cards/c90503c9-guardian-choir-circuit-3star-card.md
+++ b/.codex/tasks/cards/c90503c9-guardian-choir-circuit-3star-card.md
@@ -1,0 +1,15 @@
+# Guardian Choir Circuit: Carly 3★ sustain anchor
+
+## Summary
+Every existing 3★ reward is offensive—either crit conversion, revival armor, or chain lightning—leaving no high-impact sustain card for runs that lean on healers like Carly and other Light specialists.【F:.codex/implementation/card-inventory.md†L58-L66】【F:.codex/planning/archive/726d03ae-card-plan.md†L56-L64】【F:.codex/implementation/player-foe-reference.md†L51-L52】 We need a premium support option that spreads Carly's guardian shields without duplicating Iron Resurgence's revive loop.
+
+## Details
+* Add **Guardian Choir Circuit** as a 3★ card granting +200% DEF and +150% Regain so teams that invest in healing get both sturdiness and stronger regen ticks.【F:.codex/implementation/card-inventory.md†L58-L66】【F:.codex/implementation/player-foe-reference.md†L51-L52】
+* Hook into the `heal_received` event: whenever an ally is directly healed, funnel 15% of that heal into a shield on the lowest-HP teammate (including the target if still lowest) and apply a 1-turn +12% mitigation buff to the shield recipient. Limit to once per ally turn to prevent infinite loops from multi-hit heals.【F:.codex/implementation/damage-healing.md†L12-L37】【F:.codex/implementation/stats-and-effects.md†L33-L63】
+* Surface telemetry noting the healer, heal amount, shield size, mitigation bonus, and which ally received the choir redirect for debugging.
+
+## Requirements
+- Implement `backend/plugins/cards/guardian_choir_circuit.py` with stat boosts, heal listener, per-turn throttling, and cleanup following the patterns in Balanced Diet and Guardian Shard.
+- Write backend tests covering multi-target heals, overheal handling, and ensuring the mitigation buff and shield expire correctly between turns.
+- Update `.codex/implementation/card-inventory.md` plus the archived card plan to document the new sustain-focused 3★ card.【F:.codex/implementation/card-inventory.md†L58-L69】【F:.codex/planning/archive/726d03ae-card-plan.md†L56-L69】
+- Create `guardianchoircircuit.png` under `frontend/src/lib/assets/cards/Art/` so the reward picker displays the new option.

--- a/.codex/tasks/cards/d4603fd2-eclipse-theater-sigil-5star-card.md
+++ b/.codex/tasks/cards/d4603fd2-eclipse-theater-sigil-5star-card.md
@@ -1,0 +1,15 @@
+# Eclipse Theater Sigil: Persona Light/Dark 5★ rotation
+
+## Summary
+Our 5★ options currently cover summon tempo, near-invulnerability, and crit-stacked echoes, but none capture Persona Light and Dark's alternating aura that flips between radiant support and oppressive debuffs.【F:.codex/planning/archive/726d03ae-card-plan.md†L66-L69】【F:.codex/implementation/player-foe-reference.md†L68-L70】 Delivering a toggle that swaps Light heals and Dark pressure each turn would broaden endgame builds beyond raw damage spikes.
+
+## Details
+* Introduce **Eclipse Theater Sigil** as a 5★ card granting +1500% Max HP and +1500% ATK so it meaningfully boosts both sides of the dual persona fantasy.【F:.codex/planning/archive/726d03ae-card-plan.md†L66-L69】【F:.codex/implementation/player-foe-reference.md†L68-L70】
+* Maintain a global polarity flag: Light turns (odd overall turns) should cleanse one DoT from each ally and apply a 2-turn `Radiant Regeneration`; Dark turns (even turns) should apply one stack of `Abyssal Weakness` to all foes and give every ally a 1-action +50% crit rate buff to represent the aggressive surge. Reset ally-specific crit buffs after they consume the bonus to avoid stacking indefinitely.【F:.codex/implementation/damage-healing.md†L7-L23】【F:.codex/implementation/stats-and-effects.md†L33-L73】
+* Emit telemetry describing the chosen polarity, dispelled debuffs, applied DoTs, and crit buffs so replay logs can confirm the alternating cadence.
+
+## Requirements
+- Implement `backend/plugins/cards/eclipse_theater_sigil.py` with stat mods, turn-based polarity toggles, ally/foe effect application, crit buff cleanup, and subscription teardown patterned after Reality Split and Temporal Shield.
+- Extend backend tests to cover alternating turns, ensuring cleanses happen only on Light turns, Dark debuffs/buffs fire once per turn, and polarity resets between battles.
+- Document the new card in `.codex/implementation/card-inventory.md` (adding the missing 5★ section if needed) and refresh the archived card plan with the alternating aura description.【F:.codex/implementation/card-inventory.md†L63-L69】【F:.codex/planning/archive/726d03ae-card-plan.md†L66-L69】
+- Drop `eclipsetheatersigil.png` into `frontend/src/lib/assets/cards/Art/` and confirm the UI catalogs it.

--- a/.codex/tasks/cards/e0055455-flux-paradox-engine-4star-card.md
+++ b/.codex/tasks/cards/e0055455-flux-paradox-engine-4star-card.md
@@ -1,0 +1,15 @@
+# Flux Paradox Engine: LadyFireAndIce 4★ stance cycling
+
+## Summary
+Current 4★ rewards hand out brute-force tempo (Overclock), revives (Iron Resolve), or repeat strikes (Arcane Repeater) but none lean into elemental stance play despite LadyFireAndIce anchoring the roster's dual-mode identity.【F:.codex/implementation/card-inventory.md†L63-L66】【F:.codex/planning/archive/726d03ae-card-plan.md†L61-L64】【F:.codex/implementation/player-foe-reference.md†L59-L60】 Introducing a card that rotates Fire/Ice boons each turn would unlock hybrid teams without overshadowing existing raw DPS options.
+
+## Details
+* Build **Flux Paradox Engine** as a 4★ card that grants +240% Effect Hit Rate and +240% Effect Resistance, underscoring its control-focused stance swaps rather than straight damage.【F:.codex/implementation/card-inventory.md†L63-L66】【F:.codex/implementation/player-foe-reference.md†L59-L60】
+* Track a battle-wide `mode` flag that flips each global `turn_start`: Fire stance on odd turns, Ice stance on even. In Fire stance, the first damaging action each ally performs that turn should apply one stack of `Blazing Torment` to its target; in Ice stance, the first damaging action applies one stack of `Cold Wound` and grants the attacker +12% mitigation for 1 turn. Reset per-ally triggers every turn so multi-attack characters can still benefit once per stance.【F:.codex/implementation/damage-healing.md†L7-L26】【F:.codex/implementation/stats-and-effects.md†L33-L63】
+* Emit telemetry identifying the stance, triggering ally, and applied effects so testers can confirm swaps in combat logs.
+
+## Requirements
+- Implement `backend/plugins/cards/flux_paradox_engine.py` with stat boosts, stance state machine, per-ally triggers, and proper cleanup. Lean on existing event subscriptions (turn_start, damage_dealt) to avoid polling loops.
+- Extend backend tests to cover both stances, ensuring stacks flip correctly across turns and mitigation buffs expire after one round.
+- Update `.codex/implementation/card-inventory.md` and the archived card plan with the stance-cycling description and numerical tuning.【F:.codex/implementation/card-inventory.md†L63-L69】【F:.codex/planning/archive/726d03ae-card-plan.md†L61-L69】
+- Provide `fluxparadoxengine.png` in `frontend/src/lib/assets/cards/Art/` and verify reward previews pick up the asset.


### PR DESCRIPTION
## Summary
- add Oracle Prayer Charm 1★ task inspired by Ryne to drip-feed Radiant Regeneration when allies are low
- add Tempest Pathfinder 2★ task built around LadyWind crit-triggered dodge rallies
- add Guardian Choir Circuit, Flux Paradox Engine, and Eclipse Theater Sigil tasks to expand 3★–5★ card variety with support and stance mechanics

## Testing
- n/a (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68efaaa7fe90832cae9876566dbf969c