### PR TITLE
Audit: update reward and relic task statuses

### DIFF
--- a/.codex/tasks/a28b5711-reward-progression-consistency.md
+++ b/.codex/tasks/a28b5711-reward-progression-consistency.md
@@ -32,4 +32,9 @@ Guarantee `reward_progression` accompanies every staged reward payload so the fr
 - Updated `.codex/implementation/post-fight-loot-screen.md` and `.codex/implementation/battle-endpoint-payload.md` to document the guarantee.
 - Backend env synced with `uv sync`; ran `uv run pytest tests/test_reward_staging_service_hooks.py tests/test_reward_staging_confirmation.py tests/test_reward_gate.py` (pass).
 
-ready for review
+## Auditor summary (2025-02-19)
+- Confirmed `runs.lifecycle.ensure_reward_progression` backfills and persists canonical sequencing across map loads/saves, `_refresh_snapshot` mirrors the field into `battle_snapshots`, and `/ui` responses expose the structure until all steps resolve.【F:backend/runs/lifecycle.py†L58-L198】【F:backend/services/reward_service.py†L71-L118】【F:backend/routes/ui.py†L200-L332】
+- Verified `reward_service` selection handlers always include `reward_progression` in their payloads and `reward_activation_log` snapshots, ensuring reconnects retain state.【F:backend/services/reward_service.py†L52-L190】
+- Re-ran targeted pytest suite covering reward progression to confirm behavior (see task f2622706 audit for shared test command output).【1dcee1†L1-L12】
+
+requesting review from the Task Master

--- a/.codex/tasks/bfb6d0b4-reward-staging-confirmation.md
+++ b/.codex/tasks/bfb6d0b4-reward-staging-confirmation.md
@@ -24,4 +24,10 @@ Duplicate-prevention guardrails and regression tests live in the guardrail tasks
 - The backend docs called out in the task (`post-fight-loot-screen.md`, `battle-endpoint-payload.md`) still describe the pre-confirmation flow, so contributors have no reference for the new lifecycle.
 
 Updated docs to document the confirmation/cancellation pipeline and staging cleanup.
-ready for review
+
+## Auditor summary (2025-02-19)
+- Confirmed `backend/services/reward_service.py` now serialises activation logs, clears staging buckets, and flips the awaiting flags consistently when confirming or cancelling rewards, including reopening progression steps on cancellation.【F:backend/services/reward_service.py†L118-L266】
+- Verified `/ui` action handler short-circuits to emit refreshed progression payloads before advancing rooms, and documentation in `.codex/implementation/post-fight-loot-screen.md` and `battle-endpoint-payload.md` reflects the lifecycle contract.【F:backend/routes/ui.py†L520-L565】【F:backend/.codex/implementation/post-fight-loot-screen.md†L1-L87】【F:backend/.codex/implementation/battle-endpoint-payload.md†L1-L115】
+- Ran `uv run pytest tests/test_reward_staging_service_hooks.py tests/test_reward_staging_confirmation.py tests/test_reward_gate.py` to cover the new flows (all passed).【1dcee1†L1-L12】
+
+requesting review from the Task Master

--- a/.codex/tasks/cards/c1a05833-tempest-pathfinder-2star-card.md
+++ b/.codex/tasks/cards/c1a05833-tempest-pathfinder-2star-card.md
@@ -38,4 +38,9 @@ Our 2★ line-up focuses on Critical Boost loops, global DEF pulses, or extra ac
 - ✅ Added Tempest Pathfinder to `.codex/planning/archive/726d03ae-card-plan.md`
 - ✅ Added placeholder art prompt to `luna_items_prompts.txt` for tempestpathfinder.png
 
