### PR TITLE
[DOCS] Emphasize failure hunting in audit and review modes

### DIFF
--- a/.codex/modes/AUDITOR.md
+++ b/.codex/modes/AUDITOR.md
@@ -4,7 +4,7 @@
 > **Note:** Only create a new audit report in `.codex/audit/` when you need a long-form record (e.g., multi-day investigations, historical tracking, or cross-task findings). Routine task checks should be recorded by updating the originating task file.
 
 ## Purpose
-For contributors performing rigorous, comprehensive reviews of code, documentation, environments, and processes to ensure the highest standards of quality, completeness, and compliance. Auditors are expected to catch anything others may have missed. Capture quick day-to-day findings directly in the task file you are auditing—remove the `ready to review` footer and replace it with your notes so the Task Master can see the outcome without chasing a separate artifact. Reserve `.codex/audit/` for in-depth reports that require a persistent home.
+For contributors performing rigorous, comprehensive reviews of code, documentation, environments, and processes to ensure the highest standards of quality, completeness, and compliance. Auditors are expected to catch anything others may have missed and to deliberately probe for issues, bugs, regressions, or breakages that could cause the system to stop working. Capture quick day-to-day findings directly in the task file you are auditing—remove the `ready to review` footer and replace it with your notes so the Task Master can see the outcome without chasing a separate artifact. Reserve `.codex/audit/` for in-depth reports that require a persistent home.
 
 ## Guidelines
 - Be exhaustive: review all changes, not just the latest ones. Check past commits for hidden or unresolved issues.
@@ -14,6 +14,7 @@ For contributors performing rigorous, comprehensive reviews of code, documentati
 - Verify documentation is complete, accurate, and reflects all recent changes (especially in `.codex/implementation/` in the relevant service).
 - Trace data and control flow end-to-end across services, configs, and scripts so hidden coupling or regressions are surfaced.
 - Actively look for security, performance, maintainability, and architectural issues.
+- Stress test the change: try to trigger edge cases, race conditions, and failure paths so anything that may be wrong, break, or stop working is surfaced before release.
 - Check for feedback loops, repeated mistakes, and unresolved feedback from previous reviews.
 - Cross-check dependency upgrades, environment variables, and infrastructure manifests to confirm no hidden risk was introduced.
 - Identify and report anything missed by previous contributors or reviewers.

--- a/.codex/modes/REVIEWER.md
+++ b/.codex/modes/REVIEWER.md
@@ -3,7 +3,7 @@
 > **Note:** Save all review notes in `.codex/review/` at the repository root or in the corresponding service's `.codex/review/` directory. Generate a random hash with `openssl rand -hex 4` and prefix filenames accordingly, e.g., `abcd1234-review-note.md`.
 
 ## Purpose
-For contributors who audit repository documentation to keep it accurate and current. Reviewers identify outdated or missing information, validate cross-file consistency, and create follow-up work for Task Masters and Coders.
+For contributors who audit repository documentation to keep it accurate and current. Reviewers identify outdated or missing information, validate cross-file consistency, and create follow-up work for Task Masters and Coders. Every review should actively surface issues, bugs, broken workflows, or any instruction that could cause work to fail or stop functioning if followed as written.
 
 ## Guidelines
 - **Do not edit or implement code or documentation.** Reviewers only report issues and leave all changes to Coders.
@@ -11,6 +11,7 @@ For contributors who audit repository documentation to keep it accurate and curr
 - Review `.feedback/` folders, planning documents, `notes` directories (`**/planning**` and `**/notes**`), `.codex/**` instructions, `.github/` configs, and top-level `README` files.
 - Trace documentation references end-to-end: confirm links, filenames, and referenced processes exist and still match current implementation notes or code locations.
 - Compare current instructions against recent commits, open pull requests, and linked tasks to verify nothing has drifted or been partially applied.
+- Flag any process gaps, risky directions, or missing warnings that could lead to regressions, bugs, or other breakage when contributors follow the documentation.
 - When reviewing a service, scan its `AGENTS.md`, mode docs, and `.codex/implementation/` records together so conflicting directions are surfaced in a single note.
 - For every discrepancy, generate a `TMT-<hash>-<description>.md` task file in the root `.codex/tasks/` folder using a random hash from `openssl rand -hex 4`.
 - Maintain `.codex/notes/reviewer-mode-cheat-sheet.md` with human or lead preferences gathered during audits.


### PR DESCRIPTION
## Summary
- clarify that auditors must deliberately probe for bugs, regressions, and breakages
- direct reviewers to flag documentation issues that could cause failures or broken workflows

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68efd813b684832c8d1c05bd7d6f1379