### PR TITLE
[DOC] Sync entropy mirror relic plan

### DIFF
--- a/.codex/planning/archive/bd48a561-relic-plan.md
+++ b/.codex/planning/archive/bd48a561-relic-plan.md
@@ -44,6 +44,7 @@ Parent: [Web Game Plan](8a7d9c1e-web-game-plan.md)
 
 ## 4★ Relics
   - [ ] **Null Lantern** – Shops no longer appear. All foes are buffed by 150% for each fight cleared while holding this relic. Every fight now drops 1 pull plus 1 per stack.
+  - [x] **Entropy Mirror** – At battle start, all foes gain +30% ATK per stack. When they deal damage, they suffer recoil equal to 10% of the damage dealt per stack that bypasses mitigation.
   - [x] **Traveler's Charm** – When an ally is hit, they gain +25% DEF and +10% mitigation for the next turn plus 25% DEF and +10% mitigation per stack.
   - [x] **Timekeeper's Hourglass** – At the start of each turn, there is a 10% chance plus 1% per stack for all allies to take an additional turn.
 

--- a/.codex/tasks/relics/fffbf71c-entropy-mirror.md
+++ b/.codex/tasks/relics/fffbf71c-entropy-mirror.md
@@ -45,7 +45,7 @@ Deliver a high-risk relic that accelerates battles by juicing enemy damage while
 - ✅ Updated `.codex/implementation/relic-inventory.md` with 4★ entry
 - ✅ Proper stacking behavior for multiple relic copies
 
-## Auditor summary (2025-02-19)
-- `.codex/planning/archive/bd48a561-relic-plan.md` has not been updated to include Entropy Mirror in the 4★ list, leaving the planning doc inconsistent with the new relic.【F:.codex/planning/archive/bd48a561-relic-plan.md†L38-L49】
+## Coder follow-up (2025-02-22)
+- Updated `.codex/planning/archive/bd48a561-relic-plan.md` to document Entropy Mirror in the 4★ relic list, matching the implemented behavior and inventory docs.
 
-more work needed
+ready for review


### PR DESCRIPTION
## Summary
- document the Entropy Mirror relic in the long-form relic planning guide
- update the task record to note the documentation sync and mark it ready for review

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_b_68f53d55e3c4832cb3b9d821d41f27b8