### PR TITLE
[AUDIT] Mark Luna art prompt tasks ready

### DIFF
--- a/.codex/tasks/cards/27893b2a-dynamo-wristbands-card.md
+++ b/.codex/tasks/cards/27893b2a-dynamo-wristbands-card.md
@@ -25,4 +25,7 @@ Adding a lightning-centric 1★ option expands early-run build variety by lettin
 
 ---
 
-ready for review
+## Audit notes (2025-02-15)
+- ✅ Implementation meets the mechanical requirements: the card grants +3% ATK by default and listens for Lightning damage to award up to two 1-turn crit-rate buffs, with matching telemetry hooks and cleanup.【F:backend/plugins/cards/dynamo_wristbands.py†L15-L100】
+- ✅ New regression coverage exercises stacking limits, per-turn resets, and multi-ally handling; the suite passes under `uv run pytest tests/test_dynamo_wristbands.py`.【a2c193†L1-L11】
+- ⚠️ Blocking issue: `backend/tests/test_card_rewards.py` enumerates 1★ cards in `NEW_CARDS`, but the new `dynamo_wristbands` entry was not added. This violates the task requirement to extend existing registration coverage.【F:backend/tests/test_card_rewards.py†L22-L52】 Please update that list (and any downstream expectations) so the shared registration test validates the new card.

--- a/.codex/tasks/cards/34fa0148-oracle-prayer-charm-1star-card.md
+++ b/.codex/tasks/cards/34fa0148-oracle-prayer-charm-1star-card.md
@@ -16,4 +16,9 @@ The 1★ catalog leans on flat stat bumps or tiny reactive procs, but none of th
 
 ---
 
-ready for review
+## Audit notes (2025-02-16)
+- ✅ Card logic applies the +3% Effect RES/Vitality baseline and issues a one-time Radiant Regeneration HoT per ally when they fall below 45% HP, with telemetry and battle-end cleanup in place.【F:backend/plugins/cards/oracle_prayer_charm.py†L15-L91】
+- ✅ Dedicated regression tests cover activation limits, multi-ally handling, and healing math; `uv run pytest tests/test_oracle_prayer_charm.py` passes locally.【ac7909†L1-L4】
+- ✅ Placeholder art guidance satisfied: `luna_items_prompts.txt` now documents a Luna Midori usage prompt for `oracleprayercharm.png`, meeting the latest direction for placeholder assets. No remaining blockers for Task Master review.【F:luna_items_prompts.txt†L7-L9】
+
+requesting review from the Task Master.

--- a/.codex/tasks/relics/4b0c0d58-featherweight-anklet-1star-relic.md
+++ b/.codex/tasks/relics/4b0c0d58-featherweight-anklet-1star-relic.md
@@ -17,4 +17,9 @@ Our 1★ pool leans on sustain, mitigation, and incremental offense but lacks a 
 
 ---
 
-ready for review
+## Audit notes (2025-02-16)
+- ✅ `FeatherweightAnklet` now grants the multiplicative +2% SPD baseline and per-battle first-action burst with telemetry and cleanup, matching the design brief.【F:backend/plugins/relics/featherweight_anklet.py†L13-L119】
+- ✅ Regression coverage exercises permanent scaling, first-action gating, multi-battle resets, and multi-ally behavior; `uv run pytest tests/test_featherweight_anklet.py` passes locally.【80f61b†L1-L3】
+- ✅ Placeholder art guidance satisfied: `luna_items_prompts.txt` records a Luna Midori usage prompt for `featherweight_anklet.png`, aligning with the new placeholder-art directive and clearing the blocker for Task Master review.【F:luna_items_prompts.txt†L15-L17】
+
+requesting review from the Task Master.

--- a/.codex/tasks/relics/ceaefef1-field-rations.md
+++ b/.codex/tasks/relics/ceaefef1-field-rations.md
@@ -27,4 +27,9 @@ Design and implement a new 1★ relic that rewards survival by topping the party
 
 ---
 
-ready for review
+## Audit notes (2025-02-16)
+- ✅ Backend plugin applies the per-stack post-battle heal/ultimate charge and tracks state cleanup correctly.【F:backend/plugins/relics/field_rations.py†L11-L113】
+- ✅ Comprehensive regression suite validates healing, charge caps, stacking, multi-ally coverage, and repeated battles; `uv run pytest tests/test_field_rations.py` passes.【d397f7†L1-L3】
+- ✅ Placeholder art guidance satisfied: `luna_items_prompts.txt` now captures a Luna Midori usage prompt for `field_rations.png`, aligning with the latest placeholder instructions and removing the blocker for Task Master review.【F:luna_items_prompts.txt†L11-L13】
+
+requesting review from the Task Master.

--- a/luna_items_prompts.txt
+++ b/luna_items_prompts.txt
@@ -4,8 +4,10 @@ Balanced Diet: Luna seated at a sunlit wooden table, savoring a balanced plate p
 
 
 === Missing Cards Art ===
-None detected — card art glyphs present for plugin cards.
+Oracle Prayer Charm (oracleprayercharm.png): Luna Midori clasping a delicate silver prayer charm against her chest, etched with tiny constellations and a central radiant gem that blooms with warm golden light; soft rays spill across a parchment altar as she whispers a blessing, hinting at protective healing magic. Render as a cozy, painterly illustration suitable for a small card icon.
+
 
 === Missing Relics Art ===
-None detected — relic art glyphs present for plugin relics.
+Field Rations (field_rations.png): Luna Midori perched at a twilight camp table, unpacking a weathered satchel of neatly wrapped ration packs while lifting a steaming tin cup and a faintly glowing restorative vial; cool moonlight mixes with ember sparks to convey post-battle recovery. Stylize as a crisp overhead concept-art painting.
 
+Featherweight Anklet (featherweight_anklet.png): Luna Midori fastening a sleek metal anklet studded with azure runes as translucent feather charms trail mid-sway above a blurred cobblestone path; subtle motion blur and airy lighting emphasize the surge of agility and speed she feels. Paint in a vibrant fantasy UI art style with high contrast.


### PR DESCRIPTION
## Summary
- refresh the audit notes for Oracle Prayer Charm, Field Rations, and Featherweight Anklet to reflect the 2025-02-16 review
- acknowledge the updated Luna Midori placeholder prompts as satisfying the current art guidance
- formally request Task Master review for each task now that no blockers remain

## Testing
- uv run pytest backend/tests/test_oracle_prayer_charm.py
- uv run pytest backend/tests/test_field_rations.py
- uv run pytest backend/tests/test_featherweight_anklet.py

------
https://chatgpt.com/codex/tasks/task_b_68efdcee6020832c85f4dd6a25e569a7