### PR TITLE
Add tasks for glitched, boss, and prime passive implementations

### DIFF
--- a/.codex/tasks/passives/1eade916-prime-passives-implementation.md
+++ b/.codex/tasks/passives/1eade916-prime-passives-implementation.md
@@ -1,0 +1,24 @@
+# Task: Flesh Out Prime Passive Variants
+
+## Background
+Prime-tier characters are supposed to represent the pinnacle builds, yet their passives are missing. Every module in
+`backend/plugins/passives/prime/` is just a two-line stub with `pass` (e.g., `backend/plugins/passives/prime/kboshi_flux_cycle.py`
+lines 1-3). The passive registry therefore has no prime entries, and any reference to a prime passive ID will fail.
+
+## Problem
+Without functional prime passives we cannot deliver the power spike or mechanical twists expected at that tier. The empty modules
+also make it ambiguous whether prime passives should exist at all, which blocks design discussions and implementation planning.
+
+## Requested Changes
+- Define concrete prime passive classes in each module under `backend/plugins/passives/prime/`. Start from the normal versions but
+  document and implement the upgrades that justify the prime tier (stronger effects, additional triggers, etc.).
+- Ensure the new classes expose meaningful `describe()`/`get_description()` output so the UI can explain the enhancements.
+- Add automated coverage (unit tests or snapshot checks) verifying that prime passives load through `PassiveRegistry` and apply their
+  special rules without raising.
+- Update the passive documentation in `.codex/docs/character-passives.md` to outline how prime passives differ from the base kits.
+
+## Acceptance Criteria
+- The prime passive directory no longer contains raw placeholders; each file provides a usable passive class.
+- Loading the passive registry includes prime IDs, and tests confirm they can be instantiated and invoked.
+- Prime passives demonstrate tier-appropriate enhancements compared to their normal counterparts.
+- Documentation clearly describes the intent and behaviour of the prime-tier passives.

--- a/.codex/tasks/passives/30b7c731-boss-passives-implementation.md
+++ b/.codex/tasks/passives/30b7c731-boss-passives-implementation.md
@@ -1,0 +1,25 @@
+# Task: Restore Boss-Tier Passive Coverage
+
+## Background
+The boss passive directory mirrors the normal roster names but every module is a stub. For instance,
+`backend/plugins/passives/boss/kboshi_flux_cycle.py` contains only a comment and `pass` (lines 1-3), so the loader cannot
+produce boss-specific passives even though the naming scheme implies they should exist.
+
+## Problem
+Boss encounters currently fall back to normal passives or fail to load because there is no boss-tier implementation. This prevents
+us from giving bosses the enhanced behaviours their data files expect and risks runtime errors if we ever reference a boss passive ID.
+
+## Requested Changes
+- Audit `backend/plugins/passives/boss/` and replace each placeholder with an actual passive implementation. Reuse the normal logic
+  when appropriate but adjust stats, triggers, and stack caps to match boss balance goals.
+- Add defensive logic so that bosses gracefully clean up event subscriptions on defeat/battle end (mirroring the patterns used in the
+  normal passives).
+- Extend the passive registry tests to assert that every boss file registers a class and that instantiation works without raising.
+- Update `.codex/docs/character-passives.md` (or add a boss-specific appendix) to describe how the boss passives differ from the
+  baseline versions.
+
+## Acceptance Criteria
+- Every module in `backend/plugins/passives/boss/` defines at least one concrete passive class with `plugin_type = "passive"`.
+- Passive discovery reports boss IDs, and smoke tests confirm they can be instantiated and triggered.
+- Battle simulations (unit or integration tests) verify representative boss passives execute their intended effects.
+- Documentation captures the presence and purpose of the boss-specific passives.

--- a/.codex/tasks/passives/b15b27b9-glitched-passives-implementation.md
+++ b/.codex/tasks/passives/b15b27b9-glitched-passives-implementation.md
@@ -1,0 +1,27 @@
+# Task: Implement Glitched-Tier Passive Plugins
+
+## Background
+Glitched characters are supposed to lean on distorted versions of our normal passives, but the modules under
+`backend/plugins/passives/glitched/` are just empty stubs. Each file only contains a comment and `pass`, so the plugin loader
+registers nothing for glitched variants (see `backend/plugins/passives/glitched/kboshi_flux_cycle.py` lines 1-3 for a typical
+example). Without concrete classes, any character that tries to load a `glitched` passive will receive a missing plug-in error.
+
+## Problem
+We cannot assign glitched-tier passives because there are no classes to instantiate. The placeholders also make it unclear
+whether we should fall back to the normal versions or implement bespoke behaviour. This leaves the glitched roster unusable
+and blocks future balance work.
+
+## Requested Changes
+- Decide on an approach for glitched passives: either subclass/wrap the normal implementations with glitched-specific tweaks or
+  provide distinct behaviour that fits the glitch theme. Document the decision inside the module docstrings.
+- Replace every `pass` file in `backend/plugins/passives/glitched/` with a concrete plug-in class that sets `plugin_type = "passive"`,
+  exposes the expected metadata (`id`, `name`, `trigger`, `max_stacks`, etc.), and implements the appropriate async hooks.
+- Ensure each plug-in registers cleanly with the `PluginLoader` (import side effects are enough, but include a simple unit test or
+  loader smoke test in `backend/tests/` to prevent regressions).
+- Update `.codex/docs/character-passives.md` with a short description of the new glitched behaviour so the roster reference stays in sync.
+
+## Acceptance Criteria
+- All files in `backend/plugins/passives/glitched/` define real plug-in classes (no raw `pass` placeholders remain).
+- Loading the passive registry (e.g., via `PassiveRegistry()._registry`) exposes the glitched IDs without errors.
+- Automated coverage confirms at least one glitched passive executes its custom logic.
+- Documentation reflects the availability and intent of the glitched-tier passives.


### PR DESCRIPTION
## Summary
- record a task for implementing the glitched-tier passive plugins that are currently empty stubs
- add a task for filling in the boss passive modules so the loader can register boss behaviours
- create a task covering the missing prime passive implementations and documentation updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68efe72d44b0832c924be5b78d95c4a4