### PR TITLE
[TASKMASTER] Split reward overlay overhaul

### DIFF
--- a/.codex/tasks/1b801b74-reward-overlay-step-controller.md
+++ b/.codex/tasks/1b801b74-reward-overlay-step-controller.md
@@ -1,0 +1,16 @@
+# Implement reward overlay phase controller
+
+## Summary
+Introduce an explicit four-phase controller inside the WebUI reward overlay so Drops, Cards, Relics, and Battle Review execute sequentially without soft-locks.
+
+## Requirements
+- Drive the overlay UI from the backend-provided `reward_progression` metadata, mapping each phase (Drops → Cards → Relics → Review) to a clear internal state machine.
+- Render the Drops phase with only loot tiles visible and gate later UI elements until completion.
+- Add a stained-glass styled right-rail with an `Advance` button and a prominently displayed 10 second countdown that auto-advances when it expires but allows manual clicks.
+- Ensure early confirmation moves the controller into the next phase safely, including when the backend skips a phase.
+- Provide graceful fallback behaviour if `reward_progression` is missing or malformed: log, default to the current single-phase behaviour, and prevent freezes.
+- Verify keyboard focus flows correctly into and out of the advance button during automatic and manual transitions.
+
+## Coordination notes
+- Check `frontend/.codex/implementation/reward-overlay.md` for existing structure notes before refactoring.
+- Confirm with backend maintainers whether additional `reward_progression` hints are expected so the controller can be resilient.

--- a/.codex/tasks/1f113358-reward-automation-doc-sync.md
+++ b/.codex/tasks/1f113358-reward-automation-doc-sync.md
@@ -1,0 +1,15 @@
+# Align reward automation & docs with four-phase flow
+
+## Summary
+Update idle-mode automation, regression tests, and documentation so they follow the new four-step reward overlay sequence.
+
+## Requirements
+- Adjust idle automation scripts/services to advance through the Drops, Cards, Relics, and Battle Review phases, invoking the new confirm hooks introduced by the overlay refresh.
+- Add or update automated tests to cover the countdown auto-advance, manual advance button, and confirm flows for cards and relics.
+- Review any mocked data or fixtures to ensure they include representative `reward_progression` metadata so tests don’t regress.
+- Update `frontend/.codex/implementation/reward-overlay.md` with the four-phase sequence, wiggle interaction, countdown advance behaviour, and removal of the preview panel.
+- Coordinate with backend reviewers to confirm no API adjustments are required; document any assumptions or follow-up backend work in the task file if discovered.
+
+## Coordination notes
+- Check `.codex/review` and `.codex/planning` for related automation efforts to avoid duplicating work.
+- Work with QA to validate the automation on staging once UI changes land.

--- a/.codex/tasks/5e4992b5-reward-flow-four-step-overhaul.md
+++ b/.codex/tasks/5e4992b5-reward-flow-four-step-overhaul.md
@@ -1,26 +1,13 @@
 # Rebuild reward overlay into four-phase flow
 
 ## Summary
-Redesign the WebUI reward overlay so rewards resolve in four distinct phases—Drops → Cards → Relics → Battle Review—with clearer affordances that prevent the current soft-lock behaviour.
+Umbrella pointer for the reward overlay overhaul. The original monolithic work item has been decomposed into three focused tasks so coders can deliver the Drops → Cards → Relics → Review experience incrementally.
 
