### PR TITLE
Fix reward overlay state syncing and pending selection handling

### DIFF
--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -315,6 +315,8 @@
 
   $: awaitingConfirmation =
     pendingConfirmationCount > 0 ||
+    pendingCardSelection !== null ||
+    pendingRelicSelection !== null ||
     pendingCardConfirm !== null ||
     pendingCardCancel !== null ||
     pendingRelicConfirm !== null ||

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1008,11 +1008,17 @@
       base.next_room = result.next_room;
     }
 
-    if (Array.isArray(base.card_choices)) {
+    if (Object.prototype.hasOwnProperty.call(result ?? {}, 'card_choices')) {
+      const nextCardChoices = Array.isArray(result?.card_choices) ? result.card_choices : [];
+      base.card_choices = cloneRewardEntries(nextCardChoices);
+    } else if (Array.isArray(base.card_choices)) {
       base.card_choices = cloneRewardEntries(base.card_choices);
     }
 
-    if (Array.isArray(base.relic_choices)) {
+    if (Object.prototype.hasOwnProperty.call(result ?? {}, 'relic_choices')) {
+      const nextRelicChoices = Array.isArray(result?.relic_choices) ? result.relic_choices : [];
+      base.relic_choices = cloneRewardEntries(nextRelicChoices);
+    } else if (Array.isArray(base.relic_choices)) {
       base.relic_choices = cloneRewardEntries(base.relic_choices);
     }
 


### PR DESCRIPTION
## Summary
- replace cached reward card and relic choices with the payload returned from reward actions
- treat pending selection requests as confirmations-in-flight to prevent premature auto-advance

## Testing
- `bun x vitest run tests/reward-overlay-selection-regression.vitest.js` *(fails: no test files matched pattern in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f14c6be354832cb097477845a11289