### PR TITLE
Adjust StatTabs footer layout when player is required

### DIFF
--- a/frontend/src/lib/components/StatTabs.svelte
+++ b/frontend/src/lib/components/StatTabs.svelte
@@ -42,6 +42,7 @@
   $: isPlayer = !!previewChar?.is_player;
   $: viewStats = previewChar?.stats || {};
   $: playerRequired = selected.includes(previewId) && isPlayer;
+  $: showConfirmButton = !playerRequired;
 
   $: upgradeTotals = upgradeData?.stat_totals || {};
   $: upgradeCounts = upgradeData?.stat_counts || {};
@@ -286,16 +287,18 @@
       {#if playerRequired}
         <span class="required-note" role="status">Player is required</span>
       {/if}
-      {#if upgradeMode}
-        <button class="secondary" on:click={() => handleUpgradeDismiss('footer')} title="Close upgrade stats">Cancel upgrade</button>
-      {:else}
-        <button class="secondary" on:click={openUpgrade} title="Upgrade stats for this character">Upgrade stats</button>
-      {/if}
-      {#if !playerRequired}
-        <button class="confirm" on:click={toggleMember}>
-          {selected.includes(previewId) ? 'Remove from party' : 'Add to party'}
-        </button>
-      {/if}
+      <div class="footer-actions" class:single-action={!showConfirmButton}>
+        {#if upgradeMode}
+          <button class="secondary" on:click={() => handleUpgradeDismiss('footer')} title="Close upgrade stats">Cancel upgrade</button>
+        {:else}
+          <button class="secondary" on:click={openUpgrade} title="Upgrade stats for this character">Upgrade stats</button>
+        {/if}
+        {#if showConfirmButton}
+          <button class="confirm" on:click={toggleMember}>
+            {selected.includes(previewId) ? 'Remove from party' : 'Add to party'}
+          </button>
+        {/if}
+      </div>
     </div>
   {/if}
 </div>
@@ -350,10 +353,26 @@
     padding: 0.15rem 0;
     margin-top: 0.25rem;
     gap: 0.5rem;
+    width: 100%;
   }
   .stats-confirm.player-required {
     justify-content: space-between;
     gap: 0.75rem;
+  }
+  .footer-actions {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
+  }
+  .stats-confirm.player-required .footer-actions {
+    flex: 1 1 auto;
+  }
+  .footer-actions.single-action {
+    flex: 1 1 auto;
+  }
+  .footer-actions.single-action button {
+    flex: 1 1 auto;
   }
   button.secondary,
   button.confirm {
@@ -368,6 +387,9 @@
     opacity: 0.9;
     box-shadow: var(--glass-shadow);
     backdrop-filter: var(--glass-filter);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
   button.secondary { font-size: 0.9rem; opacity: 0.85; }
   button.confirm { font-size: 0.95rem; }
@@ -390,6 +412,7 @@
     line-height: 1.2;
     display: inline-flex;
     align-items: center;
+    flex-shrink: 0;
   }
   .stats-tabs {
     display: flex;


### PR DESCRIPTION
## Summary
- add a computed flag so StatTabs can detect when the party confirm control is hidden
- wrap the footer buttons in a flex container and adjust styling so the remaining action fills the row when the player is required
- make secondary/confirm buttons use inline-flex alignment and keep the required note from shrinking

## Testing
- bun test tests/partypicker.test.js *(fails: expectation `'selected = oldSelected.filter((id) => roster.some((c) => c.id === id))'` not found in PartyPicker.svelte; existing test appears out of sync with source)*

------
https://chatgpt.com/codex/tasks/task_b_68f534782b30832c9f13e4b073642987