### PR TITLE
fix: declare reward confirmation state

### DIFF
--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -61,6 +61,16 @@
   let relicChoiceEntryMap = new Map();
   let queuedCardConfirmation = null;
   let queuedRelicConfirmation = null;
+  let showCardConfirmation = false;
+  let showRelicConfirmation = false;
+  let cardConfirmEntry = null;
+  let relicConfirmEntry = null;
+  let cardConfirmLabel = '';
+  let relicConfirmLabel = '';
+  let cardConfirmDescription = 'Card selection';
+  let relicConfirmDescription = 'Relic selection';
+  let cardConfirmDisabled = true;
+  let relicConfirmDisabled = true;
 
   onMount(() => {
     const exitDisposer = rewardPhaseController.on('exit', (detail) => {


### PR DESCRIPTION
## Summary
- declare reward confirmation state variables in RewardOverlay before reactive assignments
- initialize confirmation labels, descriptions, and disabled flags with sensible defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68f8eb18b9b0832c880abe04eb896943