### PR TITLE
Auto-confirm staged relics during advance gating

### DIFF
--- a/backend/routes/ui.py
+++ b/backend/routes/ui.py
@@ -520,8 +520,29 @@ async def handle_ui_action() -> tuple[str, int, dict[str, Any]]:
                 if isinstance(item_bucket, list):
                     staged_items = item_bucket
 
-            if state.get("awaiting_relic") and not staged_relics:
-                return create_error_response("Cannot advance room while rewards are pending", 400)
+            if state.get("awaiting_relic"):
+                if not staged_relics:
+                    return create_error_response("Cannot advance room while rewards are pending", 400)
+
+                try:
+                    await confirm_reward(run_id, "relic")
+                except ValueError as exc:
+                    return create_error_response(str(exc), 400)
+
+                state, rooms = await asyncio.to_thread(load_map, run_id)
+                staging_raw = state.get("reward_staging")
+                staging = staging_raw if isinstance(staging_raw, Mapping) else None
+
+                staged_relics = []
+                staged_items = []
+                if isinstance(staging, Mapping):
+                    relic_bucket = staging.get("relics")
+                    if isinstance(relic_bucket, list):
+                        staged_relics = relic_bucket
+                    item_bucket = staging.get("items")
+                    if isinstance(item_bucket, list):
+                        staged_items = item_bucket
+
             if state.get("awaiting_loot") and not staged_items:
                 return create_error_response("Cannot advance room while rewards are pending", 400)
             if has_pending_rewards(state):


### PR DESCRIPTION
## Summary
- auto-confirm staged relic rewards during advance_room handling and refresh staged reward caches
- ensure reward gating tests verify relic staging is cleared automatically before continuing

## Testing
- uv run --project backend pytest backend/tests/test_reward_gate.py

------
https://chatgpt.com/codex/tasks/task_b_68f9259e4b54832ca86fb57ba51b344c