### PR TITLE
Add planning tasks for new cards across star ranks

### DIFF
--- a/.codex/tasks/cards/2143c67c-guardians-beacon-card.md
+++ b/.codex/tasks/cards/2143c67c-guardians-beacon-card.md
@@ -1,0 +1,24 @@
+# Add 2★ card: Guardian's Beacon inspired by Carly
+
+## Summary
+Introduce a defensive two-star card that channels Carly's protective playstyle by blending large defense scaling with targeted sustain. The goal is to support defensive or sustain-heavy parties without duplicating Iron Guard.
+
+## Design requirements
+- Name the card **Guardian's Beacon** and register it as a 2★ reward.
+- Baseline stats: **+55% DEF** to align with other defensive 2★ options.
+- Passive effect: at the end of each turn, heal the lowest-HP ally for **8% of their Max HP**. If that ally's damage type is **Light**, also grant them **+10% Mitigation for 1 turn**.
+- Healing should respect overheal rules and mitigation stacks should expire normally at turn end.
+
+## Implementation notes
+- Implement the new plugin in `backend/plugins/cards/`, wiring into the turn-end hooks that existing sustain cards use.
+- Ensure the Light element check leverages the same damage-type metadata covered in `.codex/implementation/player-foe-reference.md`.
+- Update `.codex/implementation/card-inventory.md` and `.codex/planning/archive/726d03ae-card-plan.md` to list the new reward under 2★ cards with its full effect text.
+- Add or extend backend tests validating 2★ card registration and the healing/mitigation trigger (mocking a Light ally to confirm the conditional bonus).
+
+## Deliverables
+- Card plugin with metadata, star rank, stat bonuses, and passive trigger logic.
+- Documentation updates reflecting the new card in both reference and planning files.
+- Automated test coverage proving the end-of-turn heal and Light-aligned mitigation bonus work as specified.
+
+## Player impact
+Guardian's Beacon provides a fresh sustain option for defensive squads, letting Carly-focused teams or Light-heavy parties maintain shields without relying solely on revival-centric cards.

--- a/.codex/tasks/cards/27893b2a-dynamo-wristbands-card.md
+++ b/.codex/tasks/cards/27893b2a-dynamo-wristbands-card.md
@@ -1,0 +1,24 @@
+# Add 1★ card: Dynamo Wristbands for Ixia-centric lineups
+
+## Summary
+Design and implement a new one-star card that leans into Ixia's lightning bruiser theme while keeping the effect appropriately modest for the rarity tier. The reward should provide a small offensive bump and encourage players to mix lightning dealers with crit-focused builds without eclipsing existing 1★ staples.
+
+## Design requirements
+- Name the card **Dynamo Wristbands** and classify it as a 1★ reward.
+- Baseline bonus: **+3% ATK** to mirror other low-tier offensive cards.
+- Unique passive: whenever an ally deals **Lightning** damage (including basic attacks or skill effects tagged to the lightning element), grant that ally **+3% Crit Rate for 1 turn**, stacking up to **2 times**.
+- Ensure the effect respects existing turn/stack cleanup rules so the crit rate buff expires correctly when the duration ends.
+
+## Implementation notes
+- Add a new plugin under `backend/plugins/cards/` that extends the common card base and hooks lightning damage events without blocking other elements.
+- Verify the element check aligns with the damage type plumbing described in `.codex/implementation/stats-and-effects.md`.
+- Update inventory and planning docs so the new reward appears alongside other 1★ entries (`.codex/implementation/card-inventory.md`, `.codex/planning/archive/726d03ae-card-plan.md`).
+- Extend any unit tests that enumerate 1★ cards (see `backend/tests` coverage for card registration) so Dynamo Wristbands is included.
+
+## Deliverables
+- New card plugin with metadata, star rank, stat bonus, and triggered buff logic.
+- Doc updates covering the new card in both the live inventory reference and the planning document.
+- Passing backend tests relevant to card registration and reward rolls.
+
+## Player impact
+Adding a lightning-centric 1★ option expands early-run build variety by letting players chase bonus crit uptime when they roll Ixia, LadyLightning, or other lightning specialists, while still offering a straightforward stat bump for general parties.

