### PR TITLE
Fix relic reward selection opacity

### DIFF
--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -1730,13 +1730,15 @@
     animation-delay: var(--delay, 0ms);
   }
 
-  /* Fix for card selection visual bug: Ensure selected cards have full opacity
-     to prevent reveal animation interference. The reveal animation sets opacity: 0
-     initially and animates to opacity: 1. When a card is selected, the wiggle animation
-     is applied, but the reveal animation's opacity property can interfere, causing the
-     card to disappear. This rule ensures selected cards always have opacity: 1 regardless
-     of the reveal animation state. */
-  .reveal :global(.card-shell.selected .card-art) {
+  /* Fix for reward selection visual bug: Ensure selected cards and relics have
+     full opacity to prevent reveal animation interference. The reveal animation
+     sets opacity: 0 initially and animates to opacity: 1. When a reward is
+     selected, the wiggle animation is applied, but the reveal animation's
+     opacity property can interfere, causing the reward to disappear. These
+     rules ensure selected rewards always have opacity: 1 regardless of the
+     reveal animation state. */
+  .reveal :global(.card-shell.selected .card-art),
+  .reveal :global(.curio-shell.selected .card-art) {
     opacity: 1 !important;
   }
 


### PR DESCRIPTION
## Summary
- ensure reward overlay reveal animation keeps selected relic art visible
- update comment to reflect handling for both cards and relics

## Testing
- bun test tests/audio-settings.test.js

------
https://chatgpt.com/codex/tasks/task_b_68f915f1f614832cb0e99050e1d25143