### PR TITLE
Update placeholder art guidance for card and relic tasks

### DIFF
--- a/.codex/tasks/cards/AGENTS.md
+++ b/.codex/tasks/cards/AGENTS.md
@@ -1,3 +1,5 @@
 # Task Priority Guidance
 
 Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.
+
+When placeholder card art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the item that should appear in the image. After saving the prompt, unblock any card tasks that were waiting on that placeholder art.

--- a/.codex/tasks/relics/AGENTS.md
+++ b/.codex/tasks/relics/AGENTS.md
@@ -1,3 +1,5 @@
 # Task Priority Guidance
 
 Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.
+
+When placeholder relic art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the relic or item that should appear in the image. After saving the prompt, unblock any relic tasks that were waiting on that placeholder art.


### PR DESCRIPTION
## Summary
- add placeholder art instructions referencing `luna_items_prompts.txt` to the card and relic task guides

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [x] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68efe3271318832c9f433ae0cd45ebd6