### PR TITLE
[TASKS] Split reward overlay overhaul subtasks

### DIFF
--- a/.codex/tasks/01508135-drops-phase-overlay-refactor.md
+++ b/.codex/tasks/01508135-drops-phase-overlay-refactor.md
@@ -1,0 +1,15 @@
+# Build drops-only reward phase experience
+
+## Summary
+Implement the UI pieces for the Drops phase so loot tiles render in isolation and subsequent reward controls remain hidden until the controller advances.
+
+## Requirements
+- Subscribe to the new reward overlay state machine and render the Drops grid when `currentPhase === "drops"`.
+- Gate all card, relic, and review components (including confirm buttons) behind later phases so they are not present in the DOM during Drops.
+- Ensure the right-rail shows a phase indicator/progress breadcrumbs but hides action buttons until the advance countdown task lands.
+- Provide analytics/telemetry hook (if existing system) noting when the Drops phase completes so automation can confirm the transition.
+- Validate layout responsiveness on mobile/tablet breakpoints so the isolated Drops screen still fits within the overlay constraints.
+
+## Coordination notes
+- Pair with the advance button implementer to confirm how the controller signals Drops completion.
+- Flag any styling tokens needed for shared stained-glass visuals so the follow-up task can reuse them.

--- a/.codex/tasks/1b801b74-reward-overlay-step-controller.md
+++ b/.codex/tasks/1b801b74-reward-overlay-step-controller.md
@@ -1,16 +1,14 @@
 # Implement reward overlay phase controller
 
 ## Summary
-Introduce an explicit four-phase controller inside the WebUI reward overlay so Drops, Cards, Relics, and Battle Review execute sequentially without soft-locks.
+Umbrella pointer for the frontend controller track. Work has been split so coders can land the state machine, drops-only phase, advance countdown, and resilience pieces independently.
 
-## Requirements
-- Drive the overlay UI from the backend-provided `reward_progression` metadata, mapping each phase (Drops → Cards → Relics → Review) to a clear internal state machine.
-- Render the Drops phase with only loot tiles visible and gate later UI elements until completion.
-- Add a stained-glass styled right-rail with an `Advance` button and a prominently displayed 10 second countdown that auto-advances when it expires but allows manual clicks.
-- Ensure early confirmation moves the controller into the next phase safely, including when the backend skips a phase.
-- Provide graceful fallback behaviour if `reward_progression` is missing or malformed: log, default to the current single-phase behaviour, and prevent freezes.
-- Verify keyboard focus flows correctly into and out of the advance button during automatic and manual transitions.
+## Subtasks
+- `.codex/tasks/f7ae6ddd-reward-overlay-state-machine.md` — build the state machine scaffold around `reward_progression`.
+- `.codex/tasks/01508135-drops-phase-overlay-refactor.md` — render the Drops-only experience.
+- `.codex/tasks/bcfc52bc-reward-advance-countdown.md` — add the advance button and countdown timer.
+- `.codex/tasks/6afb12ae-reward-overlay-resilience.md` — harden transitions and accessibility edge cases.
 
-## Coordination notes
-- Check `frontend/.codex/implementation/reward-overlay.md` for existing structure notes before refactoring.
-- Confirm with backend maintainers whether additional `reward_progression` hints are expected so the controller can be resilient.
+## Notes
+- Keep this parent file updated as subtasks land or new gaps appear.
+- Coordinate sequencing with the card/relic refresh umbrella to avoid merge conflicts in shared components.

--- a/.codex/tasks/1f113358-reward-automation-doc-sync.md
+++ b/.codex/tasks/1f113358-reward-automation-doc-sync.md
@@ -1,15 +1,13 @@
 # Align reward automation & docs with four-phase flow
 
 ## Summary
-Update idle-mode automation, regression tests, and documentation so they follow the new four-step reward overlay sequence.
+Umbrella pointer covering automation, regression coverage, and documentation updates for the four-phase reward overlay. Work is split across dedicated tasks to keep ownership clear.
 
