### PR TITLE
Add reward staging persistence to run state

### DIFF
--- a/.codex/implementation/post-fight-loot-screen.md
+++ b/.codex/implementation/post-fight-loot-screen.md
@@ -2,6 +2,11 @@
 
 After a battle concludes the frontend polls `roomAction(runId, 'battle', 'snapshot')` until the snapshot includes a `loot` object summarizing gold earned and any reward choices. `OverlayHost.svelte` keeps `BattleView.svelte` mounted during this polling and only opens `RewardOverlay.svelte` once the `loot` data arrives and combat is flagged complete. Players must resolve any card or relic picks and then press the **Next Room** button, which calls `/run/<id>/next` to advance the run.
 
+## Reward staging persistence
+- The run map JSON stored in the `runs.map` column now includes a `reward_staging` object with `cards`, `relics`, and `items` arrays. These buckets capture unconfirmed selections so reconnecting clients can resume the overlay without mutating the live party loadout.
+- `runs.lifecycle.load_map` backfills this structure for older saves and mirrors the data into any in-memory battle snapshot (`battle_snapshots[run_id]`) so `/ui` and `/map/<id>` consumers receive the same staged entries.
+- `runs.lifecycle.save_map` always normalizes the `reward_staging` payload before writing so downstream services can append staged rewards without defensive guards. Future confirmation flows will clear the buckets once rewards are committed.
+
 ## Testing
 - `uv run pytest tests/test_loot_summary.py`
 - `bun test`

--- a/.codex/implementation/save-system.md
+++ b/.codex/implementation/save-system.md
@@ -7,7 +7,7 @@
 - Install dependencies with `uv add sqlcipher3-binary`.
 
 ## Schema
-- `runs(id TEXT PRIMARY KEY, party TEXT, map TEXT)` stores the current run state.
+- `runs(id TEXT PRIMARY KEY, party TEXT, map TEXT)` stores the current run state. The `map` JSON now always contains a `reward_staging` object with `cards`, `relics`, and `items` arrays so staged rewards persist across reconnects without mutating the `party` payload.
 - `options(key TEXT PRIMARY KEY, value TEXT)` stores player customization and settings.
 - Additional tables for players and settings will be added as features return.
 

--- a/.codex/tasks/431efb19-reward-staging-schema.md
+++ b/.codex/tasks/431efb19-reward-staging-schema.md
@@ -11,3 +11,5 @@ Design and persist a dedicated reward staging structure alongside the run map so
 
 ## Out of scope
 Do not change service APIs, confirmation flows, or UI payloads yet—those are covered by follow-up tasks.
+
+ready for review

--- a/backend/runs/__init__.py
+++ b/backend/runs/__init__.py
@@ -2,10 +2,13 @@
 
 from .encryption import get_fernet
 from .encryption import get_save_manager
+from .lifecycle import REWARD_STAGING_KEYS
 from .lifecycle import battle_locks
 from .lifecycle import battle_snapshots
 from .lifecycle import battle_tasks
 from .lifecycle import cleanup_battle_state
+from .lifecycle import empty_reward_staging
+from .lifecycle import ensure_reward_staging
 from .lifecycle import get_battle_state_sizes
 from .lifecycle import load_map
 from .lifecycle import save_map
