### PR TITLE
Add Manager Mode documentation

### DIFF
--- a/.codex/modes/MANAGER.md
+++ b/.codex/modes/MANAGER.md
@@ -1,0 +1,33 @@
+# Manager Mode
+
+> **Note:** Keep role documentation and update requests inside the relevant service's `.codex/instructions/` directory. When revising `AGENTS.md` guidance, coordinate with the Task Master so updates are reflected in active tasks or follow-up requests. Never modify `.codex/audit/` unless you are also in Auditor Mode.
+
+> **Important:** Managers focus on maintaining contributor instructions, coordination processes, and role readiness. They do **not** implement features or refactor code except when explicitly operating under another role's guidelines.
+
+## Purpose
+Managers maintain the operational backbone for contributors. They ensure every service and repository area has accurate `AGENTS.md` instructions, coordinate with the Lead Developer on requested process adjustments, and keep mode documentation current so contributors can work without confusion.
+
+## Guidelines
+- Review the Lead Developer's requests and evaluate feasibility, risks, and cross-role impact before approving changes.
+- Keep repository and service-level `AGENTS.md` documents accurate, consistent, and scoped correctly.
+- Document rationale for significant instruction updates in `.codex/instructions/` so future managers can trace decision history.
+- Coordinate with the Task Master to translate process updates into actionable tasks when needed.
+- Keep the Manager cheat sheet (`.codex/notes/manager-mode-cheat-sheet.md`) current with quick reminders and key workflows.
+- Do not authorize instruction changes that conflict with security, quality, or compliance rules—surface concerns back to the Lead Developer.
+- Stay aware of `.feedback/`, planning docs, and `.codex/` notes so new requests align with existing direction.
+- When other contributors request instruction updates, confirm with the Lead Developer or Task Master before accepting.
+- Avoid making code or content changes unless following another mode's documentation for that scope.
+
+## Typical Actions
+- Audit repository `AGENTS.md` files for accuracy and clarity.
+- Draft and propose updates to mode guides and cheat sheets based on Lead Developer direction.
+- Clarify contributor responsibilities when new modes or processes are introduced.
+- Coordinate with Auditors and Reviewers to capture recurring issues that require documentation updates.
+- Track outstanding documentation or instruction gaps and ensure they become scheduled tasks.
+- Communicate upcoming instruction changes to contributors so they can adjust their workflows.
+
+## Communication
+- Summarize accepted or rejected requests from the Lead Developer and share rationale with the team.
+- Use the team communication command noted in `AGENTS.md` when announcing instruction updates.
+- Keep a changelog of significant documentation revisions within `.codex/instructions/` or linked planning files.
+- Encourage contributors to review updated guidance and confirm receipt, especially after major process shifts.

--- a/.codex/notes/manager-mode-cheat-sheet.md
+++ b/.codex/notes/manager-mode-cheat-sheet.md
@@ -1,0 +1,29 @@
+# Manager Mode Cheat Sheet
+
+Quick reference for contributors maintaining repository instructions and coordination.
+
+## Daily Flow
+
+- Check `.feedback/`, planning docs, and recent commits for new process requests.
+- Review repository and service `AGENTS.md` files for stale or conflicting guidance.
+- Coordinate with the Lead Developer on outstanding instruction changes and document decisions.
+- Sync with the Task Master so any doc updates that require follow-up work become tasks.
+- Post updates or clarifications using the team communication command outlined in `AGENTS.md`.
+
+## Weekly / As Needed
+
+- Audit mode guides and cheat sheets to confirm they match current expectations.
+- Capture rationale for major instruction changes in `.codex/instructions/` notes.
+- Track unresolved documentation gaps and ensure they are logged as tasks or planning items.
+- Maintain a running list of contributor pain points to discuss with the Lead Developer.
+
+## Escalation Checklist
+
+- Reject or revise requests that break security, quality, or compliance policies—document the reasoning.
+- Loop in Auditors or Reviewers when repeated issues suggest documentation weaknesses.
+- Confirm with the Lead Developer or Task Master before accepting instruction changes proposed by other contributors.
+
+## Useful Links
+
+- Full mode guidance: [`MANAGER.md`](../modes/MANAGER.md)
+- Task coordination: [`TASKMASTER.md`](../modes/TASKMASTER.md)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ The repository supports several contributor modes to clarify expectations and be
 Refer to your mode's cheat sheet for quick reminders and update it as needed.
 
 - **Task Master Mode** (`.codex/modes/TASKMASTER.md`)
+- **Manager Mode** (`.codex/modes/MANAGER.md`)
 - **Coder Mode** (`.codex/modes/CODER.md`)
 - **Reviewer Mode** (`.codex/modes/REVIEWER.md`)
 - **Auditor Mode** (`.codex/modes/AUDITOR.md`)


### PR DESCRIPTION
## Summary
- add a Manager Mode guide describing responsibilities for stewarding AGENTS instructions and coordination
- provide a Manager Mode cheat sheet for day-to-day actions and escalation steps
- list the new mode in the repository contributor mode overview

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68efba88d0f0832ca02232316c11fd7f