--- a/.codex/tasks/cards/6949190a-flux-convergence-card.md
+++ b/.codex/tasks/cards/6949190a-flux-convergence-card.md
@@ -1,0 +1,27 @@
+# Add 3★ card: Flux Convergence honoring Kboshi
+
+## Summary
+Deliver a high-impact three-star reward that channels Kboshi's flux manipulation by rewarding debuff-centric teams. The design should lean into dark-element control without duplicating existing crit engines.
+
+## Design requirements
+- Name the card **Flux Convergence** and designate it as a 3★ reward.
+- Base stats: **+255% Effect Hit Rate** to help status-heavy squads stick their debuffs.
+- Passive loop:
+  - Track a global **Flux counter** that increments each time any ally successfully applies a debuff to an enemy.
+  - When the counter reaches **5 stacks**, immediately consume all stacks to deal **120% ATK dark damage** to all foes and grant the debuffing ally **+20% Effect Resistance for 1 turn**.
+  - Flux counter should persist across turns but reset whenever it triggers, encouraging steady debuff application.
+- Damage instance should leverage the existing dark damage type hooks so related passives can react.
+
+## Implementation notes
+- Implement the plugin under `backend/plugins/cards/`, using shared event hooks for debuff application (consult `.codex/implementation/stats-and-effects.md` for debuff plumbing).
+- Ensure AoE damage respects mitigation and logs correctly through the damage manager.
+- Document the card in `.codex/implementation/card-inventory.md` and update the planning entry in `.codex/planning/archive/726d03ae-card-plan.md`.
+- Extend backend tests for 3★ card registration and add targeted unit coverage to confirm the Flux counter, damage burst, and resistance buff fire at exactly five debuff applications.
+
+## Deliverables
+- Fully implemented card plugin with stat bonuses, Flux counter tracking, AoE damage trigger, and resistance buff handling.
+- Updated docs listing Flux Convergence with accurate rules text.
+- Passing backend tests covering registration and the Flux mechanic edge cases.
+
+## Player impact
+Flux Convergence gives debuff-centric teams—especially those fielding Kboshi or LadyDarkness—a reason to invest in multi-turn control loops, providing reliable AoE bursts and protection against incoming cleanses.

--- a/.codex/tasks/cards/8782fc1d-equilibrium-prism-card.md
+++ b/.codex/tasks/cards/8782fc1d-equilibrium-prism-card.md
@@ -1,0 +1,30 @@
+# Add 5★ card: Equilibrium Prism echoing Ryne's balance theme
+
+## Summary
+Ship a top-tier five-star reward centered on Ryne's balance mechanic, giving late-game teams a strategic redistribution tool rather than raw damage. The card should fundamentally alter party flow, competing with existing 5★ powerhouses.
+
+## Design requirements
+- Name the card **Equilibrium Prism** and classify it as a 5★ card.
+- Base bonuses: **+1500% ATK** and **+1500% DEF** to underscore the late-game power spike.
+- Passive effect sequence each round start:
+  - Redistribute HP so that all allies are raised toward the party's average percentage without exceeding their Max HP (healing only; no ally should lose HP).
+  - Grant **Balance tokens** equal to the number of allies healed by the redistribution.
+  - When Balance tokens reach **5**, consume them to: 
+    - Grant all allies **+50% Crit Rate** and **+50% Mitigation** for 1 turn.
+    - Deal **200% Light damage** to the enemy with the highest current HP.
+- Token counter persists across turns and resets only when the burst fires.
+
+## Implementation notes
+- Implement the plugin under `backend/plugins/cards/`, reusing healing helpers to avoid damage from redistribution and ensuring logs match existing heal events.
+- Balance token tracking can live on the party state or card instance; make sure it's accessible in multi-fight runs.
+- Confirm Light damage uses the correct damage type hooks so Ryne/LadyLight synergies trigger.
+- Update `.codex/implementation/card-inventory.md` and `.codex/planning/archive/726d03ae-card-plan.md` with detailed rules text.
+- Extend backend tests covering 5★ cards to verify HP redistribution never harms allies, tokens accumulate correctly, and the burst applies buffs plus targeted damage.
+
+## Deliverables
+- Fully realized Equilibrium Prism plugin with stat bonuses, redistribution logic, token tracking, and burst resolution.
+- Documentation updates describing the card's mechanics in both reference and planning docs.
+- Automated tests ensuring healing math, token cadence, and Light damage bursts behave as expected.
+
+## Player impact
+Equilibrium Prism introduces a balance-focused alternative to the existing offensive 5★ lineup, letting Ryne-led parties smooth sustain gaps while unleashing periodic Light detonations that reward careful formation play.

