### PR TITLE
Fix reward advance gating and busy-state UX

### DIFF
--- a/frontend/.codex/implementation/reward-overlay.md
+++ b/frontend/.codex/implementation/reward-overlay.md
@@ -124,6 +124,19 @@ automation can finish the encounter immediately. A separate five-second timer
 fires a `next` event when the popup is otherwise empty, which keeps fast loot
 pickups from stalling the run.
 
+The overlay now accepts an `advanceBusy` prop that is toggled while the client
+is waiting on the `/ui?action=advance_room` response. When `advanceBusy` is
+true the advance panel switches its status copy to **“Advancing to the next
+room…”**, disables the **Advance** button, pauses the auto-advance countdown,
+and also disables the **Next Room** button so additional clicks do not refire
+the request. `OverlayHost.svelte` pipes this flag through from `+page.svelte`
+once the next-room flow begins, keeping the UI in sync with the server call.
+
+`uiApi.advanceRoom()` re-validates reward state against the latest
+`runState`/`rewardProgression` snapshot before surfacing the blocking overlay.
+The overlay copy now enumerates the pending reward buckets (card, relic, or
+loot) and only displays when selections or confirmations genuinely remain.
+
 ### Phase advance panel and countdown
 
 The right rail now renders a stained-glass panel that mirrors the reward phase

--- a/frontend/src/lib/components/GameViewport.svelte
+++ b/frontend/src/lib/components/GameViewport.svelte
@@ -47,6 +47,7 @@
   export let fullIdleMode = false;
   export let animationSpeed = 1;
   export let shopProcessing = false;
+  export let advanceBusy = false;
 
   let randomBg = '';
   let roster = [];
@@ -419,6 +420,7 @@
         {flashEnrageCounter}
         {fullIdleMode}
         {skipBattleReview}
+        {advanceBusy}
         bind:animationSpeed
         {selectedParty}
         {battleActive}

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -55,6 +55,7 @@
   export let flashEnrageCounter = true;
   export let fullIdleMode = false;
   export let skipBattleReview = false;
+  export let advanceBusy = false;
   export let animationSpeed = 1;
   export let selectedParty = [];
   export let battleActive = false;
@@ -489,6 +490,7 @@
       awaitingRelic={awaitingRelic}
       awaitingLoot={awaitingLoot}
       awaitingNext={awaitingNext}
+      advanceBusy={advanceBusy}
       items={roomData?.loot?.items || []}
       gold={roomData?.loot?.gold || 0}
       nextRoom={roomData?.next_room || ''}

--- a/frontend/tests/reward-overlay-flow-regression.vitest.js
+++ b/frontend/tests/reward-overlay-flow-regression.vitest.js
@@ -167,6 +167,39 @@ describe('reward overlay multi-phase regression', () => {
 
     const nextRoomButton = container.querySelector('button.next-button.overlay');
     expect(nextRoomButton).toBeInstanceOf(HTMLButtonElement);
+    if (nextRoomButton instanceof HTMLButtonElement) {
+      expect(nextRoomButton.disabled).toBe(false);
+    }
+
+    const statusEl = container.querySelector('[data-testid="advance-countdown"]');
+    expect(statusEl).not.toBeNull();
+    if (statusEl) {
+      expect(statusEl.textContent).toContain('Advance ready');
+    }
+
+    const advancePanel = container.querySelector('.advance-panel');
+    expect(advancePanel?.classList.contains('locked')).toBe(false);
+
+    component.$set({ advanceBusy: true });
+    await tick();
+
+    if (statusEl) {
+      expect(statusEl.textContent).toContain('Advancing to the next room');
+    }
+    expect(advanceButton.disabled).toBe(true);
+    if (nextRoomButton instanceof HTMLButtonElement) {
+      expect(nextRoomButton.disabled).toBe(true);
+    }
+
+    component.$set({ advanceBusy: false });
+    await tick();
+
+    if (statusEl) {
+      expect(statusEl.textContent).toContain('Advance ready');
+    }
+    if (nextRoomButton instanceof HTMLButtonElement) {
+      expect(nextRoomButton.disabled).toBe(false);
+    }
 
     expect(advanceEvents.length).toBeGreaterThan(0);
     expect(advanceEvents[0]?.reason).toBe('manual');


### PR DESCRIPTION
## Summary
- rework `uiApi.advanceRoom()` to revalidate reward snapshots before surfacing the blocking overlay and to collapse concurrent advance calls
- surface an `advanceBusy` flag from the page controller through `GameViewport`/`OverlayHost` so `RewardOverlay` disables controls and updates status text while the server advance is pending
- extend the reward overlay regression test for the full drops→cards→relics→review path and document the new busy-state guidance

## Testing
- bun x vitest run tests/reward-overlay-flow-regression.vitest.js *(fails: Vitest caught an unhandled error before test discovery; see run log)*

------
https://chatgpt.com/codex/tasks/task_b_68f7662288f4832c8534d36a1b61e5cf