### PR TITLE
Allow manual loot acknowledgement retries when blocked

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1602,12 +1602,13 @@
   }
 
   async function handleLootAcknowledge() {
-    if (!runId || lootAckBlocked) return;
+    if (!runId) return;
     stopBattlePolling();
     const acknowledged = await attemptLootAcknowledge({ source: 'manual-loot' });
     if (!acknowledged) {
       return;
     }
+    lootAckBlocked = false;
     await handleNextRoom();
   }
 


### PR DESCRIPTION
## Summary
- track a loot acknowledgement block flag that resets when `awaiting_loot` changes
- wrap `acknowledgeLoot` calls to surface errors, reset the reward controller, and halt progression
- prevent automation and countdown handlers from retrying while acknowledgement is blocked
- allow manual loot acknowledgement retries to bypass the block once a retry succeeds

## Testing
- not run (follow-up change)

------
https://chatgpt.com/codex/tasks/task_b_68f754ebfb1c832ca3a5f87d08407530