### PR TITLE
Update foe HP modifier scaling and metadata version

### DIFF
--- a/backend/.codex/implementation/run-configuration-metadata.md
+++ b/backend/.codex/implementation/run-configuration-metadata.md
@@ -21,8 +21,15 @@ and stored with the run record.
     counts, whether stacks grant reward bonuses, and tooltip data. Stacks are no
     longer hard capped; validation only enforces the documented minimums and
     converts numeric input.
-  - `pressure.tooltip` – canonical tooltip text summarizing encounter sizing,
-    defense floors, elite odds, and shop tax scaling for pressure stacks.
+- `pressure.tooltip` – canonical tooltip text summarizing encounter sizing,
+  defense floors, elite odds, and shop tax scaling for pressure stacks.
+
+### Modifier Notes
+
+- `foe_hp` applies a +150× additive multiplier (15,000% increase) to both max
+  and current HP for each stack before diminishing returns. Preview rows show
+  the raw multiplier alongside the diminished effective value so designers can
+  size late-game encounters against the new scaling curve.
 
 Telemetry records a `Run/view_config` menu action so analytics can measure how
 often the setup flow is opened.

--- a/backend/services/run_configuration.py
+++ b/backend/services/run_configuration.py
@@ -15,7 +15,7 @@ from typing import Mapping
 from autofighter.effects import DIMINISHING_RETURNS_CONFIG
 from autofighter.effects import calculate_diminishing_returns
 
-METADATA_VERSION = "2025.02"
+METADATA_VERSION = "2025.03"
 
 _PRESSURE_TOOLTIP = (
     "Each stack raises encounter pressure. Base encounters gain +1 foe slot for every "
@@ -221,10 +221,10 @@ _MODIFIER_DEFINITIONS: dict[str, dict[str, Any]] = {
         "min_stacks": 0,
         "stack_step": 1,
         "grants_reward_bonus": True,
-        "description": "Raises foe max/current HP by +0.5× per stack before diminishing returns.",
+        "description": "Raises foe max/current HP by +150× (15,000%) per stack before diminishing returns.",
         "effects_metadata": {
             "stat": "max_hp",
-            "per_stack": 0.5,
+            "per_stack": 150.0,
             "scaling_type": "additive",
         },
         "diminishing_returns": {
@@ -237,7 +237,7 @@ _MODIFIER_DEFINITIONS: dict[str, dict[str, Any]] = {
             "rdr_bonus_per_stack": 0.01,
         },
         "preview_stacks": [0, 1, 5, 10],
-        "effects": lambda stacks: _foe_modifier_effect("max_hp", 0.5, stacks),
+        "effects": lambda stacks: _foe_modifier_effect("max_hp", 150.0, stacks),
         "diminishing_stat": "max_hp",
     },
     "foe_mitigation": {

--- a/backend/tests/test_run_configuration_service.py
+++ b/backend/tests/test_run_configuration_service.py
@@ -18,10 +18,10 @@ def test_run_configuration_metadata_shape():
 def test_run_configuration_metadata_details():
     metadata = get_run_configuration_metadata()
     foe_hp = next(mod for mod in metadata["modifiers"] if mod["id"] == "foe_hp")
-    assert foe_hp["effects"]["per_stack"] == pytest.approx(0.5)
+    assert foe_hp["effects"]["per_stack"] == pytest.approx(150.0)
     assert foe_hp["diminishing_returns"]["applies"] is True
     preview_five = next(item for item in foe_hp["preview"] if item["stacks"] == 5)
-    assert preview_five["raw_bonus"] == pytest.approx(2.5)
+    assert preview_five["raw_bonus"] == pytest.approx(750.0)
     foe_speed = next(mod for mod in metadata["modifiers"] if mod["id"] == "foe_speed")
     assert foe_speed["reward_bonuses"]["exp_bonus_per_stack"] == pytest.approx(0.5)
     assert foe_speed["reward_bonuses"]["rdr_bonus_per_stack"] == pytest.approx(0.01)

--- a/frontend/tests/api.test.js
+++ b/frontend/tests/api.test.js
@@ -46,7 +46,7 @@ describe('api calls', () => {
           pressure: 5,
           run_type: 'boss_rush',
           modifiers: { pressure: 5 },
-          metadata_version: '2025.02'
+          metadata_version: '2025.03'
         }
       });
       return {
@@ -62,7 +62,7 @@ describe('api calls', () => {
       pressure: 5,
       runType: 'boss_rush',
       modifiers: { pressure: 5 },
-      metadataVersion: '2025.02'
+      metadataVersion: '2025.03'
     });
     expect(result).toEqual({ run_id: 'abc', map: [] });
     expect(fetchMock.mock.calls.length).toBe(1);

--- a/frontend/tests/uiApi.metadata.vitest.js
+++ b/frontend/tests/uiApi.metadata.vitest.js
@@ -24,25 +24,25 @@ describe('run configuration metadata caching', () => {
   });
 
   test('returns cached metadata on subsequent calls', async () => {
-    httpGet.mockResolvedValueOnce(createMetadata('2025.02'));
+    httpGet.mockResolvedValueOnce(createMetadata('2025.03'));
 
     const first = await getRunConfigurationMetadata();
     expect(httpGet).toHaveBeenCalledTimes(1);
-    expect(first.version).toBe('2025.02');
+    expect(first.version).toBe('2025.03');
 
     const second = await getRunConfigurationMetadata();
     expect(httpGet).toHaveBeenCalledTimes(1);
-    expect(second.version).toBe('2025.02');
+    expect(second.version).toBe('2025.03');
   });
 
   test('refetches when requested hash differs from cache', async () => {
-    httpGet.mockResolvedValueOnce(createMetadata('2025.02'));
+    httpGet.mockResolvedValueOnce(createMetadata('2025.03'));
     await getRunConfigurationMetadata();
 
-    httpGet.mockResolvedValueOnce(createMetadata('2025.03'));
-    const refreshed = await getRunConfigurationMetadata({ metadataHash: '2025.03' });
+    httpGet.mockResolvedValueOnce(createMetadata('2025.04'));
+    const refreshed = await getRunConfigurationMetadata({ metadataHash: '2025.04' });
     expect(httpGet).toHaveBeenCalledTimes(2);
-    expect(refreshed.version).toBe('2025.03');
+    expect(refreshed.version).toBe('2025.04');
   });
 
   test('hydrates from sessionStorage without fetching', async () => {


### PR DESCRIPTION
## Summary
- raise the foe HP modifier per-stack multiplier to 150x and bump the run configuration metadata version
- refresh backend and frontend tests to reflect the new per-stack preview values and metadata hash string
- document the revised HP scaling in the run configuration metadata notes

## Testing
- uv run pytest tests/test_run_configuration_service.py tests/test_run_configuration_context.py *(fails: ImportError: cannot import name 'empty_reward_staging' from 'runs.lifecycle')*


------
https://chatgpt.com/codex/tasks/task_b_68f6d9edebc0832ca16a45bcf87a6767