-## Requirements
-- Adjust idle automation scripts/services to advance through the Drops, Cards, Relics, and Battle Review phases, invoking the new confirm hooks introduced by the overlay refresh.
-- Add or update automated tests to cover the countdown auto-advance, manual advance button, and confirm flows for cards and relics.
-- Review any mocked data or fixtures to ensure they include representative `reward_progression` metadata so tests don’t regress.
-- Update `frontend/.codex/implementation/reward-overlay.md` with the four-phase sequence, wiggle interaction, countdown advance behaviour, and removal of the preview panel.
-- Coordinate with backend reviewers to confirm no API adjustments are required; document any assumptions or follow-up backend work in the task file if discovered.
+## Subtasks
+- `.codex/tasks/68168a61-reward-automation-advance-hooks.md` — update idle automation scripts to use the new hooks.
+- `.codex/tasks/b8904271-reward-regression-coverage.md` — extend regression coverage with countdown and confirm scenarios.
+- `.codex/tasks/2d6e3f12-reward-overlay-docs-update.md` — refresh documentation and fixtures for the new flow.
 
-## Coordination notes
-- Check `.codex/review` and `.codex/planning` for related automation efforts to avoid duplicating work.
-- Work with QA to validate the automation on staging once UI changes land.
+## Notes
+- Coordinate timing with the UI subtasks so automation/tests target the finalised hooks and styling.
+- Once all child tasks close, revisit this parent to confirm no further follow-up is required.

--- a/.codex/tasks/1f2b8b4a-reward-confirm-accessibility.md
+++ b/.codex/tasks/1f2b8b4a-reward-confirm-accessibility.md
@@ -1,0 +1,15 @@
+# Finalise reward confirm accessibility & styling tokens
+
+## Summary
+Polish the shared styling and accessibility surface for the refreshed card and relic confirm controls so both phases meet keyboard, screen reader, and design expectations.
+
+## Requirements
+- Centralise stained-glass button styles, animation durations, and colour tokens in a shared stylesheet or design token file used by both card and relic confirms.
+- Audit keyboard focus order through Drops → Cards → Relics to ensure tab/arrow navigation and aria attributes read correctly for confirm buttons.
+- Add screen reader announcements when the confirm button appears/disappears and when selections change, following accessibility task guidance.
+- Update any localisation strings or tooltip copy so both phases share the same wording.
+- Provide documentation snippets or Storybook notes (if applicable) demonstrating the expected interactions for QA.
+
+## Coordination notes
+- Coordinate with the resilience task owner to avoid conflicting focus management changes.
+- Loop in UX for sign-off on the shared styling tokens before merging.

--- a/.codex/tasks/2d6e3f12-reward-overlay-docs-update.md
+++ b/.codex/tasks/2d6e3f12-reward-overlay-docs-update.md
@@ -1,0 +1,15 @@
+# Refresh reward overlay documentation set
+
+## Summary
+Update documentation artifacts so they describe the four-phase reward flow, new confirm interactions, and automation touchpoints introduced by the overhaul.
+
+## Requirements
+- Revise `frontend/.codex/implementation/reward-overlay.md` with the new phase diagram, countdown behaviour, confirm interactions, and fallback notes.
+- Document the state machine API for other contributors (inputs, events, hooks) and link to any shared styling token sources.
+- Audit other docs (automation guides, QA notes, README excerpts) referencing the old single-phase overlay and update them or flag obsolete references.
+- Include callouts for accessibility expectations (focus order, screen reader announcements) so reviewers know what to validate.
+- Coordinate with QA/automation owners to capture any new manual testing steps introduced by the countdown or confirm flows.
+
+## Coordination notes
+- Share the updated docs with coders once the major UI tasks land to confirm accuracy.
+- If documentation gaps remain after UI/testing work completes, outline follow-up tasks in this file.

--- a/.codex/tasks/5e4992b5-reward-flow-four-step-overhaul.md
+++ b/.codex/tasks/5e4992b5-reward-flow-four-step-overhaul.md
@@ -1,12 +1,22 @@
 # Rebuild reward overlay into four-phase flow
 
 ## Summary
-Umbrella pointer for the reward overlay overhaul. The original monolithic work item has been decomposed into three focused tasks so coders can deliver the Drops → Cards → Relics → Review experience incrementally.
+Umbrella pointer for the reward overlay overhaul. The monolithic work item has been decomposed into focused umbrellas, each of which now references bite-sized implementation tasks so coders can land the Drops → Cards → Relics → Review experience incrementally.
 
 ## Subtasks
