### PR TITLE
Simplify reward overlay to single-click selection

### DIFF
--- a/frontend/src/lib/components/CurioChoice.svelte
+++ b/frontend/src/lib/components/CurioChoice.svelte
@@ -3,7 +3,6 @@
   import Tooltip from './Tooltip.svelte';
   import { createEventDispatcher } from 'svelte';
   import { selectionAnimationCssVariables } from '../constants/rewardAnimationTokens.js';
-  import { rewardConfirmCssVariables } from '../constants/rewardConfirmTokens.js';
 
   export let entry = {};
   export let size = 'normal';
@@ -12,9 +11,6 @@
   export let fluid = false;
   export let selectionKey = '';
   export let selected = false;
-  export let confirmable = false;
-  export let confirmDisabled = false;
-  export let confirmLabel = 'Confirm';
   export let reducedMotion = false;
   export let disabled = false;
 
@@ -24,25 +20,12 @@
   const selectionAnimationStyle = Object.entries(selectionAnimationVars)
     .map(([key, value]) => `${key}: ${value}`)
     .join('; ');
-  const confirmButtonVars = rewardConfirmCssVariables();
-  const confirmButtonStyle = Object.entries(confirmButtonVars)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join('; ');
-
   function dispatchSelect() {
     dispatch('select', { type: 'relic', id: entry?.id, entry, key: selectionKey });
   }
 
-  function dispatchConfirm() {
-    dispatch('confirm', { type: 'relic', id: entry?.id, entry, key: selectionKey });
-  }
-
   function handleClick() {
     if (disabled) return;
-    if (confirmable && selected && !confirmDisabled) {
-      dispatchConfirm();
-      return;
-    }
     dispatchSelect();
   }
 
@@ -52,10 +35,6 @@
     if (disabled) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      if (confirmable && selected && !confirmDisabled) {
-        dispatchConfirm();
-        return;
-      }
       dispatchSelect();
     }
   };
@@ -66,7 +45,6 @@
     <div
       class="curio-shell"
       class:selected={selected}
-      class:confirmable={confirmable}
       data-reduced-motion={reducedMotion ? 'true' : 'false'}
       style={selectionAnimationStyle}
     >
@@ -90,28 +68,12 @@
           {fluid}
         />
       </button>
