### PR TITLE
[AUDIT] Reward staging hooks require fixes

### DIFF
--- a/.codex/tasks/e69ad95e-reward-staging-service-hooks.md
+++ b/.codex/tasks/e69ad95e-reward-staging-service-hooks.md
@@ -16,4 +16,9 @@ Complete `431efb19-reward-staging-schema.md` first so the persistence layer is r
 ## Out of scope
 Confirmation/cancellation cleanup and duplicate-prevention guardrails belong to follow-up tasks.
 
-ready for review
+
+## Auditor notes (2025-10-15)
+- Ran `uv run pytest tests/test_reward_staging_service_hooks.py`; both regression tests fail because rewards are applied directly to the party instead of remaining staged.
+- `reward_service.select_card` still calls `award_card`, so the party deck gains the selected card immediately, violating the staging requirement.
+- `reward_service.select_relic` also calls `award_relic`, increasing the stack count and mutating the party, which breaks the staged-only contract.
+- Please update the reward flows so selections only populate `reward_staging`, keep the live party untouched, and adjust the tests/docs accordingly.


### PR DESCRIPTION
## Summary
- remove the `ready for review` marker on the reward staging service hooks task
- document audit findings that card and relic selection still mutate the live party deck instead of remaining staged

## Testing
- `uv run pytest tests/test_reward_staging_service_hooks.py` *(fails: card/relic staging expectations are not met)*

------
https://chatgpt.com/codex/tasks/task_b_68efdacacaf0832cb1e44f6ce14fbbc4