@@ -19,6 +22,9 @@ __all__ = [
     "battle_snapshots",
     "battle_tasks",
     "cleanup_battle_state",
+    "empty_reward_staging",
+    "ensure_reward_staging",
+    "REWARD_STAGING_KEYS",
     "get_battle_state_sizes",
     "load_map",
     "save_map",

--- a/backend/services/run_service.py
+++ b/backend/services/run_service.py
@@ -14,6 +14,7 @@ from battle_logging.writers import start_run_logging
 from runs.encryption import get_fernet
 from runs.encryption import get_save_manager
 from runs.lifecycle import battle_snapshots
+from runs.lifecycle import empty_reward_staging
 from runs.lifecycle import emit_battle_end_for_runs
 from runs.lifecycle import load_map
 from runs.lifecycle import purge_all_run_state
@@ -243,6 +244,7 @@ async def start_run(
         "awaiting_relic": False,
         "awaiting_loot": False,
         "awaiting_next": False,
+        "reward_staging": empty_reward_staging(),
         "total_rooms_cleared": 0,
         "floors_cleared": 0,
         "current_pressure": int(pressure_value or 0),

--- a/backend/tests/test_reward_staging_schema.py
+++ b/backend/tests/test_reward_staging_schema.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+EXPECTED_EMPTY = {"cards": [], "relics": [], "items": []}
+
+enc: ModuleType | None = None
+lifecycle: ModuleType | None = None
+
+
+def _import_runs_modules() -> tuple[ModuleType, ModuleType]:
+    """Load real ``runs`` modules instead of the test stubs."""
+
+    for name in list(sys.modules):
+        if name == "runs" or name.startswith("runs."):
+            sys.modules.pop(name)
+    real_enc = importlib.import_module("runs.encryption")
+    real_lifecycle = importlib.import_module("runs.lifecycle")
+    return real_enc, real_lifecycle
+
+
+@pytest.fixture(autouse=True)
+def reset_save_manager(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Isolate each test with a dedicated encrypted database and real modules."""
+
+    global enc
+    global lifecycle
+
+    enc, lifecycle = _import_runs_modules()
+
+    db_path = tmp_path / "reward-staging.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+
+    original_manager = getattr(enc, "SAVE_MANAGER", None)
+    original_fernet = getattr(enc, "FERNET", None)
+    setattr(enc, "SAVE_MANAGER", None)
+    setattr(enc, "FERNET", None)
+
+    lifecycle.battle_snapshots.clear()
+
+    try:
+        yield
+    finally:
+        lifecycle.battle_snapshots.clear()
+        setattr(enc, "SAVE_MANAGER", original_manager)
+        setattr(enc, "FERNET", original_fernet)
+        monkeypatch.delenv("AF_DB_PATH", raising=False)
+
+
+def _insert_run(run_id: str, map_payload: dict[str, object]) -> None:
+    assert enc is not None
+    manager = enc.get_save_manager()
+    with manager.connection() as conn:
+        conn.execute(
+            "INSERT INTO runs (id, party, map) VALUES (?, ?, ?)",
+            (run_id, json.dumps({}), json.dumps(map_payload)),
+        )
+
+
+def test_load_map_backfills_reward_staging() -> None:
+    assert lifecycle is not None
+    run_id = "staging-run"
+    initial_map = {"rooms": [], "current": 0, "battle": False}
+    _insert_run(run_id, initial_map)
+    lifecycle.battle_snapshots[run_id] = {"result": "victory"}
+
+    state, rooms = lifecycle.load_map(run_id)
+    assert rooms == []
+
+    staging = state.get("reward_staging")
+    assert isinstance(staging, dict)
+    for bucket in ("cards", "relics", "items"):
+        assert staging[bucket] == []
+
+    snapshot = lifecycle.battle_snapshots[run_id]
+    assert "reward_staging" in snapshot
+    for bucket in ("cards", "relics", "items"):
+        assert snapshot["reward_staging"][bucket] == []
+
+    manager = enc.get_save_manager()
+    with manager.connection() as conn:
+        stored_map = json.loads(
+            conn.execute("SELECT map FROM runs WHERE id = ?", (run_id,)).fetchone()[0]
+        )
+    assert stored_map["reward_staging"] == staging
+
+
+def test_save_map_initialises_missing_reward_staging() -> None:
+    assert lifecycle is not None
+    run_id = "staging-save"
+    _insert_run(run_id, {"rooms": [], "current": 0, "battle": False})
+
+    state = {"rooms": [], "current": 0, "battle": False}
+    lifecycle.save_map(run_id, state)
+
+    assert state["reward_staging"] == EXPECTED_EMPTY
+
+    manager = enc.get_save_manager()
+    with manager.connection() as conn:
+        stored = json.loads(
+            conn.execute("SELECT map FROM runs WHERE id = ?", (run_id,)).fetchone()[0]
+        )
+
+    assert stored["reward_staging"] == EXPECTED_EMPTY


### PR DESCRIPTION
## Summary
- add reward staging helpers that normalize and backfill run map state when it is loaded or saved
- seed empty reward staging buckets for new runs and export the helpers for downstream use
- document the new schema and add tests that cover map backfill and save behavior

## Testing
- ./run-tests.sh
- uv run pytest tests/test_reward_staging_schema.py

------
https://chatgpt.com/codex/tasks/task_b_68efbbfb9544832c833783f1d1064817