### PR TITLE
[backend] Finalize staged reward confirmation

### DIFF
--- a/.codex/tasks/bfb6d0b4-reward-staging-confirmation.md
+++ b/.codex/tasks/bfb6d0b4-reward-staging-confirmation.md
@@ -14,3 +14,5 @@ Complete `431efb19-reward-staging-schema.md` and `e69ad95e-reward-staging-servic
 
 ## Out of scope
 Duplicate-prevention guardrails and regression tests live in the guardrail tasks.
+
+ready for review

--- a/backend/.codex/implementation/battle-endpoint-payload.md
+++ b/backend/.codex/implementation/battle-endpoint-payload.md
@@ -1,0 +1,77 @@
+# Reward confirmation payloads
+
+This reference outlines the payloads returned by the reward confirmation and
+rollback endpoints introduced with the staging flow. The endpoints live under
+`/rewards/<type>/<run_id>/*` and return a consistent shape so clients can update
+their local state without re-fetching the full map.
+
+## Confirmation response
+
+`POST /rewards/{card|relic}/<run_id>/confirm`
+
+```json
+{
+  "reward_staging": {
+    "cards": [],
+    "relics": [],
+    "items": []
+  },
+  "awaiting_card": false,
+  "awaiting_relic": true,
+  "awaiting_loot": false,
+  "awaiting_next": false,
+  "reward_progression": {
+    "available": ["card", "relic"],
+    "completed": ["card"],
+    "current_step": "relic"
+  },
+  "cards": ["arc_lightning"],
+  "next_room": "shop"
+}
+```
+
+Key fields:
+
+- `reward_staging`: always returned so UIs can clear local staging state.
+- `awaiting_*`: reflect the refreshed gating flags. When all are false the
+  backend flips `awaiting_next` to `true` to signal room advancement is allowed.
+- `reward_progression`: present when additional reward steps remain. The field is
+  omitted entirely once the sequence completes.
+- `cards` / `relics`: included only for the confirmed reward type so overlays can
+  show the updated deck or relic stacks without another `/ui` poll.
+- `next_room`: populated when `awaiting_next` becomes `true`.
+
+## Cancellation response
+
+`POST /rewards/{card|relic}/<run_id>/cancel`
+
+```json
+{
+  "reward_staging": {
+    "cards": [],
+    "relics": [],
+    "items": []
+  },
+  "awaiting_card": true,
+  "awaiting_relic": false,
+  "awaiting_loot": false,
+  "awaiting_next": false,
+  "reward_progression": {
+    "available": ["card"],
+    "completed": [],
+    "current_step": "card"
+  }
+}
+```
+
+- Cancellation never returns the party roster because nothing changed on disk.
+- `awaiting_next` is always `false` so the UI keeps the loot overlay open.
+- The progression block is reset to the cancelled step so the front-end can
+  redisplay the appropriate selection UI.
+
+## Cleanup behaviour
+
+Once a run leaves the reward state (advancing to the next room or ending the
+run) `cleanup_battle_state` empties any remaining staging buckets in both the
+stored map and the in-memory snapshot. This guarantees confirmation responses
+never surface stale staged data on reconnects.

--- a/backend/routes/rewards.py
+++ b/backend/routes/rewards.py
@@ -6,6 +6,8 @@ from quart import request
 from services.login_reward_service import claim_login_reward
 from services.login_reward_service import get_login_reward_status
 from services.reward_service import acknowledge_loot as acknowledge_loot_service
+from services.reward_service import cancel_reward as cancel_reward_service
+from services.reward_service import confirm_reward as confirm_reward_service
 from services.reward_service import select_card as select_card_service
 from services.reward_service import select_relic as select_relic_service
 
@@ -29,6 +31,24 @@ async def select_relic(run_id: str):
     relic_id = data.get("relic")
     try:
         result = await select_relic_service(run_id, relic_id)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    return jsonify(result)
+
+
+@bp.post("/rewards/<reward_type>/<run_id>/confirm")
+async def confirm_reward(run_id: str, reward_type: str):
+    try:
+        result = await confirm_reward_service(run_id, reward_type)
+    except ValueError as exc:
+        return jsonify({"error": str(exc)}), 400
+    return jsonify(result)
+
+
+@bp.post("/rewards/<reward_type>/<run_id>/cancel")
+async def cancel_reward(run_id: str, reward_type: str):
+    try:
+        result = await cancel_reward_service(run_id, reward_type)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
     return jsonify(result)

--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -17,6 +17,8 @@ from runs.lifecycle import load_map
 from runs.lifecycle import save_map
 from runs.party_manager import load_party
 from services.asset_service import get_asset_manifest
+from services.reward_service import cancel_reward
+from services.reward_service import confirm_reward
 from services.reward_service import select_card
 from services.reward_service import select_relic
 from services.room_service import BATTLE_ROOM_TYPES
@@ -571,6 +573,46 @@ async def handle_ui_action() -> tuple[str, int, dict[str, Any]]:
 
             try:
                 result = await select_relic(run_id, relic_id)
+                return jsonify(result)
+            except ValueError as exc:
+                return create_error_response(str(exc), 400)
+
+        elif action == "confirm_card":
+            if not run_id:
+                return create_error_response("No active run", 400)
+
+            try:
+                result = await confirm_reward(run_id, "card")
+                return jsonify(result)
+            except ValueError as exc:
+                return create_error_response(str(exc), 400)
+
+        elif action == "confirm_relic":
+            if not run_id:
+                return create_error_response("No active run", 400)
+
+            try:
+                result = await confirm_reward(run_id, "relic")
+                return jsonify(result)
+            except ValueError as exc:
+                return create_error_response(str(exc), 400)
+
+        elif action == "cancel_card":
+            if not run_id:
+                return create_error_response("No active run", 400)
+
+            try:
+                result = await cancel_reward(run_id, "card")
+                return jsonify(result)
+            except ValueError as exc:
+                return create_error_response(str(exc), 400)
+
+        elif action == "cancel_relic":
+            if not run_id:
+                return create_error_response("No active run", 400)
+
+            try:
+                result = await cancel_reward(run_id, "relic")
                 return jsonify(result)
             except ValueError as exc:
                 return create_error_response(str(exc), 400)

--- a/backend/tests/test_reward_staging_confirmation.py
+++ b/backend/tests/test_reward_staging_confirmation.py
@@ -1,0 +1,306 @@
+import asyncio
+import importlib
+import json
+from pathlib import Path
+import sys
+from types import ModuleType
+
+import pytest
+
+enc: ModuleType | None = None
+lifecycle: ModuleType | None = None
+party_manager: ModuleType | None = None
+reward_service: ModuleType | None = None
+
+
+def _import_real_modules() -> None:
+    """Reload the concrete implementations instead of test doubles."""
+
+    global enc
+    global lifecycle
+    global party_manager
+    global reward_service
+
+    for name in list(sys.modules):
+        if name == "runs" or name.startswith("runs."):
+            sys.modules.pop(name)
+        if name == "services" or name.startswith("services."):
+            sys.modules.pop(name)
+
+    enc = importlib.import_module("runs.encryption")
+    lifecycle = importlib.import_module("runs.lifecycle")
+    party_manager = importlib.import_module("runs.party_manager")
+    reward_service = importlib.import_module("services.reward_service")
+
+
+@pytest.fixture(autouse=True)
+def isolated_database(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Provide a fresh encrypted database per test."""
+
+    _import_real_modules()
+
+    assert enc is not None
+    assert lifecycle is not None
+    assert party_manager is not None
+    assert reward_service is not None
+
+    db_path = tmp_path / "reward-confirmation.db"
+    monkeypatch.setenv("AF_DB_PATH", str(db_path))
+
+    original_manager = enc.SAVE_MANAGER
+    original_fernet = enc.FERNET
+    enc.SAVE_MANAGER = None
+    enc.FERNET = None
+    lifecycle.battle_snapshots.clear()
+
+    try:
+        yield
+    finally:
+        lifecycle.battle_snapshots.clear()
+        enc.SAVE_MANAGER = original_manager
+        enc.FERNET = original_fernet
+        monkeypatch.delenv("AF_DB_PATH", raising=False)
+
+
+def _insert_run(run_id: str, party_payload: dict[str, object], map_payload: dict[str, object]) -> None:
+    assert enc is not None
+    manager = enc.get_save_manager()
+    with manager.connection() as conn:
+        conn.execute(
+            "INSERT INTO runs (id, party, map) VALUES (?, ?, ?)",
+            (run_id, json.dumps(party_payload), json.dumps(map_payload)),
+        )
+
+
+@pytest.mark.asyncio()
+async def test_confirm_card_commits_and_unlocks_next_step() -> None:
+    assert lifecycle is not None
+    assert party_manager is not None
+    assert reward_service is not None
+
+    run_id = "confirm-card"
+    party_payload = {
+        "members": ["player"],
+        "gold": 0,
+        "relics": [],
+        "cards": [],
+        "exp": {"player": 0},
+        "level": {"player": 1},
+        "player": {"pronouns": "", "damage_type": "Light", "stats": {}},
+    }
+    map_payload = {
+        "rooms": [
+            {"room_id": 0, "room_type": "battle-normal"},
+            {"room_id": 1, "room_type": "shop"},
+        ],
+        "current": 0,
+        "battle": False,
+        "awaiting_card": True,
+        "awaiting_relic": False,
+        "awaiting_loot": False,
+        "awaiting_next": False,
+        "reward_progression": {
+            "available": ["card"],
+            "completed": [],
+            "current_step": "card",
+        },
+        "reward_staging": {"cards": [], "relics": [], "items": []},
+    }
+    _insert_run(run_id, party_payload, map_payload)
+
+    lifecycle.battle_snapshots[run_id] = {
+        "result": "battle",
+        "ended": True,
+        "card_choices": [
+            {
+                "id": "arc_lightning",
+                "name": "Arc Lightning",
+                "stars": 3,
+                "about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
+            }
+        ],
+        "relic_choices": [],
+        "reward_staging": {"cards": [], "relics": [], "items": []},
+    }
+
+    await reward_service.select_card(run_id, "arc_lightning")
+
+    confirm_payload = await reward_service.confirm_reward(run_id, "card")
+
+    assert confirm_payload["awaiting_card"] is False
+    assert confirm_payload["awaiting_next"] is True
+    assert confirm_payload["reward_staging"]["cards"] == []
+    assert "cards" in confirm_payload and "arc_lightning" in confirm_payload["cards"]
+
+    party = await asyncio.to_thread(party_manager.load_party, run_id)
+    assert party.cards == ["arc_lightning"]
+
+    state, _ = lifecycle.load_map(run_id)
+    assert state.get("awaiting_card") is False
+    assert state.get("awaiting_next") is True
+    assert state.get("reward_staging", {}).get("cards") == []
+    assert "reward_progression" not in state
+
+    snapshot = lifecycle.battle_snapshots[run_id]
+    assert snapshot["reward_staging"]["cards"] == []
+    assert snapshot["awaiting_card"] is False
+    assert snapshot["awaiting_next"] is True
+
+
+@pytest.mark.asyncio()
+async def test_cancel_card_reopens_progression_step() -> None:
+    assert lifecycle is not None
+    assert reward_service is not None
+
+    run_id = "cancel-card"
+    party_payload = {
+        "members": ["player"],
+        "gold": 0,
+        "relics": [],
+        "cards": [],
+        "exp": {"player": 0},
+        "level": {"player": 1},
+        "player": {"pronouns": "", "damage_type": "Light", "stats": {}},
+    }
+    map_payload = {
+        "rooms": [
+            {"room_id": 0, "room_type": "battle-normal"},
+            {"room_id": 1, "room_type": "shop"},
+        ],
+        "current": 0,
+        "battle": False,
+        "awaiting_card": True,
+        "awaiting_relic": False,
+        "awaiting_loot": False,
+        "awaiting_next": False,
+        "reward_progression": {
+            "available": ["card"],
+            "completed": [],
+            "current_step": "card",
+        },
+        "reward_staging": {"cards": [], "relics": [], "items": []},
+    }
+    _insert_run(run_id, party_payload, map_payload)
+
+    lifecycle.battle_snapshots[run_id] = {
+        "result": "battle",
+        "ended": True,
+        "card_choices": [
+            {
+                "id": "arc_lightning",
+                "name": "Arc Lightning",
+                "stars": 3,
+                "about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
+            }
+        ],
+        "relic_choices": [],
+        "reward_staging": {"cards": [], "relics": [], "items": []},
+    }
+
+    await reward_service.select_card(run_id, "arc_lightning")
+
+    cancel_payload = await reward_service.cancel_reward(run_id, "card")
+
+    assert cancel_payload["awaiting_card"] is True
+    assert cancel_payload["awaiting_next"] is False
+    assert cancel_payload["reward_staging"]["cards"] == []
+
+    state, _ = lifecycle.load_map(run_id)
+    assert state.get("awaiting_card") is True
+    assert state.get("awaiting_next") is False
+    progression = state.get("reward_progression")
+    assert isinstance(progression, dict)
+    assert progression.get("current_step") == "card"
+
+    snapshot = lifecycle.battle_snapshots[run_id]
+    assert snapshot["reward_staging"]["cards"] == []
+    assert snapshot["awaiting_card"] is True
+    assert snapshot.get("reward_progression", {}).get("current_step") == "card"
+
+
+@pytest.mark.asyncio()
+async def test_confirm_multiple_steps_advances_sequence() -> None:
+    assert lifecycle is not None
+    assert party_manager is not None
+    assert reward_service is not None
+
+    run_id = "confirm-sequence"
+    party_payload = {
+        "members": ["player"],
+        "gold": 0,
+        "relics": ["old_coin"],
+        "cards": [],
+        "exp": {"player": 0},
+        "level": {"player": 1},
+        "player": {"pronouns": "", "damage_type": "Light", "stats": {}},
+    }
+    map_payload = {
+        "rooms": [
+            {"room_id": 0, "room_type": "battle-normal"},
+            {"room_id": 1, "room_type": "battle-normal"},
+        ],
+        "current": 0,
+        "battle": False,
+        "awaiting_card": True,
+        "awaiting_relic": True,
+        "awaiting_loot": False,
+        "awaiting_next": False,
+        "reward_progression": {
+            "available": ["card", "relic"],
+            "completed": [],
+            "current_step": "card",
+        },
+        "reward_staging": {"cards": [], "relics": [], "items": []},
+    }
+    _insert_run(run_id, party_payload, map_payload)
+
+    lifecycle.battle_snapshots[run_id] = {
+        "result": "battle",
+        "ended": True,
+        "card_choices": [
+            {
+                "id": "arc_lightning",
+                "name": "Arc Lightning",
+                "stars": 3,
+            }
+        ],
+        "relic_choices": [
+            {
+                "id": "old_coin",
+                "name": "Old Coin",
+                "stars": 2,
+                "about": "Gain 20% more gold from all sources.",
+                "stacks": 1,
+            }
+        ],
+        "reward_staging": {"cards": [], "relics": [], "items": []},
+    }
+
+    await reward_service.select_card(run_id, "arc_lightning")
+    card_payload = await reward_service.confirm_reward(run_id, "card")
+    assert card_payload["awaiting_card"] is False
+    assert card_payload["awaiting_relic"] is True
+    assert card_payload["awaiting_next"] is False
+    progression = card_payload.get("reward_progression")
+    assert isinstance(progression, dict)
+    assert progression.get("current_step") == "relic"
+
+    await reward_service.select_relic(run_id, "old_coin")
+    relic_payload = await reward_service.confirm_reward(run_id, "relic")
+
+    assert relic_payload["awaiting_relic"] is False
+    assert relic_payload["awaiting_next"] is True
+    assert relic_payload["reward_staging"]["relics"] == []
+    assert "relics" in relic_payload and relic_payload["relics"].count("old_coin") == 2
+
+    party = await asyncio.to_thread(party_manager.load_party, run_id)
+    assert party.cards == ["arc_lightning"]
+    assert party.relics.count("old_coin") == 2
+
+    state, _ = lifecycle.load_map(run_id)
+    assert state.get("awaiting_card") is False
+    assert state.get("awaiting_relic") is False
+    assert state.get("awaiting_next") is True
+    assert state.get("reward_staging", {}).get("relics") == []
+    assert "reward_progression" not in state
+


### PR DESCRIPTION
## Summary
- add confirmation and cancellation services for staged card and relic rewards, plus REST/UI wiring
- clear stale reward staging entries during cleanup and document the confirmation workflow payloads
- add targeted regression tests covering confirmation, cancellation, and multi-step reward sequences

## Testing
- uv run pytest tests/test_reward_staging_service_hooks.py tests/test_reward_staging_confirmation.py

------
https://chatgpt.com/codex/tasks/task_b_68f12bd9118c832cafe2963aeaca0f48