### PR TITLE
Add resilience guardrails to reward overlay flow

### DIFF
--- a/.codex/tasks/6afb12ae-reward-overlay-resilience.md
+++ b/.codex/tasks/6afb12ae-reward-overlay-resilience.md
@@ -13,3 +13,6 @@ Tighten the reward overlay's transition handling, fallback behaviour, and focus 
 ## Coordination notes
 - Pair with QA or accessibility reviewers to validate screen reader messaging.
 - Sync with backend engineers if additional metadata is required to cover new edge cases uncovered during implementation.
+- Remaining risk: the Bun test runner currently resolves Svelte's server build, so reward overlay component tests must run under a DOM-capable environment (e.g., jsdom) to execute successfully.
+
+ready for review


### PR DESCRIPTION
## Summary
- harden the reward overlay against malformed reward progression and provide accessible focus handling
- surface screen reader announcements, countdown messaging, and legacy fallback notices in the UI
- expand the advance-panel test suite with timer mocks and coverage for keyboard and fallback behaviour
- document the remaining test-runner risk in the task file

## Testing
- bun test ./tests/reward-overlay-advance-panel.vitest.js *(fails: Svelte runtime resolved to server build in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68f6cd61d658832c916ab372dc0b0839