### PR TITLE
[FIX] Require explicit card reward selection before advancing

### DIFF
--- a/backend/.codex/implementation/reward-progression.md
+++ b/backend/.codex/implementation/reward-progression.md
@@ -2,11 +2,23 @@
 
 The map state blocks advancing to the next room while any post-battle rewards remain unresolved. Three boolean flags gate this progression:
 
-- `awaiting_card` – set when a card reward is offered. If the battle yields no card, this flag stays `False` and does not block advancement.
-- `awaiting_relic` – set when a relic reward is pending. Runs without relic drops leave this flag `False`.
-- `awaiting_loot` – reserved for manual loot flows. The backend currently auto-collects gold and similar drops, so this flag is usually `False`.
+- `awaiting_card` – set when a card reward is offered. If the battle yields no
+  card, this flag stays `False` and does not block advancement. When card
+  options are generated they are also written to `card_choice_options` in the
+  map state so reconnecting clients can validate selections against the original
+  pool.
+- `awaiting_relic` – set when a relic reward is pending. Runs without relic drops
+  leave this flag `False`.
+- `awaiting_loot` – reserved for manual loot flows. The backend currently
+  auto-collects gold and similar drops, so this flag is usually `False`.
 
-`advance_room` refuses to progress while any of these flags are `True`. The UI action handler returns an HTTP 400 error when a client attempts to advance with pending rewards, and the `run_service.advance_room` function raises a `ValueError` so direct calls cannot bypass the restriction.
+`advance_room` refuses to progress while any of these flags are `True`. The UI
+action handler returns an HTTP 400 error when a client attempts to advance with
+pending rewards, and the `run_service.advance_room` function raises a
+`ValueError` so direct calls cannot bypass the restriction. When a staged card
+selection is present the handler auto-confirms it before advancing, allowing
+progress once a valid choice arrives while still rejecting attempts that provide
+no selection.
 
 Reward sequences also use a `reward_progression` structure to represent the
 remaining post-battle phases. The payload always exposes `available`,
@@ -27,8 +39,10 @@ items. When a player chooses a card or relic the backend appends a serialized
 entry to the appropriate bucket instead of mutating the party immediately.
 
 Because staged rewards are not yet confirmed the original `awaiting_*` flags are
-left `True` until a follow-up confirmation API applies the staged payload. This
-keeps room advancement blocked and ensures reconnecting clients still present a
-confirmation overlay. Downstream code must rely on `reward_staging` to surface
-the selected reward while continuing to treat the party roster as unchanged until
-confirmation succeeds.
+left `True` until a follow-up confirmation API applies the staged payload. For
+card rewards the `advance_room` handler now performs this confirmation step when
+it detects a staged card, so a run cannot advance without an explicit selection
+but no longer requires a dedicated confirmation call. Downstream code must rely
+on `reward_staging` to surface the selected reward while continuing to treat the
+party roster as unchanged until confirmation succeeds (either via the explicit
+confirmation APIs or the implicit confirmation triggered by `advance_room`).

--- a/backend/runs/lifecycle.py
+++ b/backend/runs/lifecycle.py
@@ -720,7 +720,8 @@ async def _run_battle(
                 battle_tasks.pop(run_id, None)
                 battle_locks.pop(run_id, None)
                 return
-            has_card_choices = bool(result.get("card_choices"))
+            raw_card_choices = result.get("card_choices")
+            has_card_choices = bool(raw_card_choices)
             has_relic_choices = bool(result.get("relic_choices"))
             loot_payload = result.get("loot", {})
             loot_gold_raw = 0
@@ -735,6 +736,14 @@ async def _run_battle(
             has_loot = has_loot_gold or has_loot_items
 
             state["awaiting_card"] = has_card_choices
+            if has_card_choices:
+                state["card_choice_options"] = [
+                    dict(choice)
+                    for choice in raw_card_choices
+                    if isinstance(choice, Mapping)
+                ]
+            else:
+                state.pop("card_choice_options", None)
             state["awaiting_relic"] = has_relic_choices
             state["awaiting_loot"] = has_loot
 


### PR DESCRIPTION
## Summary
- persist card reward options in the run state and validate card selections against the offered pool
- ensure advance_room auto-confirms staged card rewards only after an explicit selection arrives and update the reward docs
- expand the reward gate tests to cover the new card-selection flow and advancing once a choice is made

## Testing
- [x] Backend tests (`uv run pytest tests/test_reward_gate.py`)
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68f8e525ff80832c850f5eb66e7b3ff0