### PR TITLE
Keep relic grid visible during staged confirmation

### DIFF
--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -732,9 +732,10 @@
   let autoRelicSelectionInFlight = false;
 
   $: cardSelectionLocked = pendingCardSelection !== null;
-  $: relicSelectionLocked = pendingRelicSelection !== null || stagedRelicEntries.length > 0;
   $: showCards = cardChoiceEntries.length > 0;
-  $: showRelics = relicChoiceEntries.length > 0 && !awaitingCard && !relicSelectionLocked;
+  $: hasRelicChoices = relicChoiceEntries.length > 0;
+  $: hasStagedRelics = stagedRelicEntries.length > 0;
+  $: showRelics = (hasRelicChoices || hasStagedRelics) && !awaitingCard;
 
   $: selectionInFlight = pendingCardSelection !== null || pendingRelicSelection !== null;
 

--- a/frontend/tests/reward-overlay-relic-phase.vitest.js
+++ b/frontend/tests/reward-overlay-relic-phase.vitest.js
@@ -141,6 +141,45 @@ describe('RewardOverlay relic phase interactions', () => {
     expect(stagedShell?.classList.contains('selected')).toBe(true);
   });
 
+  test('keeps relic grid and confirmation controls visible during staged confirmation', async () => {
+    updateRewardProgression({
+      available: ['cards', 'relics', 'battle_review'],
+      completed: ['cards'],
+      current_step: 'relics'
+    });
+
+    const relicPool = [
+      { id: 'moon-charm', name: 'Moon Charm' },
+      { id: 'sun-charm', name: 'Sun Charm' }
+    ];
+
+    const { container, getByRole, getByText } = render(RewardOverlay, {
+      props: {
+        ...baseProps,
+        relics: relicPool,
+        stagedRelics: [relicPool[0]],
+        awaitingRelic: true
+      }
+    });
+
+    await tick();
+
+    const relicHeading = getByText('Choose a Relic');
+    expect(relicHeading).not.toBeNull();
+
+    const relicGrid = relicHeading?.nextElementSibling;
+    expect(relicGrid).not.toBeNull();
+    expect(relicGrid?.classList.contains('choices')).toBe(true);
+    expect(relicGrid?.querySelectorAll('.curio-shell').length ?? 0).toBeGreaterThan(0);
+
+    const confirmGroup = getByRole('group', { name: 'Confirm relic selection' });
+    expect(confirmGroup).not.toBeNull();
+
+    const confirmButton = confirmGroup?.querySelector('button');
+    expect(confirmButton).not.toBeNull();
+    expect(confirmButton?.textContent?.trim()).toBe('Confirm');
+  });
+
   test('requires a second click on the highlighted relic to confirm', async () => {
     updateRewardProgression({
       available: ['relics'],


### PR DESCRIPTION
## Summary
- ensure the relic choices grid remains visible while a relic is staged so the confirmation panel matches the cards flow
- extend the relic phase vitest suite with coverage that verifies the choices grid and confirmation controls stay mounted during staging

## Testing
- bun install
- bun test *(fails: tests/pullresultsoverlay.test.js expects `catch((error) => {` in PullResultsOverlay markup)*

------
https://chatgpt.com/codex/tasks/task_b_68f90daf8b60832c8d2f8256bce79625