### PR TITLE
Update multi-hit pacing documentation

### DIFF
--- a/.codex/tasks/eebb38d2-multi-hit-pacing.md
+++ b/.codex/tasks/eebb38d2-multi-hit-pacing.md
@@ -18,4 +18,7 @@ Coder, fix the battle pacing so multi-hit sequences (e.g., wind spreads and ulti
 - Battle pacing helpers (`pace_per_target`, `compute_multi_hit_timing`) behave as expected and regression tests pass, but the documentation requirement was missed.
 - `.codex/implementation/damage-healing.md` still lacks any explanation of the new multi-hit timing model—please document how per-target animation pacing is calculated.
 
-more work needed
+## Coder notes (2025-02-16)
+- Expanded `.codex/implementation/damage-healing.md` with timeline breakdown, implementation guidance, and testing tips covering the multi-hit pacing helpers.
+
+ready for review


### PR DESCRIPTION
## Summary
- expand the damage/healing implementation notes with a timeline breakdown, implementation playbook, and testing guidance for the multi-hit pacing helpers
- update the multi-hit pacing task with coder notes and mark it ready for review now that documentation is in place

## Testing
- `uv run pytest tests/test_damage_type_pacing.py`


------
https://chatgpt.com/codex/tasks/task_b_68f11cf45394832c8d1c18ec15a4ef35