--- a/.codex/tasks/cards/b00303e1-supercell-conductor-card.md
+++ b/.codex/tasks/cards/b00303e1-supercell-conductor-card.md
@@ -1,0 +1,28 @@
+# Add 4★ card: Supercell Conductor themed after LadyStorm
+
+## Summary
+Create a four-star reward that captures LadyStorm's slipstream-and-burst gameplay by chaining bonus actions for Wind and Lightning allies. The effect should offer proactive tempo without duplicating Overclock's global double turn.
+
+## Design requirements
+- Title the card **Supercell Conductor** and register it at the 4★ rarity.
+- Base bonuses: **+240% ATK** and **+240% Effect Hit Rate** to amplify aggressive hybrid casters.
+- Passive effect:
+  - At battle start and every **third round** thereafter, grant the fastest Wind or Lightning ally a **Tailwind** buff.
+  - Tailwind immediately grants a bonus action at **50% damage** and **+30% Effect Hit Rate** for that action only.
+  - After the bonus action resolves, apply **-10% Mitigation** to all enemies hit for 1 turn to set up follow-up bursts.
+- Ensure the round counter respects the battle loop so the cadence is predictable (start of rounds 1, 4, 7, ...).
+
+## Implementation notes
+- Add the new plugin under `backend/plugins/cards/`, hooking into round start triggers and selecting the appropriate ally via initiative stats.
+- Implement the Tailwind bonus action by leveraging the existing extra-action utilities used by Swift Footwork, but scope it to the chosen ally and reduced damage.
+- Mitigation shred should reuse existing debuff helpers and expire at the next turn start.
+- Update `.codex/implementation/card-inventory.md` and `.codex/planning/archive/726d03ae-card-plan.md` with the card details, and adjust any UI copy if the cadence needs clarification.
+- Expand tests for 4★ cards to cover Tailwind scheduling, damage scaling, and mitigation debuff application.
+
+## Deliverables
+- Functional Supercell Conductor plugin with stat bonuses, Tailwind cadence, and mitigation debuff handling.
+- Documentation updates enumerating the new card and clarifying its timing windows.
+- Automated test coverage verifying the round-based trigger and reduced-damage action.
+
+## Player impact
+Supercell Conductor supplies Wind/Lightning lineups with periodic tempo spikes that soften enemy defenses, supporting aggressive combo lines distinct from Overclock's global action flood.


### PR DESCRIPTION
## Summary
- add a task for a new 1★ lightning-focused card inspired by Ixia
- add a task for a new 2★ defensive card inspired by Carly
- add tasks for new 3★, 4★, and 5★ cards reflecting Kboshi, LadyStorm, and Ryne themes

## Testing
- not run (documentation-only tasks)


------
https://chatgpt.com/codex/tasks/task_b_68efaaa7fe90832cae9876566dbf969c