-ready for review
+## Auditor summary (2025-02-19)
+- Confirmed `TempestPathfinder` listens for party crits, applies the party-wide dodge buff with a per-turn lockout, emits telemetry, and resets state correctly, with coverage from `tests/test_tempest_pathfinder.py`.【F:backend/plugins/cards/tempest_pathfinder.py†L1-L74】【F:backend/tests/test_tempest_pathfinder.py†L1-L109】
+- Documentation updates and card plan entries reference the new dodge rally, and `tempestpathfinder.png` is present under `frontend/src/lib/assets/cards/Art/` so the UI can render the card art.【F:.codex/implementation/card-inventory.md†L49-L66】【F:.codex/planning/archive/726d03ae-card-plan.md†L47-L64】【db3fc1†L1-L10】
+- Ran `uv run pytest tests/test_tempest_pathfinder.py` to verify the new card behaviour (passes).【c1f548†L1-L10】
+
+requesting review from the Task Master

--- a/.codex/tasks/f2622706-reward-preview-frontend.md
+++ b/.codex/tasks/f2622706-reward-preview-frontend.md
@@ -16,4 +16,9 @@ Complete the backend preview schema task (`b30ad6a1-reward-preview-schema.md`) f
 ## Out of scope
 Guardrails, staging confirmation logic, and backend tests belong to other tasks.
 
-ready for review
+## Auditor summary (2025-02-19)
+- Frontend normalises staged reward previews and renders stat/trigger panels for cards and relics, and the UI API integrates the `reward_staging.preview` payloads.【F:frontend/src/routes/+page.svelte†L972-L1056】【F:frontend/src/lib/components/RewardOverlay.svelte†L1-L340】
+- `RewardPreviewFormatter` covers summary/stat formatting and has Vitest coverage, but the documentation references screenshot files (`reward-overlay-card-preview.png`, `reward-overlay-relic-preview.png`) that are not present under `.codex/screenshots/`, so designers cannot review the new layout assets.【F:.codex/implementation/reward-overlay.md†L12-L25】【bccb0e†L1-L1】
+- `tests/battlepolling.test.js` still expects `if (snap?.error)` inside `+page.svelte`, and the string is absent, causing `bun test tests/battlepolling.test.js` to fail (the test inspects the file contents).【F:frontend/tests/battlepolling.test.js†L8-L33】【F:frontend/src/routes/+page.svelte†L1-L120】【4f5838†L1-L1】
+
+more work needed

--- a/.codex/tasks/relics/72b2f866-copper-siphon-relic.md
+++ b/.codex/tasks/relics/72b2f866-copper-siphon-relic.md
@@ -32,4 +32,8 @@ more work needed
 - ✅ Relic-system.md already documents the lifesteal-to-shield behavior in general terms
 - ℹ️ Note: Actual `.png` asset will be created by Lead Developer from the prompt
 
-ready for review
+## Auditor summary (2025-02-19)
+- Backend plugin and tests behave as expected, but there is still no `coppersiphon.png` asset under `frontend/src/lib/assets/relics/Art/`, so the UI cannot show the relic art.【58f131†L1-L6】
+- `.codex/implementation/relic-system.md` has not been updated to cover Copper Siphon’s lifesteal-to-shield interaction, despite the requirement to document it for contributors.【F:.codex/implementation/relic-system.md†L1-L16】
+
+more work needed

--- a/.codex/tasks/relics/72c67e47-siege-banner-3star-relic.md
+++ b/.codex/tasks/relics/72c67e47-siege-banner-3star-relic.md
@@ -40,4 +40,8 @@ Our 3★ relics reward economy (Greed Engine), crit scaling (Stellar Compass), o
 - ✅ Added placeholder art prompt to `luna_items_prompts.txt` for siegebanner.png
 - ✅ All Siege Banner tests pass (5/5 passing)
 
-ready for review
+## Auditor summary (2025-02-19)
+- Backend plugin, tests, and documentation updates look solid, but there is still no `siegebanner.png` asset under `frontend/src/lib/assets/relics/Art/`, so the reward overlay will fall back to the generic relic icon.【58f131†L1-L6】
+- `luna_items_prompts.txt` still has an empty entry for “Siege Banner (siegebanner)”, so the placeholder art prompt the coder noted has not been recorded.【F:luna_items_prompts.txt†L11-L12】
+
+more work needed

