### PR TITLE
Add regression coverage for loot acknowledgement gating

### DIFF
--- a/backend/services/reward_service.py
+++ b/backend/services/reward_service.py
@@ -281,6 +281,9 @@ async def acknowledge_loot(run_id: str) -> dict[str, Any]:
             raise ValueError("not awaiting loot")
         current_index = int(state.get("current", 0))
         state["awaiting_loot"] = False
+        staging, _ = ensure_reward_staging(state)
+        staging["items"] = []
+        _refresh_snapshot(run_id, state, staging)
         _update_reward_progression(state, completed_step=REWARD_STEP_DROPS)
 
         if state.get("reward_progression"):


### PR DESCRIPTION
## Summary
- extend the reward gate test to stage loot drops, walk through card/relic confirmations, and assert loot acknowledgement unblocks room advancement
- clear staged loot items and refresh battle snapshots when acknowledging loot so pending reward checks no longer block advancing

## Testing
- `uv run pytest tests/test_reward_gate.py`


------
https://chatgpt.com/codex/tasks/task_b_68f742094a2c832c89a087d699c0ca10