### PR TITLE
Update task guidance for placeholder art completion

### DIFF
--- a/.codex/tasks/cards/AGENTS.md
+++ b/.codex/tasks/cards/AGENTS.md
@@ -2,4 +2,4 @@
 
 Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.
 
-When placeholder card art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the item that should appear in the image. After saving the prompt, unblock any card tasks that were waiting on that placeholder art.
+When placeholder card art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the item that should appear in the image. After saving the prompt, unblock any card tasks that were waiting on that placeholder art. Once the prompt is recorded, placeholder art is fully complete even if a `.png` asset is not yet present—Luna Midori (Lead Developer) will hand-create the final files from the prompt list.

--- a/.codex/tasks/relics/AGENTS.md
+++ b/.codex/tasks/relics/AGENTS.md
@@ -2,4 +2,4 @@
 
 Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.
 
-When placeholder relic art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the relic or item that should appear in the image. After saving the prompt, unblock any relic tasks that were waiting on that placeholder art.
+When placeholder relic art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the relic or item that should appear in the image. After saving the prompt, unblock any relic tasks that were waiting on that placeholder art. Once the prompt is recorded, placeholder art is fully complete even if a `.png` asset is not yet present—Luna Midori (Lead Developer) will hand-create the final files from the prompt list.


### PR DESCRIPTION
## Summary
- clarify that saving prompts to luna_items_prompts.txt fully satisfies placeholder art tasks in card and relic folders
- note that Luna Midori will hand-create the corresponding image files even if a png is not yet present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68efea8f2b14832c8f267eddc0613b62