### PR TITLE
[AUDIT] Verify reward confirmation tasks

### DIFF
--- a/.codex/tasks/6ebaed1b-reward-activation-atomicity.md
+++ b/.codex/tasks/6ebaed1b-reward-activation-atomicity.md
@@ -14,4 +14,10 @@ Complete staging schema/service/confirmation tasks (`431efb19`, `e69ad95e`, `bfb
 
 ## Out of scope
 Extended test coverage and metrics instrumentation live in the companion task `tests/dc47b2ce-reward-activation-tests-metrics.md`.
-ready for review
+
+### Audit notes (2025-10-16)
+- Confirmed `backend/services/reward_service.py` now serialises confirmations under `reward_locks`, clears staging buckets, and appends activation records with bounded history.
+- Verified both `backend/routes/ui.py` and `backend/services/run_service.py` gate `advance_room` on empty staging via `has_pending_rewards` and refreshed docs in `.codex/implementation` describe the guardrails.
+- Exercised the new pytest coverage: `tests/test_reward_staging_confirmation.py` and `tests/test_reward_gate.py`.
+
+requesting review from the Task Master

--- a/.codex/tasks/9dfda476-reward-confirmation-flow.md
+++ b/.codex/tasks/9dfda476-reward-confirmation-flow.md
@@ -41,5 +41,10 @@ The overlay never renders staged rewards from `reward_staging`, so the player ca
 - Manual: clear a battle, stage a card, confirm it, and verify `advance_room` succeeds and the deck updates.
 - Automated: add frontend integration/unit tests for the confirm handlers if feasible; backend pytest coverage for staged confirmation sequences.
 
-ready for review
+### Audit notes (2025-10-16)
+- Frontend: Confirmed `OverlayHost.svelte`, `RewardOverlay.svelte`, and `src/routes/+page.svelte` flow staged rewards with confirm/cancel plumbing; `uiApi.js` exposes the new helpers and idle automation now confirms via API. `.codex/implementation/reward-overlay.md` documents the behaviour.
+- Backend: Verified `/ui` confirm/cancel responses now return staging, progression, activation metadata, and `advance_room` enforces empty staging. Docs in `backend/.codex/implementation` refreshed accordingly.
+- Tests: Ran `uv run pytest tests/test_reward_staging_confirmation.py tests/test_reward_gate.py`; attempted `bun test ./tests/reward-overlay-selection-regression.vitest.js` but Bun + Svelte runes currently throw `rune_outside_svelte` when mounting the component (needs follow-up from implementer).
+
+requesting review from the Task Master
 

--- a/.codex/tasks/bfb6d0b4-reward-staging-confirmation.md
+++ b/.codex/tasks/bfb6d0b4-reward-staging-confirmation.md
@@ -15,4 +15,9 @@ Complete `431efb19-reward-staging-schema.md` and `e69ad95e-reward-staging-servic
 ## Out of scope
 Duplicate-prevention guardrails and regression tests live in the guardrail tasks.
 
-ready for review
+### Audit notes (2025-10-16)
+- Verified `backend/routes/rewards.py` exposes confirm/cancel endpoints backed by `services.reward_service`, which now mutates parties, clears staging, and refreshes snapshots.
+- Confirmed `cancel_reward` reopens progression steps and `cleanup_battle_state` purges lingering staging buckets when runs exit the reward flow.
+- Documentation in `backend/.codex/implementation/post-fight-loot-screen.md` and `battle-endpoint-payload.md` reflects the lifecycle updates.
+
+requesting review from the Task Master


### PR DESCRIPTION
## Summary
- recorded audit notes for reward activation atomicity, staging confirmation, and confirmation flow tasks to reflect backend guardrails and docs
- confirmed frontend overlay wiring and backend endpoints through review notes for Task Master handoff

## Testing
- `uv run pytest tests/test_reward_staging_confirmation.py tests/test_reward_gate.py`
- `bun test ./tests/reward-overlay-selection-regression.vitest.js` *(fails: Svelte `$state` rune unsupported outside .svelte during test runner)*

------
https://chatgpt.com/codex/tasks/task_b_68f177a17150832c99fad73ad3161c0a