-- `.codex/tasks/1b801b74-reward-overlay-step-controller.md` — introduce the explicit four-phase controller, drops-only screen, and timed advance button.
-- `.codex/tasks/b500ea24-card-relic-confirmation-refresh.md` — refresh card/relic selection with wiggle animation, on-card confirms, and shared stained-glass styling.
-- `.codex/tasks/1f113358-reward-automation-doc-sync.md` — update idle automation, regression coverage, and documentation to follow the new flow.
+- `.codex/tasks/1b801b74-reward-overlay-step-controller.md` — controller umbrella.
+  - `.codex/tasks/f7ae6ddd-reward-overlay-state-machine.md`
+  - `.codex/tasks/01508135-drops-phase-overlay-refactor.md`
+  - `.codex/tasks/bcfc52bc-reward-advance-countdown.md`
+  - `.codex/tasks/6afb12ae-reward-overlay-resilience.md`
+- `.codex/tasks/b500ea24-card-relic-confirmation-refresh.md` — card/relic UX umbrella.
+  - `.codex/tasks/ebfb0389-card-highlight-wiggle.md`
+  - `.codex/tasks/d7196ce9-relic-highlight-confirm.md`
+  - `.codex/tasks/1f2b8b4a-reward-confirm-accessibility.md`
+- `.codex/tasks/1f113358-reward-automation-doc-sync.md` — automation + docs umbrella.
+  - `.codex/tasks/68168a61-reward-automation-advance-hooks.md`
+  - `.codex/tasks/b8904271-reward-regression-coverage.md`
+  - `.codex/tasks/2d6e3f12-reward-overlay-docs-update.md`
 
 ## Notes
 - Use this parent file to coordinate sequencing and cross-task dependencies.

--- a/.codex/tasks/68168a61-reward-automation-advance-hooks.md
+++ b/.codex/tasks/68168a61-reward-automation-advance-hooks.md
@@ -1,0 +1,15 @@
+# Update idle automation for four-phase rewards
+
+## Summary
+Teach the idle automation/assist scripts to drive the new Drops → Cards → Relics → Review flow, invoking the advance hooks introduced by the overlay refresh.
+
+## Requirements
+- Inspect existing automation scripts/services (frontend or backend) and identify where reward confirmations occur today.
+- Update the automation to wait for the new state machine events, triggering Drops completion, card confirm, relic confirm, and review dismiss in order.
+- Add handling for the countdown auto-advance so automation does not fight the timer when it fires first.
+- Expose logging or metrics so QA can verify each phase was touched during automation runs.
+- Dry-run the automation against staging or a local mocked flow to confirm compatibility with the updated UI.
+
+## Coordination notes
+- Collaborate with the overlay implementers to reuse their published hooks/callbacks.
+- Capture any follow-up backend tooling needed in a separate task if automation reveals API gaps.

--- a/.codex/tasks/6afb12ae-reward-overlay-resilience.md
+++ b/.codex/tasks/6afb12ae-reward-overlay-resilience.md
@@ -1,0 +1,15 @@
+# Harden reward overlay transitions & accessibility
+
+## Summary
+Tighten the reward overlay's transition handling, fallback behaviour, and focus management so each phase change remains resilient even when metadata is missing or users advance early.
+
+## Requirements
+- Implement guards around each phase entry to catch malformed `reward_progression` data and gracefully default to the legacy single-phase overlay with logging.
+- Ensure early confirmations (manual button clicks, keyboard Enter) dispatch safe transitions and cannot fire multiple times or leave the overlay in a stuck state.
+- Add focus management so the advance button gains focus when it appears, returns focus to the overlay root when auto-advancing, and respects skip paths.
+- Verify screen reader announcements describe the new phase on entry and the countdown status for accessibility compliance.
+- Document any remaining risks or follow-up work directly in the task file for visibility.
+
+## Coordination notes
+- Pair with QA or accessibility reviewers to validate screen reader messaging.
+- Sync with backend engineers if additional metadata is required to cover new edge cases uncovered during implementation.

