### PR TITLE
Document reward confirmation guardrails

### DIFF
--- a/.codex/implementation/post-fight-loot-screen.md
+++ b/.codex/implementation/post-fight-loot-screen.md
@@ -7,6 +7,12 @@ After a battle concludes the frontend polls `roomAction(runId, 'battle', 'snapsh
 - `runs.lifecycle.load_map` backfills this structure for older saves and mirrors the data into any in-memory battle snapshot (`battle_snapshots[run_id]`) so `/ui` and `/map/<id>` consumers receive the same staged entries.
 - `runs.lifecycle.save_map` always normalizes the `reward_staging` payload before writing so downstream services can append staged rewards without defensive guards. Future confirmation flows will clear the buckets once rewards are committed.
 
+## Single-confirm guardrails
+- `services.reward_service.confirm_reward` acquires a per-run `reward_locks[run_id]` mutex before mutating staging data, ensuring duplicate HTTP calls or reconnects cannot race each other while a confirmation is in flight.
+- On success the targeted staging bucket is cleared, the appropriate `awaiting_*` flags are flipped off, and `awaiting_next` is only raised once every bucket is empty. Failed or replayed confirmations raise an error because the staging list is empty.
+- Each activation appends a record to `state["reward_activation_log"]` with a generated `activation_id`, timestamp, bucket name, and the committed payload. Snapshots mirror this log so the frontend can surface audit breadcrumbs and the backend retains the last 20 activations for debugging.
+- `services.run_service.advance_room` now blocks when any staging bucket still contains entries via `runs.lifecycle.has_pending_rewards`, preventing map progression until the overlay has been fully resolved.
+
 ## Testing
 - `uv run pytest tests/test_loot_summary.py`
 - `bun test`

--- a/.codex/implementation/reward-overlay.md
+++ b/.codex/implementation/reward-overlay.md
@@ -9,6 +9,10 @@ Selecting a card posts to `/cards/<run_id>` via the `chooseCard` API helper once
 When a relic reward is selected, the overlay shows its `about` text so players
 see the effect with the next stack applied.
 
+## Confirmation responses
+
+Confirmed selections now return an `activation_record` with `activation_id`, `activated_at`, `bucket`, and the committed payload so reconnecting clients can surface what was just accepted. The backend also streams a bounded `reward_activation_log` array alongside the usual `awaiting_*` flags, letting the overlay highlight historical confirmations for audit trails. Because confirmations operate under a per-run mutex, retries that arrive after the staging bucket has been cleared raise an error instead of duplicating rewards.
+
 ## Preview metadata
 
 Staged cards and relics now surface preview metadata returned by the backend. `RewardOverlay` renders a preview panel beneath the Confirm/Cancel controls whenever a staged entry includes a `preview` payload (or an `about` fallback). The panel highlights:

--- a/.codex/implementation/save-system.md
+++ b/.codex/implementation/save-system.md
@@ -7,7 +7,7 @@
 - Install dependencies with `uv add sqlcipher3-binary`.
 
 ## Schema
-- `runs(id TEXT PRIMARY KEY, party TEXT, map TEXT)` stores the current run state. The `map` JSON now always contains a `reward_staging` object with `cards`, `relics`, and `items` arrays so staged rewards persist across reconnects without mutating the `party` payload. Staged entries include a `preview` block describing stat modifiers and triggers so reconnects do not lose context about pending rewards.
+- `runs(id TEXT PRIMARY KEY, party TEXT, map TEXT)` stores the current run state. The `map` JSON now always contains a `reward_staging` object with `cards`, `relics`, and `items` arrays so staged rewards persist across reconnects without mutating the `party` payload. Staged entries include a `preview` block describing stat modifiers and triggers so reconnects do not lose context about pending rewards. Confirmations append audit breadcrumbs to `reward_activation_log`, which keeps the twenty most recent activation records (id, timestamp, bucket, payload) so duplicate submits can be traced without growing the save file unboundedly.
 - `options(key TEXT PRIMARY KEY, value TEXT)` stores player customization and settings.
 - Additional tables for players and settings will be added as features return.
 

--- a/.codex/tasks/6ebaed1b-reward-activation-atomicity.md
+++ b/.codex/tasks/6ebaed1b-reward-activation-atomicity.md
@@ -20,7 +20,9 @@ Extended test coverage and metrics instrumentation live in the companion task `t
 - Verified both `backend/routes/ui.py` and `backend/services/run_service.py` gate `advance_room` on empty staging via `has_pending_rewards` and refreshed docs in `.codex/implementation` describe the guardrails.
 - Exercised the new pytest coverage: `tests/test_reward_staging_confirmation.py` and `tests/test_reward_gate.py`.
 
-### Task Master review (2025-02-16)
-- The `.codex/implementation` docs referenced in the requirements were not updated to document the activation guardrails, so knowledge about the new single-confirm rules remains implicit.
+### Documentation refresh (2025-02-20)
+- Added a "Single-confirm guardrails" section to `.codex/implementation/post-fight-loot-screen.md` describing the per-run mutex, staging cleanup, activation log, and `advance_room` gate.
+- Documented the `reward_activation_log` payload in `.codex/implementation/save-system.md` so the persistent schema notes cover the audit breadcrumbs.
+- Expanded `.codex/implementation/reward-overlay.md` with the confirmation response contract, including activation records and mutex-driven duplicate protection for reconnects.
 
-more work needed — add the guardrail details to the relevant `.codex/implementation` docs before closing this task.
+ready for review


### PR DESCRIPTION
## Summary
- document the single-confirm guardrails in the post-fight loot screen guide, including locking, staging cleanup, and advance gating
- record the reward activation log schema details in the save system documentation
- expand the reward overlay doc with the activation record payload returned on confirmations

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68f51d217dd8832ca5a364cd4b0abf3a