-## Requirements
-- Introduce explicit step sequencing in the reward overlay (Drops, Cards, Relics, Review) driven by the backend’s `reward_progression` metadata.
-- **Drops phase:** show only loot tiles (gold, damage-type items, pulls). Render a right-panel `Advance` button that matches the main-menu/party-menu style (`stained-glass` container + `icon-btn` aesthetics) and display a visible 10 s countdown beside the label. Auto-advance when the timer completes, but permit early clicks. Hide card/relic UI until drops are complete.
-- **Card phase:** first click highlights the card, starts a looping wiggle animation that persists until the selection is confirmed or a different card is chosen, and reveals a themed confirm button directly beneath the selected card. Keep the wiggle subtle—small rotation/scale offsets with a hint of randomised timing so the motion feels alive but not distracting. The button should reuse the right-panel styling (same glass bar + `icon-btn` treatment). Second click on the highlighted card behaves like pressing the confirm button. Remove the existing preview panel and cancel button. Keep accessibility in mind (keyboard activation should still work and focus should move to the confirm button when it appears).
-- **Relic phase:** mirror the card behaviour for relics (highlight + the same subdued, slightly randomised looping wiggle until resolved, plus on-card confirm with the same right-panel styling). Ensure cancel flows from the backend clear any local highlight state.
-- **Battle review phase:** once rewards finish, transition into the review overlay only if the user setting allows it. Otherwise advance automatically.
-- Refresh idle-mode automation so it follows the new step flow (engaging the confirm actions as needed) without regressing existing automation.
-- Update styling and layout so the controls slot into the stained-glass side rails used by the main menu / warp / inventory: reuse shared CSS tokens (`--glass-bg`, `stained-glass-row`, `icon-btn`) or extract a dedicated helper if necessary.
-- Refresh `frontend/.codex/implementation/reward-overlay.md` to document the four-step sequence, wiggle interaction, countdown advance, and removal of the preview panel.
-
-## Dependencies & coordination
-- Coordinate with the backend if additional pacing or `reward_progression` cues are needed, but avoid backend changes unless blockers arise.
-- Align with any ongoing reward preview work—removing the preview panel may require updating docs/tests from those tasks.
-
-## Out of scope
-- Backend reward confirmation guardrails (already handled separately).
-- New audio or haptics for the wiggle animation.
+## Subtasks
+- `.codex/tasks/1b801b74-reward-overlay-step-controller.md` — introduce the explicit four-phase controller, drops-only screen, and timed advance button.
+- `.codex/tasks/b500ea24-card-relic-confirmation-refresh.md` — refresh card/relic selection with wiggle animation, on-card confirms, and shared stained-glass styling.
+- `.codex/tasks/1f113358-reward-automation-doc-sync.md` — update idle automation, regression coverage, and documentation to follow the new flow.
 
 ## Notes
-- Wiggle animation does not exist yet; define new CSS keyframes/utility classes in the card/relic components.
-- Make sure keyboard users can highlight and confirm without relying on pointer hover.
+- Use this parent file to coordinate sequencing and cross-task dependencies.
+- Revisit once all subtasks close to confirm no follow-up umbrella work remains.

--- a/.codex/tasks/b500ea24-card-relic-confirmation-refresh.md
+++ b/.codex/tasks/b500ea24-card-relic-confirmation-refresh.md
@@ -1,0 +1,16 @@
+# Refresh reward card & relic confirmation UX
+
+## Summary
+Update the reward overlay's card and relic selection experience with accessible highlight, wiggle, and confirm behaviours that match the stained-glass control styling.
+
+## Requirements
+- When entering the Card phase, highlight the first selected card and apply a subtle looping wiggle animation (small rotation + scale jitter with a touch of randomness) that persists until confirmation or a different card is chosen.
+- Replace the existing preview panel with an on-card confirm button that mirrors the stained-glass right-rail styling and appears directly beneath the highlighted card; second clicks on the highlighted card should trigger the same confirm.
+- Mirror the same highlight + wiggle + confirm flow for relic selection, including clearing any highlight when backend cancel/reset events occur.
+- Preserve keyboard accessibility: focus should move to the confirm control when it appears, Enter/Space should confirm, and arrow/tab navigation should allow changing the selection.
+- Remove the old cancel button, ensuring there is a clear keyboard path to back out if the backend exposes a cancel action.
+- Ensure styling tokens (`--glass-bg`, `stained-glass-row`, `icon-btn`) are reused or centralised to keep consistency with other overlays.
+
+## Coordination notes
+- Collaborate with whoever owns idle automation to align on new confirm hooks before merging.
+- Sync with any concurrent reward preview work so documentation/tests are updated consistently.


### PR DESCRIPTION
## Summary
- convert the umbrella reward overlay overhaul ticket into a coordination pointer
- add three focused subtasks covering the phase controller, card/relic UX refresh, and automation/doc updates

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [x] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68f5d2113f64832c90638fec29a6d738