### PR TITLE
Clarify audit instructions for placeholder art tasks

### DIFF
--- a/.codex/modes/AUDITOR.md
+++ b/.codex/modes/AUDITOR.md
@@ -22,6 +22,9 @@ For contributors performing rigorous, comprehensive reviews of code, documentati
 - Ignore time limits—finish the task even if it takes a long time.
 - After reviewing a task file that contains `ready for review`, remove that footer and append `requesting review from the Task Master` at the bottom only if the task is fully done and all acceptance criteria are met. Leave a short summary of what you checked so future auditors do not need to open a separate file.
 - When blocking work, cite the precise line numbers, commit hashes, and reproduction steps so the assignee can validate the issue immediately.
+- Review the applicable `AGENTS.md` or task instructions before auditing so you do not flag work that intentionally relies on a documented exception.
+- Respect the placeholder art workflow: if a task records the prompt in `luna_items_prompts.txt`, treat the asset requirement as satisfied even when the `.png` file has not been delivered yet. Do not block tasks or raise findings for missing art that Lead Developer will generate later.
+- Focus audits on tasks that are actively in review—only pick up items marked `ready for review` or `requesting review from the Task Master`. Leave tasks without recent work or tagged `more work needed` for the assignee to continue before you return.
 
 ## Typical Actions
 - Review pull requests and all related commits, not just the latest diff

--- a/.codex/tasks/AGENTS.md
+++ b/.codex/tasks/AGENTS.md
@@ -36,6 +36,9 @@ Managers and reviewers should confirm that:
    handing the task off.
 4. Any time the status changes, the contributor updates the marker
    immediately.
+5. Auditors only engage once a task is marked `ready for review` or
+   `requesting review from the Task Master`; tasks without those markers should
+   continue to incubate with the assignee.
 
 If a marker is missing, request an update before proceeding so downstream
 contributors have accurate visibility into task readiness.

--- a/.codex/tasks/cards/AGENTS.md
+++ b/.codex/tasks/cards/AGENTS.md
@@ -2,4 +2,4 @@
 
 Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.
 
-When placeholder card art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the item that should appear in the image. After saving the prompt, unblock any card tasks that were waiting on that placeholder art. Once the prompt is recorded, placeholder art is fully complete even if a `.png` asset is not yet present—Luna Midori (Lead Developer) will hand-create the final files from the prompt list.
+When placeholder card art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the item that should appear in the image. After saving the prompt, unblock any card tasks that were waiting on that placeholder art. Once the prompt is recorded, placeholder art is fully complete even if a `.png` asset is not yet present—Luna Midori (Lead Developer) will hand-create the final files from the prompt list. Auditors should treat these tasks as satisfied and must not raise findings for the missing `.png` while it is in the Lead Developer queue.

--- a/.codex/tasks/relics/AGENTS.md
+++ b/.codex/tasks/relics/AGENTS.md
@@ -2,4 +2,4 @@
 
 Tasks in this folder are lower priority than tasks in the parent `.codex/tasks` directory.
 
-When placeholder relic art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the relic or item that should appear in the image. After saving the prompt, unblock any relic tasks that were waiting on that placeholder art. Once the prompt is recorded, placeholder art is fully complete even if a `.png` asset is not yet present—Luna Midori (Lead Developer) will hand-create the final files from the prompt list.
+When placeholder relic art is required, update `luna_items_prompts.txt` with a text-to-photo prompt of Luna using the relic or item that should appear in the image. After saving the prompt, unblock any relic tasks that were waiting on that placeholder art. Once the prompt is recorded, placeholder art is fully complete even if a `.png` asset is not yet present—Luna Midori (Lead Developer) will hand-create the final files from the prompt list. Auditors should treat these tasks as satisfied and must not raise findings for the missing `.png` while it is in the Lead Developer queue.


### PR DESCRIPTION
## Summary
- remind auditors to review scoped instructions before flagging findings
- document that placeholder art tasks are complete once prompts are recorded
- limit audit pickups to tasks that are explicitly marked ready for review

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [x] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68f24ea2a424832c822af7f3b7bb4a8f