### PR TITLE
Fix reward selection animations for non-confirm flows

### DIFF
--- a/frontend/src/lib/components/CurioChoice.svelte
+++ b/frontend/src/lib/components/CurioChoice.svelte
@@ -207,7 +207,7 @@
     }
   }
 
-  .curio-shell.confirmable.selected[data-reduced-motion='false'] :global(.card-art) {
+  .curio-shell.selected[data-reduced-motion='false'] :global(.card-art) {
     animation: reward-selection-wiggle var(--reward-selection-wiggle-duration) ease-in-out infinite;
   }
 

--- a/frontend/src/lib/components/RewardCard.svelte
+++ b/frontend/src/lib/components/RewardCard.svelte
@@ -208,7 +208,7 @@
     }
   }
 
-  .card-shell.confirmable.selected[data-reduced-motion='false'] :global(.card-art) {
+  .card-shell.selected[data-reduced-motion='false'] :global(.card-art) {
     animation: reward-selection-wiggle var(--reward-selection-wiggle-duration)
       ease-in-out infinite;
   }

--- a/frontend/test-setup.js
+++ b/frontend/test-setup.js
@@ -4,7 +4,7 @@
 import { beforeAll } from 'bun:test';
 import { JSDOM } from 'jsdom';
 import { state as svelteState } from 'svelte/internal/client';
-import 'svelte/internal/flags/legacy.js';
+import 'svelte/internal/flags/legacy';
 
 process.env.SVELTE_ALLOW_RUNES_OUTSIDE_SVELTE = 'true';
 globalThis.SVELTE_ALLOW_RUNES_OUTSIDE_SVELTE = true;

--- a/frontend/tests/reward-overlay-card-phase.vitest.js
+++ b/frontend/tests/reward-overlay-card-phase.vitest.js
@@ -141,4 +141,48 @@ describe('RewardOverlay card phase interactions', () => {
     expect(confirmHandler).toHaveBeenCalledTimes(1);
     expect(confirmHandler.mock.calls[0][0]?.id).toBe('echo-strike');
   });
+
+  test('applies selected styling in the no-confirmation card flow', async () => {
+    updateRewardProgression(afterDropsProgression());
+
+    const { container } = render(RewardOverlay, {
+      props: {
+        cards: [
+          {
+            id: 'first-card',
+            name: 'First Card',
+            stars: 3
+          },
+          {
+            id: 'second-card',
+            name: 'Second Card',
+            stars: 2
+          }
+        ],
+        relics: [],
+        items: [],
+        gold: 0,
+        awaitingLoot: false,
+        awaitingCard: false,
+        awaitingRelic: false,
+        awaitingNext: false,
+        reducedMotion: false
+      }
+    });
+
+    const secondCardButton = container.querySelector(
+      'button[aria-label="Select card Second Card"]'
+    );
+    expect(secondCardButton).not.toBeNull();
+    if (!secondCardButton) return;
+
+    await fireEvent.click(secondCardButton);
+    await tick();
+
+    const shell = secondCardButton.closest('.card-shell');
+    expect(shell).not.toBeNull();
+    expect(shell?.classList.contains('selected')).toBe(true);
+    expect(shell?.classList.contains('confirmable')).toBe(false);
+    expect(shell?.dataset.reducedMotion).toBe('false');
+  });
 });

--- a/frontend/tests/reward-overlay-relic-phase.vitest.js
+++ b/frontend/tests/reward-overlay-relic-phase.vitest.js
@@ -1,5 +1,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest';
 import { tick } from 'svelte';
+import { afterCardsProgression } from './__fixtures__/rewardProgressionPayloads.js';
 
 process.env.SVELTE_ALLOW_RUNES_OUTSIDE_SVELTE = 'true';
 globalThis.SVELTE_ALLOW_RUNES_OUTSIDE_SVELTE = true;
@@ -65,6 +66,37 @@ describe('RewardOverlay relic phase interactions', () => {
     expect(selectEvents.some((detail) => detail?.type === 'relic' && detail?.id === 'first-relic')).toBe(true);
     const highlighted = container.querySelector('.curio-shell.selected');
     expect(highlighted).not.toBeNull();
+  });
+
+  test('applies selected styling in the no-confirmation relic flow', async () => {
+    updateRewardProgression(afterCardsProgression());
+
+    const { container } = render(RewardOverlay, {
+      props: {
+        ...baseProps,
+        relics: [
+          { id: 'first-relic', name: 'First Relic' },
+          { id: 'second-relic', name: 'Second Relic' }
+        ],
+        reducedMotion: false,
+        awaitingRelic: false
+      }
+    });
+
+    const secondRelicButton = container.querySelector(
+      'button[aria-label="Select relic Second Relic"]'
+    );
+    expect(secondRelicButton).not.toBeNull();
+    if (!secondRelicButton) return;
+
+    await fireEvent.click(secondRelicButton);
+    await tick();
+
+    const shell = secondRelicButton.closest('.curio-shell');
+    expect(shell).not.toBeNull();
+    expect(shell?.classList.contains('selected')).toBe(true);
+    expect(shell?.classList.contains('confirmable')).toBe(false);
+    expect(shell?.dataset.reducedMotion).toBe('false');
   });
 
   test('shows on-tile confirm controls for the staged relic', async () => {

--- a/frontend/vitest.setup.js
+++ b/frontend/vitest.setup.js
@@ -1,6 +1,6 @@
 import { beforeAll } from 'vitest';
 import { state as svelteState } from 'svelte/internal/client';
-import 'svelte/internal/flags/legacy.js';
+import 'svelte/internal/flags/legacy';
 
 process.env.SVELTE_ALLOW_RUNES_OUTSIDE_SVELTE = 'true';
 globalThis.SVELTE_ALLOW_RUNES_OUTSIDE_SVELTE = true;


### PR DESCRIPTION
## Summary
- ensure reward cards and curios apply the wiggle animation whenever they are selected and reduced motion is enabled
- update Vitest and Bun test setups to load Svelte's legacy flag entry point via the supported subpath
- extend the reward overlay card and relic phase suites to verify selected styling without the confirmation flow

## Testing
- bun x vitest run tests/reward-overlay-card-phase.vitest.js *(fails: Vitest exits early with `Unknown Error: [object Object]` before collecting tests)*

------
https://chatgpt.com/codex/tasks/task_b_68f780f4852c832c8c2e975d740ecbcd