--- a/.codex/tasks/b500ea24-card-relic-confirmation-refresh.md
+++ b/.codex/tasks/b500ea24-card-relic-confirmation-refresh.md
@@ -1,16 +1,13 @@
 # Refresh reward card & relic confirmation UX
 
 ## Summary
-Update the reward overlay's card and relic selection experience with accessible highlight, wiggle, and confirm behaviours that match the stained-glass control styling.
+Umbrella pointer for the card/relic interaction refresh. The work is now split so animation, relic parity, and accessibility/styling polish can proceed in parallel.
 
-## Requirements
-- When entering the Card phase, highlight the first selected card and apply a subtle looping wiggle animation (small rotation + scale jitter with a touch of randomness) that persists until confirmation or a different card is chosen.
-- Replace the existing preview panel with an on-card confirm button that mirrors the stained-glass right-rail styling and appears directly beneath the highlighted card; second clicks on the highlighted card should trigger the same confirm.
-- Mirror the same highlight + wiggle + confirm flow for relic selection, including clearing any highlight when backend cancel/reset events occur.
-- Preserve keyboard accessibility: focus should move to the confirm control when it appears, Enter/Space should confirm, and arrow/tab navigation should allow changing the selection.
-- Remove the old cancel button, ensuring there is a clear keyboard path to back out if the backend exposes a cancel action.
-- Ensure styling tokens (`--glass-bg`, `stained-glass-row`, `icon-btn`) are reused or centralised to keep consistency with other overlays.
+## Subtasks
+- `.codex/tasks/ebfb0389-card-highlight-wiggle.md` — implement the card highlight, wiggle, and confirm control.
+- `.codex/tasks/d7196ce9-relic-highlight-confirm.md` — apply the same interaction model to relics and handle reset events.
+- `.codex/tasks/1f2b8b4a-reward-confirm-accessibility.md` — centralise styling tokens and finalise accessibility hooks.
 
-## Coordination notes
-- Collaborate with whoever owns idle automation to align on new confirm hooks before merging.
-- Sync with any concurrent reward preview work so documentation/tests are updated consistently.
+## Notes
+- Coordinate timelines with the phase controller subtasks so confirm hooks wire into the shared state machine cleanly.
+- Update this parent as subtasks close or if additional polish work is identified.

--- a/.codex/tasks/b8904271-reward-regression-coverage.md
+++ b/.codex/tasks/b8904271-reward-regression-coverage.md
@@ -1,0 +1,15 @@
+# Expand reward overlay regression coverage
+
+## Summary
+Add automated tests and fixtures that exercise the new countdown advance, confirm flows, and multi-phase transitions introduced in the reward overlay overhaul.
+
+## Requirements
+- Identify the appropriate testing layers (unit, integration, end-to-end) covering the reward overlay today and extend them to cover each new phase.
+- Create fixtures or mocked responses containing representative `reward_progression` data for single-phase, full four-phase, and skip-phase scenarios.
+- Write tests verifying the countdown auto-advance, manual advance button, card confirm, and relic confirm behaviours fire the expected events.
+- Ensure tests cover keyboard accessibility (e.g., focus order) where feasible, or document manual QA steps where automation cannot reach.
+- Update CI pipelines or scripts to include the new tests so regressions block merges.
+
+## Coordination notes
+- Work with the automation task owner to share fixtures and avoid duplication.
+- Coordinate with QA to review new coverage and identify any remaining gaps needing manual test cases.

--- a/.codex/tasks/bcfc52bc-reward-advance-countdown.md
+++ b/.codex/tasks/bcfc52bc-reward-advance-countdown.md
@@ -1,0 +1,15 @@
+# Ship reward overlay advance button & countdown
+
+## Summary
+Add the stained-glass right-rail with a manual `Advance` button, integrate a 10-second countdown timer, and wire both into the reward overlay controller.
+
+## Requirements
+- Render the right-rail panel with stained-glass styling, including phase labels and an `Advance` button that uses shared button tokens.
+- Implement a countdown timer that starts when a phase becomes completable, displays remaining seconds, and auto-triggers the advance handler when it reaches zero.
+- Allow manual button clicks to advance immediately, cancelling the countdown when pressed.
+- Ensure the timer pauses or resets correctly when phases are skipped by the controller (e.g., backend indicates no relics).
+- Cover edge cases such as multiple rapid clicks, countdown jitter, and overlay unmounts with unit/component tests.
+
+## Coordination notes
+- Confirm animation/styling expectations with the UX owner before finalising CSS variables.
+- Provide an event or callback the automation task can hook into for validating auto-advance in tests.

