### PR TITLE
[DOCS] Clarify task status markers

### DIFF
--- a/.codex/modes/TASKMASTER.md
+++ b/.codex/modes/TASKMASTER.md
@@ -10,6 +10,7 @@ The Task Master is responsible for creating, organizing, and maintaining actiona
 ## Guidelines
 - Write clear, concise, and actionable tasks that can be easily understood and executed by Coders.
 - Place all new tasks in the root `.codex/tasks/` folder using a random hash prefix, for example `1234abcd-task-title.md`. Generate the hash with `openssl rand -hex 4`.
+- Leave the status marker off when drafting a new task; the first contributor to pick it up adds `more work needed` or another appropriate marker.
 - Regularly review, update, and close out completed or obsolete tasks.
 - Coordinate with contributors to clarify requirements and priorities as needed.
 - Ensure that tasks are linked to relevant documentation, issues, or discussions for context.

--- a/.codex/tasks/AGENTS.md
+++ b/.codex/tasks/AGENTS.md
@@ -5,7 +5,18 @@ thread, or pull request description must end with a clear status indicator.
 Coders, reviewers, and managers should verify these markers whenever a task is
 touched.
 
-## Allowed Status Markers
+## Task Creation vs. In-Progress Updates
+
+- **Task Master drafts:** Leave the status marker off entirely when creating a
+  new task file. This signals to contributors that the work has not yet been
+  started. The first coder or reviewer to touch the task should add the
+  appropriate marker once they begin work.
+- **Active or reviewed tasks:** After someone begins implementing, reviewing,
+  or handing back a task, add exactly one marker from the list below on its own
+  line at the bottom of the document. Do not append additional commentary after
+  the marker.
+
+### Allowed Status Markers
 - `ready for review` — the implementation is complete and waiting for
   feedback.
 - `requesting review from the Task Master` — reviewers append this when
@@ -15,15 +26,15 @@ touched.
   with a short summary (and optionally a percentage complete) so the next
   person understands what remains.
 
-Place one of the above phrases on its own line at the bottom of the document.
-Do not add additional commentary after the marker.
-
 ## Review Checklist
 Managers and reviewers should confirm that:
-1. A status marker is present at the bottom of every active task file.
-2. The marker reflects the current state of the work before leaving feedback or
+1. Newly authored Task Master files intentionally omit a status marker until a
+   contributor starts work.
+2. A marker is present at the bottom of every active task file after work
+   begins.
+3. The marker reflects the current state of the work before leaving feedback or
    handing the task off.
-3. Any time the status changes, the contributor updates the marker
+4. Any time the status changes, the contributor updates the marker
    immediately.
 
 If a marker is missing, request an update before proceeding so downstream


### PR DESCRIPTION
## Summary
- clarify that new Task Master task drafts are created without a status marker and document when markers should be added
- update Task Master mode guidance so authors leave the status marker for the first contributor who picks up the task

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

------
https://chatgpt.com/codex/tasks/task_b_68f13ecb02f4832ca2f6266d8bf2f200