### PR TITLE
[AUDIT] Reward progression consistency review

### DIFF
--- a/.codex/tasks/a28b5711-reward-progression-consistency.md
+++ b/.codex/tasks/a28b5711-reward-progression-consistency.md
@@ -22,5 +22,9 @@ Guarantee `reward_progression` accompanies every staged reward payload so the fr
 - Include migration/repair logic for existing runs in progress (consider applying the backfill the next time their map state loads).
 - Make sure any async locks (`reward_locks`) keep the progression state in sync with staging updates.
 
-ready for review
+## Audit (2025-02-15)
+- Verified `runs.lifecycle.ensure_reward_progression` rebuilds and normalises the canonical progression structure based on staging buckets, awaiting flags, and battle review, and that map loads/saves now guarantee the field.
+- Confirmed reward selection/confirmation flows mirror `reward_progression` into payloads and snapshots until steps finish, and documentation in backend/.codex/implementation now promises the contract.
+- Setup backend env with `uv sync` and ran `uv run pytest tests/test_reward_staging_service_hooks.py tests/test_reward_staging_confirmation.py tests/test_reward_gate.py` (all passed).
 
+requesting review from the Task Master


### PR DESCRIPTION
## Summary
- document the auditor review for the reward progression consistency task
- record the validation commands executed while auditing backend reward flows

## Testing
- uv run pytest tests/test_reward_staging_service_hooks.py tests/test_reward_staging_confirmation.py tests/test_reward_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68f4eb5b94c8832cb1abab37a19905f1