-      {#if confirmable}
-        <button
-          class="curio-confirm reward-confirm-button"
-          type="button"
-          aria-label={`Confirm relic ${entry?.name || entry?.id || 'selection'}`}
-          data-reward-confirm="relic"
-          disabled={confirmDisabled}
-          style={confirmButtonStyle}
-          on:click={() => {
-            if (!confirmDisabled) dispatchConfirm();
-          }}
-        >
-          {confirmLabel}
-        </button>
-      {/if}
     </div>
   </Tooltip>
 {:else}
   <div
     class="curio-shell"
     class:selected={selected}
-    class:confirmable={confirmable}
     data-reduced-motion={reducedMotion ? 'true' : 'false'}
     style={selectionAnimationStyle}
   >
@@ -127,27 +89,11 @@
     >
       <CardArt {entry} type="relic" roundIcon={true} {size} {quiet} {compact} {fluid} />
     </button>
-    {#if confirmable}
-      <button
-        class="curio-confirm reward-confirm-button"
-        type="button"
-        aria-label={`Confirm relic ${entry?.name || entry?.id || 'selection'}`}
-        data-reward-confirm="relic"
-        disabled={confirmDisabled}
-        style={confirmButtonStyle}
-        on:click={() => {
-          if (!confirmDisabled) dispatchConfirm();
-        }}
-      >
-        {confirmLabel}
-      </button>
-    {/if}
   </div>
 {/if}
 
 <style>
-  @import '../styles/reward-confirm.css';
-
+  
   .curio-shell {
     position: relative;
     display: flex;
@@ -213,14 +159,6 @@
 
   .curio-shell[data-reduced-motion='true'] :global(.card-art) {
     animation: none;
-  }
-
-  .curio-shell.confirmable .curio-confirm {
-    display: inline-flex;
-  }
-
-  .curio-confirm {
-    display: none;
   }
 
   /* Tooltip visuals are provided by Tooltip.svelte + settings-shared.css */

--- a/frontend/src/lib/components/GameViewport.svelte
+++ b/frontend/src/lib/components/GameViewport.svelte
@@ -431,8 +431,6 @@
       on:pauseCombat={() => dispatch('pauseCombat')}
       on:resumeCombat={() => dispatch('resumeCombat')}
       on:rewardSelect={(e) => dispatch('rewardSelect', e.detail)}
-      on:rewardConfirm={(e) => dispatch('rewardConfirm', e.detail)}
-      on:rewardCancel={(e) => dispatch('rewardCancel', e.detail)}
       on:rewardAdvance={(e) => dispatch('rewardAdvance', e.detail)}
       on:nextRoom={() => dispatch('nextRoom')}
       on:lootAcknowledge={() => dispatch('lootAcknowledge')}

--- a/frontend/src/lib/components/OverlayHost.svelte
+++ b/frontend/src/lib/components/OverlayHost.svelte
@@ -498,8 +498,6 @@
       {fullIdleMode}
       reducedMotion={overlayReducedMotion}
       on:select={(e) => dispatch('rewardSelect', e.detail)}
-      on:confirm={(e) => dispatch('rewardConfirm', e.detail)}
-      on:cancel={(e) => dispatch('rewardCancel', e.detail)}
       on:advance={(e) => dispatch('rewardAdvance', e.detail)}
       on:next={() => dispatch('nextRoom')}
       on:lootAcknowledge={() => dispatch('lootAcknowledge')}

--- a/frontend/src/lib/components/RewardCard.svelte
+++ b/frontend/src/lib/components/RewardCard.svelte
@@ -3,7 +3,6 @@
   import Tooltip from './Tooltip.svelte';
   import { createEventDispatcher } from 'svelte';
   import { selectionAnimationCssVariables } from '../constants/rewardAnimationTokens.js';
-  import { rewardConfirmCssVariables } from '../constants/rewardConfirmTokens.js';
   export let entry = {};
   export let type = 'card';
   export let size = 'normal';
@@ -11,9 +10,6 @@
   export let fluid = false;
   export let selectionKey = '';
   export let selected = false;
-  export let confirmable = false;
-  export let confirmDisabled = false;
-  export let confirmLabel = 'Confirm';
   export let reducedMotion = false;
   const dispatch = createEventDispatcher();
   // enable usage as a normal button too
@@ -28,25 +24,13 @@
   const selectionAnimationStyle = Object.entries(selectionAnimationVars)
     .map(([key, value]) => `${key}: ${value}`)
     .join('; ');
-  const confirmButtonVars = rewardConfirmCssVariables();
-  const confirmButtonStyle = Object.entries(confirmButtonVars)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join('; ');
 
   function dispatchSelect() {
     dispatch('select', { type, id: entry?.id, entry, key: selectionKey });
   }
 
-  function dispatchConfirm() {
-    dispatch('confirm', { type, id: entry?.id, entry, key: selectionKey });
-  }
-
   function handleClick() {
     if (disabled) return;
-    if (confirmable && selected && !confirmDisabled) {
-      dispatchConfirm();
-      return;
-    }
     dispatchSelect();
   }
 
@@ -54,10 +38,6 @@
     if (disabled) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
-      if (confirmable && selected && !confirmDisabled) {
-        dispatchConfirm();
-        return;
-      }
       dispatchSelect();
     }
   };
@@ -71,7 +51,6 @@
     <div
       class="card-shell"
       class:selected={selected}
-      class:confirmable={confirmable}
       data-reduced-motion={reducedMotion ? 'true' : 'false'}
       style={selectionAnimationStyle}
     >
@@ -88,28 +67,12 @@
       >
         <CardArt {entry} {type} {size} hideFallback={true} {quiet} {fluid} />
       </button>
-      {#if confirmable}
-        <button
-          class="card-confirm reward-confirm-button"
-          type="button"
-          aria-label={`Confirm card ${entry?.name || entry?.id || 'selection'}`}
-          data-reward-confirm="card"
-          disabled={confirmDisabled}
-          style={confirmButtonStyle}
-          on:click={() => {
-            if (!confirmDisabled) dispatchConfirm();
-          }}
-        >
-          {confirmLabel}
-        </button>
-      {/if}
     </div>
   </Tooltip>
 {:else}
   <div
     class="card-shell"
     class:selected={selected}
-    class:confirmable={confirmable}
     data-reduced-motion={reducedMotion ? 'true' : 'false'}
     style={selectionAnimationStyle}
   >
@@ -126,27 +89,10 @@
     >
       <CardArt {entry} {type} {size} hideFallback={true} {quiet} {fluid} />
     </button>
-    {#if confirmable}
-      <button
-        class="card-confirm reward-confirm-button"
-        type="button"
-        aria-label={`Confirm card ${entry?.name || entry?.id || 'selection'}`}
-        data-reward-confirm="card"
-        disabled={confirmDisabled}
-        style={confirmButtonStyle}
-        on:click={() => {
-          if (!confirmDisabled) dispatchConfirm();
-        }}
-      >
-        {confirmLabel}
-      </button>
-    {/if}
   </div>
 {/if}
 
 <style>
-  @import '../styles/reward-confirm.css';
-
   .card-shell {
     position: relative;
     display: flex;
@@ -178,10 +124,6 @@
   }
   .card-shell.selected .card {
     filter: drop-shadow(0 8px 18px rgba(20, 80, 160, 0.55));
-  }
-
-  .card-shell.confirmable .card-confirm {
-    display: inline-flex;
   }
 
   @keyframes reward-selection-wiggle {
@@ -217,8 +159,5 @@
     animation: none;
   }
 
-  .card-confirm {
-    display: none;
-  }
   /* Tooltip visuals are provided by Tooltip.svelte + settings-shared.css */
 </style>

--- a/frontend/src/lib/utils/rewardAutomation.js
+++ b/frontend/src/lib/utils/rewardAutomation.js
@@ -19,16 +19,8 @@ function shouldUseLegacyAutomation(snapshot) {
 function computeLegacyAction({ roomData, stagedCards, stagedRelics }) {
   if (!roomData) return { type: 'none' };
 
-  if (roomData.awaiting_card && stagedCards.length > 0) {
-    return { type: 'confirm-card' };
-  }
-
   if (Array.isArray(roomData.card_choices) && roomData.card_choices.length > 0) {
     return { type: 'select-card', choice: roomData.card_choices[0] };
-  }
-
-  if (roomData.awaiting_relic && stagedRelics.length > 0) {
-    return { type: 'confirm-relic' };
   }
 
   if (!roomData.awaiting_card && Array.isArray(roomData.relic_choices) && roomData.relic_choices.length > 0) {
@@ -65,9 +57,6 @@ function computePhaseAction({ roomData, snapshot, stagedCards, stagedRelics }) {
       break;
     }
     case 'cards': {
-      if (roomData.awaiting_card && stagedCards.length > 0) {
-        return { type: 'confirm-card' };
-      }
       if (Array.isArray(roomData.card_choices) && roomData.card_choices.length > 0) {
         return { type: 'select-card', choice: roomData.card_choices[0] };
       }
@@ -77,9 +66,6 @@ function computePhaseAction({ roomData, snapshot, stagedCards, stagedRelics }) {
       break;
     }
     case 'relics': {
-      if (roomData.awaiting_relic && stagedRelics.length > 0) {
-        return { type: 'confirm-relic' };
-      }
       if (!roomData.awaiting_card && Array.isArray(roomData.relic_choices) && roomData.relic_choices.length > 0) {
         return { type: 'select-relic', choice: roomData.relic_choices[0] };
       }

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -11,10 +11,6 @@
     roomAction,
     chooseCard,
     chooseRelic,
-    confirmCard,
-    confirmRelic,
-    cancelCard,
-    cancelRelic,
     advanceRoom,
     getMap,
     getActiveRuns,
@@ -1095,82 +1091,6 @@
     return result;
   }
 
-  async function handleRewardConfirm(detail) {
-    const payload = detail && typeof detail === 'object' ? detail : {};
-    const respond = typeof payload.respond === 'function' ? payload.respond : null;
-    const type = payload.type;
-    let result = { ok: false };
-
-    if (type === 'card' || type === 'relic') {
-      try {
-        const res = type === 'card' ? await confirmCard() : await confirmRelic();
-        if (res) {
-          applyRewardPayload(res, { type, intent: 'confirm' });
-          scheduleMapRefresh();
-        }
-        result = { ok: true };
-      } catch (error) {
-        openOverlay('error', {
-          message: 'Failed to confirm reward.',
-          traceback: (error && error.stack) || '',
-          context: error?.context ?? null
-        });
-        try {
-          if (dev || !browser) {
-            const { error: logError } = await import('$lib/systems/logger.js');
-            logError('Failed to confirm reward.', error);
-          }
-        } catch {}
-      }
-    }
-
-    if (respond) {
-      try {
-        respond(result);
-      } catch {}
-    }
-
-    return result;
-  }
-
-  async function handleRewardCancel(detail) {
-    const payload = detail && typeof detail === 'object' ? detail : {};
-    const respond = typeof payload.respond === 'function' ? payload.respond : null;
-    const type = payload.type;
-    let result = { ok: false };
-
-    if (type === 'card' || type === 'relic') {
-      try {
-        const res = type === 'card' ? await cancelCard() : await cancelRelic();
-        if (res) {
-          applyRewardPayload(res, { type, intent: 'cancel' });
-          scheduleMapRefresh();
-        }
-        result = { ok: true };
-      } catch (error) {
-        openOverlay('error', {
-          message: 'Failed to cancel reward.',
-          traceback: (error && error.stack) || '',
-          context: error?.context ?? null
-        });
-        try {
-          if (dev || !browser) {
-            const { error: logError } = await import('$lib/systems/logger.js');
-            logError('Failed to cancel reward.', error);
-          }
-        } catch {}
-      }
-    }
-
-    if (respond) {
-      try {
-        respond(result);
-      } catch {}
-    }
-
-    return result;
-  }
-
   async function handleRewardAdvance(detail) {
     const payload = detail && typeof detail === 'object' ? detail : {};
     const respond = typeof payload.respond === 'function' ? payload.respond : null;
@@ -1252,16 +1172,6 @@
       });
 
       switch (action.type) {
-        case 'confirm-card': {
-          try {
-            const res = await confirmCard();
-            if (res) {
-              applyRewardPayload(res, { type: 'card', intent: 'confirm' });
-              scheduleMapRefresh();
-            }
-          } catch {}
-          return;
-        }
         case 'select-card': {
           if (action.choice) {
             try {
@@ -1271,16 +1181,6 @@
               }
             } catch {}
           }
-          return;
-        }
-        case 'confirm-relic': {
-          try {
-            const res = await confirmRelic();
-            if (res) {
-              applyRewardPayload(res, { type: 'relic', intent: 'confirm' });
-              scheduleMapRefresh();
-            }
-          } catch {}
           return;
         }
         case 'select-relic': {
@@ -1804,8 +1704,6 @@
     on:home={homeOverlay}
     on:settings={() => openOverlay('settings')}
     on:rewardSelect={(e) => handleRewardSelect(e.detail)}
-    on:rewardConfirm={(e) => handleRewardConfirm(e.detail)}
-    on:rewardCancel={(e) => handleRewardCancel(e.detail)}
     on:rewardAdvance={(e) => handleRewardAdvance(e.detail)}
     on:loadRun={(e) => handleLoadExistingRun(e.detail)}
     on:startNewRun={handleStartNewRun}

--- a/frontend/tests/reward-automation.vitest.js
+++ b/frontend/tests/reward-automation.vitest.js
@@ -55,7 +55,7 @@ describe('reward automation helpers', () => {
     expect(action.choice).toEqual({ id: 'a' });
   });
 
-  test('confirms card when awaiting confirmation', () => {
+  test('pauses when awaiting card resolution without new choices', () => {
     const roomData = {
       awaiting_card: true,
       reward_staging: { cards: [{ id: 'a' }] }
@@ -65,7 +65,7 @@ describe('reward automation helpers', () => {
       snapshot: snapshotFor('cards'),
       stagedCards: [{ id: 'a' }]
     });
-    expect(action.type).toBe('confirm-card');
+    expect(action.type).toBe('none');
   });
 
   test('advances when card phase has no choices or staging', () => {

--- a/frontend/tests/reward-overlay-card-phase.vitest.js
+++ b/frontend/tests/reward-overlay-card-phase.vitest.js
@@ -70,7 +70,7 @@ describe('RewardOverlay card phase interactions', () => {
     ).not.toBeNull();
   });
 
-  test('shows on-card confirm controls for the staged card', async () => {
+  test('renders staged card without confirm controls', async () => {
     updateRewardProgression(fourPhaseProgression({ current_step: 'cards', completed: ['drops'] }));
 
     const stagedCard = {
@@ -79,7 +79,7 @@ describe('RewardOverlay card phase interactions', () => {
       stars: 4
     };
 
-    const { getByRole, container } = render(RewardOverlay, {
+    const { container } = render(RewardOverlay, {
       props: {
         cards: [stagedCard],
         stagedCards: [stagedCard],
@@ -95,16 +95,15 @@ describe('RewardOverlay card phase interactions', () => {
 
     await tick();
 
-    const confirmButton = getByRole('button', { name: 'Confirm card Radiant Beam' });
-    expect(confirmButton).toBeTruthy();
-
-    const confirmableShell = container.querySelector('.card-shell.confirmable');
-    expect(confirmableShell).not.toBeNull();
-    expect(confirmableShell?.dataset.reducedMotion).toBe('false');
-    expect(confirmableShell?.classList.contains('selected')).toBe(true);
+    expect(container.querySelector('.card-shell.confirmable')).toBeNull();
+    const confirmButton = container.querySelector('button.card-confirm');
+    expect(confirmButton).toBeNull();
+    const stagedShell = container.querySelector('.card-shell.selected');
+    expect(stagedShell).not.toBeNull();
+    expect(stagedShell?.dataset.reducedMotion).toBe('false');
   });
 
-  test('dispatches confirm when clicking the selected card again', async () => {
+  test('re-dispatches select when clicking the staged card again', async () => {
     updateRewardProgression(fourPhaseProgression({ current_step: 'cards', completed: ['drops'] }));
 
     const stagedCard = {
@@ -112,6 +111,8 @@ describe('RewardOverlay card phase interactions', () => {
       name: 'Echo Strike',
       stars: 5
     };
+
+    const selectHandler = vi.fn();
 
     const { component, getByLabelText } = render(RewardOverlay, {
       props: {
@@ -127,10 +128,9 @@ describe('RewardOverlay card phase interactions', () => {
       }
     });
 
-    const confirmHandler = vi.fn();
-    component.$on('confirm', (event) => {
+    component.$on('select', (event) => {
       if (event.detail?.type === 'card') {
-        confirmHandler(event.detail);
+        selectHandler(event.detail);
       }
     });
 
@@ -138,8 +138,8 @@ describe('RewardOverlay card phase interactions', () => {
     await fireEvent.click(cardButton);
     await tick();
 
-    expect(confirmHandler).toHaveBeenCalledTimes(1);
-    expect(confirmHandler.mock.calls[0][0]?.id).toBe('echo-strike');
+    expect(selectHandler).toHaveBeenCalledTimes(1);
+    expect(selectHandler.mock.calls[0][0]?.id).toBe('echo-strike');
   });
 
   test('applies selected styling in the no-confirmation card flow', async () => {

--- a/frontend/tests/reward-overlay-flow-regression.vitest.js
+++ b/frontend/tests/reward-overlay-flow-regression.vitest.js
@@ -39,7 +39,7 @@ afterEach(() => {
 });
 
 describe('reward overlay multi-phase regression', () => {
-  test('walks through the four-phase flow with confirm hooks', async () => {
+  test('walks through the four-phase flow with single-click selection', async () => {
     updateRewardProgression(fourPhaseProgression());
 
     const cards = [
@@ -55,7 +55,7 @@ describe('reward overlay multi-phase regression', () => {
     ];
 
     const advanceEvents = [];
-    const confirmEvents = [];
+    const selectEvents = [];
 
     const { component, container } = render(RewardOverlay, {
       props: {
@@ -85,8 +85,8 @@ describe('reward overlay multi-phase regression', () => {
       }
     });
 
-    component.$on('confirm', (event) => {
-      confirmEvents.push(event.detail);
+    component.$on('select', (event) => {
+      selectEvents.push(event.detail);
       event.detail?.respond?.({ ok: true });
       if (event.detail?.type === 'card') {
         queueMicrotask(() => {
@@ -135,33 +135,35 @@ describe('reward overlay multi-phase regression', () => {
     });
     await tick();
 
-    const cardConfirmButton = container.querySelector(
-      '.card-shell.confirmable button.card-confirm'
+    expect(container.querySelector('.card-shell.confirmable')).toBeNull();
+    const cardButton = container.querySelector(
+      'button[aria-label="Select card Radiant Beam"]'
     );
-    expect(cardConfirmButton).toBeInstanceOf(HTMLButtonElement);
-    if (cardConfirmButton instanceof HTMLButtonElement) {
-      await fireEvent.click(cardConfirmButton);
+    expect(cardButton).toBeInstanceOf(HTMLButtonElement);
+    if (cardButton instanceof HTMLButtonElement) {
+      await fireEvent.click(cardButton);
     }
 
     await tick();
     await tick();
 
-    expect(confirmEvents.some((detail) => detail?.type === 'card')).toBe(true);
+    expect(selectEvents.some((detail) => detail?.type === 'card')).toBe(true);
 
     await tick();
 
-    const relicConfirmButton = container.querySelector(
-      '.curio-shell.confirmable button.curio-confirm'
+    expect(container.querySelector('.curio-shell.confirmable')).toBeNull();
+    const relicButton = container.querySelector(
+      'button[aria-label="Select relic Guardian Talisman"]'
     );
-    expect(relicConfirmButton).toBeInstanceOf(HTMLButtonElement);
-    if (relicConfirmButton instanceof HTMLButtonElement) {
-      await fireEvent.click(relicConfirmButton);
+    expect(relicButton).toBeInstanceOf(HTMLButtonElement);
+    if (relicButton instanceof HTMLButtonElement) {
+      await fireEvent.click(relicButton);
     }
 
     await tick();
     await tick();
 
-    expect(confirmEvents.some((detail) => detail?.type === 'relic')).toBe(true);
+    expect(selectEvents.some((detail) => detail?.type === 'relic')).toBe(true);
 
     await tick();
 


### PR DESCRIPTION
## Summary
- remove the reward confirm/cancel flow so card and relic selections finalize immediately
- strip confirm plumbing from RewardCard/CurioChoice and the viewport/overlay hosts that listened for confirm or cancel
- update reward automation and overlay tests to reflect the single-click interaction model

## Testing
- bun x vitest run tests/reward-overlay-card-phase.vitest.js tests/reward-overlay-relic-phase.vitest.js tests/reward-overlay-selection-regression.vitest.js tests/reward-overlay-flow-regression.vitest.js tests/reward-automation.vitest.js *(fails: Vitest reports unhandled errors tied to Svelte lifecycle_function_unavailable when running these suites)*

------
https://chatgpt.com/codex/tasks/task_b_68f7871447ec832cb092970c7bfc200b