### PR TITLE
feat(frontend): streamline reward confirmation flow

### DIFF
--- a/frontend/.codex/implementation/reward-overlay.md
+++ b/frontend/.codex/implementation/reward-overlay.md
@@ -42,7 +42,7 @@ four explicit phases:
 | Phase key        | UI surface                                                                      |
 | ---------------- | ------------------------------------------------------------------------------- |
 | `drops`          | Drops grid, sequential reveal, no confirm controls.                              |
-| `cards`          | Card staging grid with highlight, wiggle animation, and on-card confirm button.  |
+| `cards`          | Card staging grid with highlight, wiggle animation, and double-click/Advance confirm support. |
 | `relics`         | Relic staging grid mirroring the card interaction model.                         |
 | `battle_review`  | Post-battle graphs and summary shell mounted via `BattleReview.svelte`.          |
 
@@ -60,15 +60,18 @@ phase transitions to screen readers, and publish analytics through
 ## Confirmation flow for staged rewards
 
 When the backend marks `awaiting_card` or `awaiting_relic` as `true` and
-provides staged entries under `reward_staging`, the overlay now surfaces a
-dedicated confirmation block. The highlighted card or relic keeps the primary
-grid visible so re-selection can happen without cancelling, auto-selects the
-first available option on entry, and renders a stained-glass **Confirm** button
-directly beneath the highlighted tile. The highlight applies a looping wiggle
-animation defined in `frontend/src/lib/constants/rewardAnimationTokens.js`;
-motion honours the player's reduced-motion preference. Second clicks (or
-keyboard activation) on the highlighted tile dispatch the confirm event
-immediately, matching the on-card button.
+provides staged entries under `reward_staging`, the overlay keeps the main
+selection grid visible and auto-selects the first available option on entry.
+The highlighted card or relic continues to use the shared wiggle animation from
+`frontend/src/lib/constants/rewardAnimationTokens.js` so staged entries remain
+obvious while respecting the player's reduced-motion preference. Instead of a
+dedicated confirmation block, the right-rail **Advance** panel switches into a
+confirm mode: its copy announces the highlighted reward, the button's
+`aria-label` becomes `Confirm Card …`/`Confirm Relic …`, and the helper note
+reminds players that Advance performs the confirmation when double-click is not
+available. Second clicks (or keyboard activation) on the highlighted tile still
+dispatch the confirm event immediately, so pointer and keyboard flows behave as
+before while the fallback lives in the shared Advance control.
 
 ### Stained-glass theme alignment
 
@@ -80,7 +83,7 @@ frosted glass. Status chips, preview panes, and loot tiles share a common
 `--overlay-chip-*` token set that keeps their borders crisp and neutral until
 the active state introduces an accent tint.
 
-Primary action buttons (Advance, Cancel, Next Room) were flattened into the
+Primary action buttons (Advance and Next Room) were flattened into the
 same rectangular glass pads used elsewhere in the web UI. They still pick up
 the run accent colour on hover/focus, but lose the oversized glow and rounded
 pill silhouette so they sit flush with the rest of the interface.
@@ -88,23 +91,21 @@ pill silhouette so they sit flush with the rest of the interface.
 - `RewardOverlay` receives `stagedCards`, `stagedRelics`, and the
   `awaiting_*` flags from `OverlayHost`. Both grids stay visible while a staged
   entry is pending so players can reselect without cancelling.
-- Clicking **Confirm** (either the on-card button or the highlighted card a
-  second time) dispatches a `confirm` event with the reward metadata so the
-  caller can invoke `/ui?action=confirm_card` or `/ui?action=confirm_relic`.
-  The detail includes the reward `type`, currently staged `key`, resolved
-  `id`, a human-readable `label`, the originating `phase`, and the staged
-  `entry` object (if available) alongside the `respond({ ok })` callback.
-  Buttons stay disabled until the parent responds via the provided callback.
-  After a successful confirmation the frontend immediately prunes the resolved
-  choice bucket so the overlay transitions to the next reward step without
-  briefly reopening the spent selection view.
-- Clicking **Cancel** dispatches a matching `cancel` event that triggers the
-  `/ui?action=cancel_*` endpoints and restores the choice list once the staging
-  bucket is cleared.
+- Confirming via a second click (or keyboard activation) on the highlighted
+  tile dispatches a `confirm` event with the reward metadata so the caller can
+  invoke `/ui?action=confirm_card` or `/ui?action=confirm_relic`. The detail
+  includes the reward `type`, currently staged `key`, resolved `id`, a
+  human-readable `label`, the originating `phase`, and the staged `entry`
+  object (if available) alongside the `respond({ ok })` callback. Once the
+  parent responds with `{ ok: true }` the frontend prunes the resolved choice
+  bucket so the overlay transitions without reopening the spent selection.
+- Pressing **Advance** while confirm mode is active triggers the same confirm
+  path. The button exposes a `data-mode` attribute (`confirm-card`/`confirm-relic`)
+  so tests and automation can detect the fallback state.
 - Idle mode relies on these events as well. Automation confirms staged rewards
   instead of calling `advance_room`, keeping the overlay visible until the
   backend reports `awaiting_next`.