--- a/.codex/tasks/relics/f08bf67f-catalyst-vials.md
+++ b/.codex/tasks/relics/f08bf67f-catalyst-vials.md
@@ -38,4 +38,9 @@ Create a mid-tier relic that turns existing damage-over-time builds into self-su
 - ✅ All Catalyst Vials tests pass (6/6 passing)
 - ✅ Documentation already exists in both `.codex/implementation/relic-inventory.md` and the relic plan
 
-ready for review
+## Auditor summary (2025-02-19)
+- Verified `CatalystVials` listens to `dot_tick`, enables overheal, applies the Effect Hit Rate buff, and emits telemetry per tick, with state cleanup on `battle_end`.【F:backend/plugins/relics/catalyst_vials.py†L1-L78】
+- Confirmed documentation updates and asset coverage (`catalystvials.png`) exist, and the relic appears in both inventory and plan references.【F:.codex/implementation/relic-inventory.md†L31-L37】【F:.codex/planning/archive/bd48a561-relic-plan.md†L31-L38】【58f131†L1-L6】
+- Ran `uv run pytest tests/test_relic_effects.py -k "catalyst_vials"` to exercise the new logic (passes as part of the combined relic subset run).【0e75c9†L1-L3】
+
+requesting review from the Task Master

--- a/.codex/tasks/relics/f433e580-momentum-gyro-relic.md
+++ b/.codex/tasks/relics/f433e580-momentum-gyro-relic.md
@@ -38,4 +38,8 @@ Introduce **Momentum Gyro**, a 2★ relic that rewards repeatedly striking the s
 - ✅ Added Momentum Gyro to `.codex/implementation/relic-inventory.md`
 - ✅ Added placeholder art prompt to `luna_items_prompts.txt` for momentumgyro.png
 
-ready for review
+## Auditor summary (2025-02-19)
+- MomentumGyro’s combat logic, telemetry, and tests are in place, but the required `frontend/src/lib/assets/relics/Art/momentumgyro.png` asset is still missing so the UI cannot display the relic art.【58f131†L1-L6】
+- `.codex/implementation/relic-system.md` has not been updated to mention the focused-assault mechanic, so contributor references still lack Momentum Gyro’s behaviour details.【F:.codex/implementation/relic-system.md†L1-L16】
+
+more work needed

--- a/.codex/tasks/relics/fffbf71c-entropy-mirror.md
+++ b/.codex/tasks/relics/fffbf71c-entropy-mirror.md
@@ -46,4 +46,8 @@ Deliver a high-risk relic that accelerates battles by juicing enemy damage while
 - ✅ Added placeholder art prompt to `luna_items_prompts.txt`
 - ✅ Proper stacking behavior for multiple relic copies
 
-ready for review
+## Auditor summary (2025-02-19)
+- EntropyMirror’s implementation and tests look correct, but there is no `entropymirror.png` asset under `frontend/src/lib/assets/relics/Art/`, so the relic still renders with the fallback icon.【58f131†L1-L6】
+- `.codex/planning/archive/bd48a561-relic-plan.md` has not been updated to include Entropy Mirror in the 4★ list, leaving the planning doc inconsistent with the new relic.【F:.codex/planning/archive/bd48a561-relic-plan.md†L38-L49】
+
+more work needed


### PR DESCRIPTION
## Summary
- record auditor confirmations for the reward progression and staging confirmation tasks, including targeted pytest coverage
- flag missing assets or documentation for Siege Banner, Copper Siphon, Momentum Gyro, Entropy Mirror, and the frontend reward preview work, adding detailed auditor notes
- mark Tempest Pathfinder and Catalyst Vials tasks as ready for Task Master review with references to their tests, docs, and assets

## Testing
- uv run pytest tests/test_reward_staging_service_hooks.py tests/test_reward_staging_confirmation.py tests/test_reward_gate.py
- uv run pytest tests/test_tempest_pathfinder.py
- uv run pytest tests/test_siege_banner.py tests/test_momentum_gyro.py tests/test_entropy_mirror.py
- uv run pytest tests/test_relic_effects.py -k "catalyst_vials or copper_siphon"

------
https://chatgpt.com/codex/tasks/task_b_68f514deeac8832c9aa7046cb0bd55a0