### PR TITLE
Implement capped overflow scaling for character stat penalties

### DIFF
--- a/backend/services/run_service.py
+++ b/backend/services/run_service.py
@@ -201,7 +201,7 @@ async def start_run(
     modifier_context = build_run_modifier_context(configuration_snapshot)
     configuration_snapshot.setdefault("derived_effects", modifier_context.derived_metrics())
 
-    player_stat_multiplier = apply_player_modifier_context(party_members, modifier_context)
+    _ = apply_player_modifier_context(party_members, modifier_context)
 
     exp_multiplier_map: dict[str, float] = {}
     for member, info in zip(party_members, party_info):
@@ -349,6 +349,8 @@ async def start_run(
             "foe_stat_multipliers": modifier_context.foe_stat_multipliers,
             "foe_stat_deltas": modifier_context.foe_stat_deltas,
             "player_stat_multiplier": modifier_context.player_stat_multiplier,
+            "player_penalty_excess_stacks": modifier_context.player_penalty_excess_stacks,
+            "foe_overflow_multiplier": modifier_context.foe_overflow_multiplier,
             "elite_spawn_bonus_pct": modifier_context.elite_spawn_bonus_pct,
             "glitched_spawn_bonus_pct": modifier_context.glitched_spawn_bonus_pct,
             "prime_spawn_bonus_pct": modifier_context.prime_spawn_bonus_pct,

--- a/backend/tests/test_run_configuration_context.py
+++ b/backend/tests/test_run_configuration_context.py
@@ -41,6 +41,8 @@ def test_build_run_modifier_context_matches_snapshot_metadata():
     assert context.prime_spawn_bonus_pct == pytest.approx(prime_bonus)
     player_multiplier = selection.snapshot["modifiers"]["character_stat_down"]["details"]["effective_multiplier"]
     assert context.player_stat_multiplier == pytest.approx(player_multiplier)
+    assert context.player_penalty_excess_stacks == 0
+    assert context.foe_overflow_multiplier == pytest.approx(1.0)
     assert context.foe_exp_bonus == pytest.approx(selection.reward_bonuses["foe_modifier_bonus"])
     assert context.player_exp_bonus == pytest.approx(selection.reward_bonuses["player_modifier_bonus"])
     assert context.foe_rdr_bonus == pytest.approx(selection.reward_bonuses["foe_rdr_bonus"])
@@ -62,6 +64,8 @@ def test_build_run_modifier_context_matches_snapshot_metadata():
     assert serialized["player_exp_bonus"] == pytest.approx(context.player_exp_bonus)
     assert serialized["foe_rdr_bonus"] == pytest.approx(context.foe_rdr_bonus)
     assert serialized["player_rdr_bonus"] == pytest.approx(context.player_rdr_bonus)
+    assert serialized["player_penalty_excess_stacks"] == 0
+    assert serialized["foe_overflow_multiplier"] == pytest.approx(1.0)
     hydrated = RunModifierContext.from_dict(serialized)
     assert hydrated.shop_multiplier == pytest.approx(context.shop_multiplier)
     assert hydrated.encounter_slot_bonus == context.encounter_slot_bonus
@@ -70,6 +74,28 @@ def test_build_run_modifier_context_matches_snapshot_metadata():
     assert hydrated.player_exp_bonus == pytest.approx(context.player_exp_bonus)
     assert hydrated.foe_rdr_bonus == pytest.approx(context.foe_rdr_bonus)
     assert hydrated.player_rdr_bonus == pytest.approx(context.player_rdr_bonus)
+    assert hydrated.player_penalty_excess_stacks == context.player_penalty_excess_stacks
+    assert hydrated.foe_overflow_multiplier == pytest.approx(context.foe_overflow_multiplier)
+
+
+def test_build_run_modifier_context_applies_overflow_scaling():
+    stacks = 5010
+    selection = validate_run_configuration(
+        run_type="standard",
+        modifiers={"character_stat_down": stacks},
+    )
+    context = build_run_modifier_context(selection.snapshot)
+
+    cap_threshold = selection.snapshot["modifiers"]["character_stat_down"]["details"]["cap_threshold_stacks"]
+    assert context.player_penalty_excess_stacks == stacks - cap_threshold
+    assert context.player_penalty_excess_stacks > 0
+    assert context.foe_overflow_multiplier == pytest.approx(1.0 + 0.01 * context.player_penalty_excess_stacks)
+    for stat in ("max_hp", "atk", "defense", "spd", "vitality"):
+        assert context.foe_stat_multipliers[stat] == pytest.approx(context.foe_overflow_multiplier)
+
+    derived = context.derived_metrics()
+    assert derived["player_penalty_excess_stacks"] == pytest.approx(float(context.player_penalty_excess_stacks))
+    assert derived["foe_overflow_multiplier"] == pytest.approx(context.foe_overflow_multiplier)
 
 
 def test_get_modifier_snapshot_normalises_entries():


### PR DESCRIPTION
## Summary
- tighten the character stat down overflow math by clamping penalties, exposing overflow metadata, and capping player RDR growth while allowing reduced EXP gains
- propagate overflow stack handling through `validate_run_configuration`, `RunModifierContext`, and the run start telemetry payload so foe stats receive 1% per-stack multipliers beyond the cap
- refresh the run-configuration documentation and tests to cover the steeper overflow coefficient, player reward cap, and new foe scaling hooks

## Testing
- `uv run pytest tests/test_run_configuration_context.py`
- `uv run pytest tests/test_run_configuration_service.py` *(fails: ImportError while importing runs.lifecycle -> empty_reward_staging)*

------
https://chatgpt.com/codex/tasks/task_b_68f6e0bb0e78832c8dddae406798244e