-- The overlay's auto-advance timer and "Next Room" button now respect staged
+- The overlay's auto-advance timer and "Next Room" button respect staged
   confirmations so players cannot accidentally skip unconfirmed rewards.
 
 This UI contract mirrors the backend guardrails introduced for staged rewards,
@@ -255,11 +256,11 @@ mid‑acknowledgement.
 - Focus automatically shifts to the **Advance** button when a phase becomes
   actionable and falls back to the overlay container when auto-advance fires,
   keeping keyboard flows predictable.
-- Confirm buttons reuse the stained-glass styling tokens but retain native
-  button semantics, so keyboard activation, focus rings, and screen reader
-  labelling stay consistent across cards and relics.
-- Live regions announce when confirm buttons appear or disappear so screen
-  reader users hear when staged selections are ready or cleared.
+- The Advance button keeps native button semantics when switching into confirm
+  mode, preserving keyboard activation, focus rings, and screen reader labelling
+  while the helper copy clarifies its temporary role.
+- Live regions announce when confirm mode engages or resolves so screen reader
+  users hear when staged selections are ready or cleared.
 - Countdown updates respect Reduced Motion; when motion is disabled the timer
   posts updates every two seconds instead of animating per-second fades.
 
@@ -273,6 +274,7 @@ mid‑acknowledgement.
 - Confirm that automation hooks (`advance` events) log both manual and auto
   reasons during idle-mode runs.
 - Navigate the overlay using only the keyboard: verify focus order is
-  Drops grid → **Advance** → staged confirm → **Advance** again after each phase.
-- With a screen reader, listen for announcements when confirm buttons appear,
-  disappear, and when the countdown reaches zero.
+  Drops grid → **Advance** → highlighted selection (confirm via second press) →
+  **Advance** again after each phase.
+- With a screen reader, listen for announcements when confirm mode engages or
+  clears and when the countdown reaches zero.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -62,11 +62,13 @@ Relics → Review:
 1. **Drops** — materials appear in a dedicated grid while floating pickups play
    out. The right rail lists the four phases but keeps the **Advance** button
    disabled until the controller marks Drops complete.
-2. **Cards** — the first card auto-selects with a stained-glass confirm button
-   mounted beneath the highlighted tile. Mouse, touch, and keyboard navigation
-   all dispatch `confirm_card` events through the overlay host.
+2. **Cards** — the first card auto-selects and wiggles to highlight the staged
+   pick. Double-clicking (or pressing the selection a second time) confirms
+   immediately, and the right-rail **Advance** button switches into a confirm
+   mode for single-tap or accessibility flows.
 3. **Relics** — mirrors the card interaction model, including staged
-   confirmations, reset handling, and the shared wiggle animation tokens.
+   confirmations, the Advance confirm fallback, reset handling, and the shared
+   wiggle animation tokens.
 4. **Battle Review** — mounts `BattleReview.svelte` with the familiar damage
    graphs and timeline view once all staged rewards resolve.
 

--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -61,16 +61,8 @@
   let relicChoiceEntryMap = new Map();
   let queuedCardConfirmation = null;
   let queuedRelicConfirmation = null;
-  let showCardConfirmation = false;
-  let showRelicConfirmation = false;
-  let cardConfirmEntry = null;
-  let relicConfirmEntry = null;
-  let cardConfirmLabel = '';
-  let relicConfirmLabel = '';
   let cardConfirmDescription = 'Card selection';
   let relicConfirmDescription = 'Relic selection';
