### PR TITLE
[TASKMASTER] Send reward flow tasks back for fixes

### DIFF
--- a/.codex/tasks/6ebaed1b-reward-activation-atomicity.md
+++ b/.codex/tasks/6ebaed1b-reward-activation-atomicity.md
@@ -20,4 +20,7 @@ Extended test coverage and metrics instrumentation live in the companion task `t
 - Verified both `backend/routes/ui.py` and `backend/services/run_service.py` gate `advance_room` on empty staging via `has_pending_rewards` and refreshed docs in `.codex/implementation` describe the guardrails.
 - Exercised the new pytest coverage: `tests/test_reward_staging_confirmation.py` and `tests/test_reward_gate.py`.
 
-requesting review from the Task Master
+### Task Master review (2025-02-16)
+- The `.codex/implementation` docs referenced in the requirements were not updated to document the activation guardrails, so knowledge about the new single-confirm rules remains implicit.
+
+more work needed — add the guardrail details to the relevant `.codex/implementation` docs before closing this task.

--- a/.codex/tasks/9dfda476-reward-confirmation-flow.md
+++ b/.codex/tasks/9dfda476-reward-confirmation-flow.md
@@ -46,5 +46,9 @@ The overlay never renders staged rewards from `reward_staging`, so the player ca
 - Backend: Verified `/ui` confirm/cancel responses now return staging, progression, activation metadata, and `advance_room` enforces empty staging. Docs in `backend/.codex/implementation` refreshed accordingly.
 - Tests: Ran `uv run pytest tests/test_reward_staging_confirmation.py tests/test_reward_gate.py`; attempted `bun test ./tests/reward-overlay-selection-regression.vitest.js` but Bun + Svelte runes currently throw `rune_outside_svelte` when mounting the component (needs follow-up from implementer).
 
-requesting review from the Task Master
+### Task Master review (2025-02-16)
+- `.codex/implementation/reward-overlay.md` still explains the pre-staging UI flow and never mentions the new confirm/cancel controls, so the documentation piece of the task is incomplete.
+- The reported Bun rune issue remains unresolved; the suite still errors with `rune_outside_svelte`, so automated coverage for the regression is missing.
+
+more work needed — refresh the reward overlay doc for the confirm/cancel UX and fix or replace the failing Bun test before handing this back.
 

--- a/.codex/tasks/a28b5711-reward-progression-consistency.md
+++ b/.codex/tasks/a28b5711-reward-progression-consistency.md
@@ -27,4 +27,8 @@ Guarantee `reward_progression` accompanies every staged reward payload so the fr
 - Confirmed reward selection/confirmation flows mirror `reward_progression` into payloads and snapshots until steps finish, and documentation in backend/.codex/implementation now promises the contract.
 - Setup backend env with `uv sync` and ran `uv run pytest tests/test_reward_staging_service_hooks.py tests/test_reward_staging_confirmation.py tests/test_reward_gate.py` (all passed).
 
-requesting review from the Task Master
+### Task Master review (2025-02-16)
+- `/ui?action=advance_room` short-circuits with a payload that lacks the refreshed `reward_progression`, so the frontend still cannot rely on the contract when another step remains.
+- The requested documentation refresh for `post-fight-loot-screen.md` and `battle-endpoint-payload.md` never landed, leaving the guarantee undocumented.
+
+more work needed — `/ui?action=advance_room` should return the updated `reward_progression`, and the backend docs still need the promised contract update.

--- a/.codex/tasks/bfb6d0b4-reward-staging-confirmation.md
+++ b/.codex/tasks/bfb6d0b4-reward-staging-confirmation.md
@@ -20,4 +20,7 @@ Duplicate-prevention guardrails and regression tests live in the guardrail tasks
 - Confirmed `cancel_reward` reopens progression steps and `cleanup_battle_state` purges lingering staging buckets when runs exit the reward flow.
 - Documentation in `backend/.codex/implementation/post-fight-loot-screen.md` and `battle-endpoint-payload.md` reflects the lifecycle updates.
 
-requesting review from the Task Master
+### Task Master review (2025-02-16)
+- The backend docs called out in the task (`post-fight-loot-screen.md`, `battle-endpoint-payload.md`) still describe the pre-confirmation flow, so contributors have no reference for the new lifecycle.
+
+more work needed — backend confirmation docs are still stale; update `.codex/implementation/post-fight-loot-screen.md` and `battle-endpoint-payload.md` to cover the confirm/cancel pipeline.


### PR DESCRIPTION
## Summary
- record Task Master review notes for the three backend reward tasks and the frontend regression task
- highlight missing `reward_progression` field in `/ui?action=advance_room` responses and the absent documentation updates in `.codex/implementation`
- flag the failing Bun regression suite so it stays on the implementer's radar

## Testing
- `uv run pytest tests/test_reward_staging_service_hooks.py tests/test_reward_staging_confirmation.py tests/test_reward_gate.py`
- `bun test ./tests/reward-overlay-selection-regression.vitest.js` *(fails with `rune_outside_svelte`)*

------
https://chatgpt.com/codex/tasks/task_b_68f4eddef688832ca6f0296b448570a9