--- a/.codex/tasks/d7196ce9-relic-highlight-confirm.md
+++ b/.codex/tasks/d7196ce9-relic-highlight-confirm.md
@@ -1,0 +1,15 @@
+# Mirror relic highlight & confirm interactions
+
+## Summary
+Apply the refreshed highlight, wiggle, and confirm flow to relic rewards, including reset handling when the backend cancels or modifies the selection.
+
+## Requirements
+- Reuse the shared animation tokens and confirm button styling from the card phase for relic tiles.
+- Ensure backend-driven reset/cancel events clear the highlight, stop animations, and hide the confirm button until a new relic is selected.
+- Support keyboard focus traversal between relic tiles and the confirm button, ensuring focus returns to the tile grid after confirmation.
+- Wire relic confirms into the overlay controller advance hooks so subsequent phases trigger reliably.
+- Provide regression tests covering reset flows and double-confirm guards.
+
+## Coordination notes
+- Verify with backend maintainers whether relic rewards can be absent or multi-select; adapt the UI accordingly.
+- Share any additional ARIA labels or accessibility copy updates with the accessibility-focused task owner.

--- a/.codex/tasks/ebfb0389-card-highlight-wiggle.md
+++ b/.codex/tasks/ebfb0389-card-highlight-wiggle.md
@@ -1,0 +1,15 @@
+# Implement reward card highlight & wiggle behaviour
+
+## Summary
+Rework the reward card phase so the selected card visually stands out with a looping wiggle animation and exposes an on-card confirm action.
+
+## Requirements
+- When entering the Card phase, auto-select the first card and render an on-card confirm button below it using the stained-glass button style.
+- Create a subtle wiggle animation (rotation + scale jitter) applied only to the highlighted card; ensure it pauses when the card loses focus/selection.
+- Support both mouse/touch re-selection and keyboard navigation; second click or confirm button should dispatch the card confirm event.
+- Ensure animation tokens/config values live in a shared location so relic tasks can reuse them.
+- Add component-level tests to verify selection defaults, confirm button rendering, and animation class toggling.
+
+## Coordination notes
+- Hand off the animation token details to the relic task owner for parity.
+- Confirm the confirm event name/signature with backend or automation maintainers so hooks remain consistent.

--- a/.codex/tasks/f7ae6ddd-reward-overlay-state-machine.md
+++ b/.codex/tasks/f7ae6ddd-reward-overlay-state-machine.md
@@ -1,0 +1,15 @@
+# Implement reward overlay state machine scaffold
+
+## Summary
+Define the frontend reward overlay controller that ingests `reward_progression` from the backend and exposes a deterministic phase state machine for Drops → Cards → Relics → Battle Review.
+
+## Requirements
+- Parse `reward_progression` payloads in the overlay store/component and normalise them into a typed sequence of phases.
+- Represent the flow as an explicit finite state machine (or equivalent enum + reducer) that exposes current phase, next phase, and helper methods for advancing and skipping.
+- Guarantee the state machine tolerates missing or reordered phases by falling back to a safe default order while logging diagnostics for QA.
+- Emit events/hooks the rest of the overlay can subscribe to for phase entry/exit so follow-up UI tasks can attach behaviour without reimplementing the progression logic.
+- Provide unit coverage over the reducer/state helper to lock in transitions, skip handling, and invalid metadata fallbacks.
+
+## Coordination notes
+- Align with backend maintainers on expected `reward_progression` schema shape before hard-coding assumptions.
+- Hand off the exposed hooks to the UI implementers working on Drops/Confirm tasks so they can rely on the same API.


### PR DESCRIPTION
## Summary
- expand the reward overlay umbrella task to list granular follow-on work
- convert each existing subtask into an umbrella pointer with explicit child task references
- add ten focused task files covering state machine, UI, accessibility, automation, testing, and documentation updates

## Testing
- not run (task updates only)


------
https://chatgpt.com/codex/tasks/task_b_68f5e6b18528832c941a7f06c2b4f6bc