-  let cardConfirmDisabled = true;
-  let relicConfirmDisabled = true;
 
   onMount(() => {
     const exitDisposer = rewardPhaseController.on('exit', (detail) => {
@@ -155,7 +147,6 @@
   let advanceInFlight = false;
   let confirmFallbackMode = null;
   let confirmFallbackKey = null;
-  let confirmFallbackLabel = '';
   let advancePanelActive = false;
   let advanceButtonMode = 'advance';
   let advanceHelperMessage = '';
@@ -811,24 +802,22 @@
     highlightedRelicKey = stagedRelicHighlightKey;
   }
 
-  $: showCardConfirmation = awaitingCard && stagedCardEntries.length > 0;
-  $: showRelicConfirmation = awaitingRelic && stagedRelicEntries.length > 0;
+  $: stagedCardSelection = awaitingCard && stagedCardEntries.length > 0 ? stagedCardEntries[0] : null;
+  $: stagedRelicSelection = awaitingRelic && stagedRelicEntries.length > 0 ? stagedRelicEntries[0] : null;
 
-  $: cardConfirmEntry = showCardConfirmation ? stagedCardEntries[0] : highlightedCardEntry;
-  $: relicConfirmEntry = showRelicConfirmation ? stagedRelicEntries[0] : highlightedRelicEntry;
+  $: cardConfirmDescription = (() => {
+    const entry = stagedCardSelection ?? highlightedCardEntry;
+    if (!entry) return 'Card selection';
+    const label = labelForRewardEntry(entry, 'card');
+    return describeRewardLabel('card', label);
+  })();
 
-  $: cardConfirmLabel = cardConfirmEntry ? labelForRewardEntry(cardConfirmEntry, 'card') : '';
-  $: relicConfirmLabel = relicConfirmEntry ? labelForRewardEntry(relicConfirmEntry, 'relic') : '';
-
-  $: cardConfirmDescription = cardConfirmLabel
-    ? describeRewardLabel('card', cardConfirmLabel)
-    : 'Card selection';
-  $: relicConfirmDescription = relicConfirmLabel
-    ? describeRewardLabel('relic', relicConfirmLabel)
-    : 'Relic selection';
-
-  $: cardConfirmDisabled = !showCardConfirmation || selectionInFlight || advanceBusy;
-  $: relicConfirmDisabled = !showRelicConfirmation || selectionInFlight || advanceBusy;
+  $: relicConfirmDescription = (() => {
+    const entry = stagedRelicSelection ?? highlightedRelicEntry;
+    if (!entry) return 'Relic selection';
+    const label = labelForRewardEntry(entry, 'relic');
+    return describeRewardLabel('relic', label);
+  })();
 
   $: {
     const cardReady =
@@ -855,14 +844,11 @@
     if (confirmFallbackMode === 'card') {
       const stagedEntry = stagedCardEntries[0] ?? null;
       confirmFallbackKey = stagedEntry ? rewardEntryKey(stagedEntry, 0, 'staged-card') : null;
-      confirmFallbackLabel = cardConfirmDescription;
     } else if (confirmFallbackMode === 'relic') {
       const stagedEntry = stagedRelicEntries[0] ?? null;
       confirmFallbackKey = stagedEntry ? rewardEntryKey(stagedEntry, 0, 'staged-relic') : null;
-      confirmFallbackLabel = relicConfirmDescription;
     } else {
       confirmFallbackKey = null;
-      confirmFallbackLabel = '';
     }
 
     advanceButtonMode = confirmFallbackMode ? `confirm-${confirmFallbackMode}` : 'advance';
@@ -1588,34 +1574,6 @@
     max-width: 1320px;
   }
 
-  .confirm-panel {
-    margin-top: 0.85rem;
-    padding: clamp(0.75rem, 1.6vw, 1.25rem);
-    border: var(--overlay-panel-border);
-    background: var(--overlay-panel-bg);
-    box-shadow: var(--overlay-panel-shadow);
-    display: flex;
-    flex-direction: column;
-    gap: 0.65rem;
-    align-items: flex-start;
-  }
-
-  .confirm-panel .confirm-actions {
-    display: flex;
-    gap: 0.75rem;
-  }
-
-  .confirm-panel .confirm-button {
-    padding: 0.65rem 1.5rem;
-    min-width: 140px;
-  }
-
-  .confirm-message {
-    margin: 0;
-    font-size: 1rem;
-    color: var(--overlay-text-primary);
-  }
-
   .status {
     margin-top: 0.25rem;
     text-align: center;
@@ -1914,21 +1872,6 @@
             </div>
           {/each}
         </div>
-        {#if showCardConfirmation}
-          <div class="confirm-panel card" role="group" aria-label="Confirm card selection">
-            <p class="confirm-message">Confirm {cardConfirmDescription}?</p>
-            <div class="confirm-actions">
-              <button
-                class="icon-btn confirm-button"
-                type="button"
-                on:click={() => handleConfirmClick('card')}
-                disabled={cardConfirmDisabled}
-              >
-                Confirm
-              </button>
-            </div>
-          </div>
-        {/if}
       {/if}
 
       {#if showRelics}
@@ -1947,21 +1890,6 @@
             </div>
           {/each}
         </div>
-        {#if showRelicConfirmation}
-          <div class="confirm-panel relic" role="group" aria-label="Confirm relic selection">
-            <p class="confirm-message">Confirm {relicConfirmDescription}?</p>
-            <div class="confirm-actions">
-              <button
-                class="icon-btn confirm-button"
-                type="button"
-                on:click={() => handleConfirmClick('relic')}
-                disabled={relicConfirmDisabled}
-              >
-                Confirm
-              </button>
-            </div>
-          </div>
-        {/if}
       {/if}
     {/if}
 

--- a/frontend/tests/httpClient.errorContext.test.js
+++ b/frontend/tests/httpClient.errorContext.test.js
@@ -16,6 +16,7 @@ describe('httpClient error context handling', () => {
 
   afterEach(() => {
     __setHttpClientTestOverrides({});
+    resetApiBase();
   });
 
   test('propagates backend context data to overlays and thrown errors', async () => {

--- a/frontend/tests/reward-overlay-confirmation-flow.vitest.js
+++ b/frontend/tests/reward-overlay-confirmation-flow.vitest.js
@@ -88,7 +88,7 @@ describe('Reward overlay confirmation flow', () => {
       }
     };
 
-    const { component, queryByLabelText, queryByText } = render(OverlayHost, {
+    const { component, container, queryByLabelText } = render(OverlayHost, {
       props: {
         runId: 'test-run',
         roomData,
@@ -144,15 +144,20 @@ describe('Reward overlay confirmation flow', () => {
 
     await fireEvent.click(cardButton);
     await tick();
+    await tick();
 
-    expect(queryByText('Confirm Card Radiant Beam?')).not.toBeNull();
+    const advancePanel = container.querySelector('.advance-panel');
+    expect(advancePanel?.classList.contains('confirm-mode')).toBe(true);
+
+    const advanceStatus = container.querySelector('.advance-status')?.textContent ?? '';
+    expect(advanceStatus).toMatch(/Highlighted card ready/);
 
     await fireEvent.click(cardButton);
     await tick();
     await tick();
 
     expect(queryByLabelText('Select card Radiant Beam')).toBeNull();
-    expect(queryByText('Confirm Card Radiant Beam?')).toBeNull();
+    expect(container.querySelector('.advance-panel')?.classList.contains('confirm-mode')).toBe(false);
 
     const snapshot = rewardPhaseController.getSnapshot?.();
     expect(snapshot?.completed || []).toContain('cards');
@@ -194,7 +199,7 @@ describe('Reward overlay confirmation flow', () => {
       }
     };
 
-    const { component, container, queryByLabelText, queryByText } = render(OverlayHost, {
+    const { component, container, queryByLabelText } = render(OverlayHost, {
       props: {
         runId: 'test-run',
         roomData,
@@ -268,7 +273,7 @@ describe('Reward overlay confirmation flow', () => {
     await tick();
     await tick();
 
-    expect(queryByText('Confirm Card Radiant Beam?')).toBeNull();
+    expect(container.querySelector('.advance-panel')?.classList.contains('confirm-mode')).toBe(false);
     const snapshot = rewardPhaseController.getSnapshot?.();
     expect(snapshot?.completed || []).toContain('cards');
     expect(snapshot?.current).not.toBe('cards');

--- a/frontend/tests/reward-overlay-relic-phase.vitest.js
+++ b/frontend/tests/reward-overlay-relic-phase.vitest.js
@@ -141,7 +141,7 @@ describe('RewardOverlay relic phase interactions', () => {
     expect(stagedShell?.classList.contains('selected')).toBe(true);
   });
 
-  test('keeps relic grid and confirmation controls visible during staged confirmation', async () => {
+  test('keeps relic grid visible and routes confirmation through Advance controls', async () => {
     updateRewardProgression({
       available: ['cards', 'relics', 'battle_review'],
       completed: ['cards'],
@@ -153,7 +153,7 @@ describe('RewardOverlay relic phase interactions', () => {
       { id: 'sun-charm', name: 'Sun Charm' }
     ];
 
-    const { container, getByRole, getByText } = render(RewardOverlay, {
+    const { container, getByText } = render(RewardOverlay, {
       props: {
         ...baseProps,
         relics: relicPool,
@@ -172,12 +172,19 @@ describe('RewardOverlay relic phase interactions', () => {
     expect(relicGrid?.classList.contains('choices')).toBe(true);
     expect(relicGrid?.querySelectorAll('.curio-shell').length ?? 0).toBeGreaterThan(0);
 
-    const confirmGroup = getByRole('group', { name: 'Confirm relic selection' });
-    expect(confirmGroup).not.toBeNull();
+    expect(container.querySelector('.confirm-panel')).toBeNull();
 
-    const confirmButton = confirmGroup?.querySelector('button');
-    expect(confirmButton).not.toBeNull();
-    expect(confirmButton?.textContent?.trim()).toBe('Confirm');
+    const advancePanel = container.querySelector('.advance-panel');
+    expect(advancePanel).not.toBeNull();
+    expect(advancePanel?.classList.contains('confirm-mode')).toBe(true);
+
+    const helper = advancePanel?.querySelector('.advance-helper');
+    expect(helper?.textContent?.trim()).toMatch(/Advance confirms/i);
+
+    const advanceButton = advancePanel?.querySelector('button.advance-button');
+    expect(advanceButton).not.toBeNull();
+    expect(advanceButton?.dataset.mode).toBe('confirm-relic');
+    expect(advanceButton?.getAttribute('aria-label') ?? '').toContain('Confirm Relic');
   });
 
   test('requires a second click on the highlighted relic to confirm', async () => {

--- a/frontend/tests/reward-overlay-selection-regression.vitest.js
+++ b/frontend/tests/reward-overlay-selection-regression.vitest.js
@@ -65,15 +65,24 @@ describe('RewardOverlay selection regression', () => {
     expect(container.querySelector('button[aria-label^="Select card"]')).not.toBeNull();
   });
 
-  test('renders staged cards with confirm controls', async () => {
+  test('activates Advance confirm mode for staged cards', async () => {
     const { container } = renderOverlay({
       cards: [],
       stagedCards: [{ id: 'radiant-beam', name: 'Radiant Beam', stars: 4 }],
       awaitingCard: true
     });
 
-    expect(container.querySelector('.confirm-panel.card')).not.toBeNull();
-    expect(container.querySelector('.confirm-panel.card button.confirm-button')).not.toBeNull();
+    expect(container.querySelector('.confirm-panel')).toBeNull();
+
+    const advancePanel = container.querySelector('.advance-panel');
+    expect(advancePanel).not.toBeNull();
+    expect(advancePanel?.classList.contains('confirm-mode')).toBe(true);
+
+    const advanceButton = advancePanel?.querySelector('button.advance-button');
+    expect(advanceButton).not.toBeNull();
+    expect(advanceButton?.dataset.mode).toBe('confirm-card');
+    expect(advanceButton?.getAttribute('aria-label') ?? '').toContain('Confirm Card');
+
     const stagedShell = container.querySelector('.card-shell.selected');
     expect(stagedShell).not.toBeNull();
   });
@@ -127,7 +136,7 @@ describe('RewardOverlay selection regression', () => {
     expect(container.querySelector('.preview-panel')).toBeNull();
   });
 
-  test('renders staged relics with confirm controls', async () => {
+  test('activates Advance confirm mode for staged relics', async () => {
     const { container } = renderOverlay({
       cards: [],
       stagedRelics: [{ id: 'lucky-charm', name: 'Lucky Charm' }],
@@ -135,8 +144,16 @@ describe('RewardOverlay selection regression', () => {
       awaitingRelic: true
     });
 
-    expect(container.querySelector('.confirm-panel.relic')).not.toBeNull();
-    expect(container.querySelector('.confirm-panel.relic button.confirm-button')).not.toBeNull();
+    expect(container.querySelector('.confirm-panel')).toBeNull();
+
+    const advancePanel = container.querySelector('.advance-panel');
+    expect(advancePanel).not.toBeNull();
+    expect(advancePanel?.classList.contains('confirm-mode')).toBe(true);
+
+    const advanceButton = advancePanel?.querySelector('button.advance-button');
+    expect(advanceButton).not.toBeNull();
+    expect(advanceButton?.dataset.mode).toBe('confirm-relic');
+    expect(advanceButton?.getAttribute('aria-label') ?? '').toContain('Confirm Relic');
   });
 
   test('re-dispatches select events for staged relics', async () => {


### PR DESCRIPTION
## Summary
- remove the card and relic confirm panels from RewardOverlay and rely on double-click or the Advance panel fallback
- refresh the Vitest suites to assert the new confirm-mode UX and ensure the Advance button continues to confirm staged choices
- update reward overlay documentation and the frontend README to describe the new flow, and reset the http client test cache between runs

## Testing
- `VITE_API_BASE=http://backend.test bun test` *(fails: existing battlepolling.test.js still expects legacy snap?.error guard)*

------
https://chatgpt.com/codex/tasks/task_b_68f91a9daa08832cac59a7d1a62c302d