### PR TITLE
Fix reward staging cleanup after confirmations

### DIFF
--- a/frontend/src/lib/utils/rewardStagingPayload.js
+++ b/frontend/src/lib/utils/rewardStagingPayload.js
@@ -1,0 +1,56 @@
+import { normalizeRewardPreview } from './rewardPreviewFormatter.js';
+
+function cloneStagingBucketEntries(values) {
+  if (!Array.isArray(values)) {
+    return [];
+  }
+  return values.map((entry) => {
+    if (!entry || typeof entry !== 'object') {
+      return entry;
+    }
+    const clone = { ...entry };
+    if (clone.preview) {
+      clone.preview = normalizeRewardPreview(clone.preview);
+    }
+    return clone;
+  });
+}
+
+function resolveEffectiveSource(source, fallback) {
+  if (source && typeof source === 'object') {
+    return source;
+  }
+  if (fallback && typeof fallback === 'object') {
+    return fallback;
+  }
+  return {};
+}
+
+export function normalizeRewardStagingPayload(source, fallback) {
+  const effective = resolveEffectiveSource(source, fallback);
+  return {
+    cards: cloneStagingBucketEntries(effective.cards),
+    relics: cloneStagingBucketEntries(effective.relics),
+    items: cloneStagingBucketEntries(effective.items)
+  };
+}
+
+export function resolveRewardStagingPayload({ current, next, type, intent } = {}) {
+  const normalizedType = type === 'card' || type === 'relic' ? type : null;
+  const normalizedIntent = typeof intent === 'string' ? intent : null;
+  const normalized = normalizeRewardStagingPayload(next, current);
+
+  if (normalizedIntent === 'confirm' && normalizedType) {
+    const bucketKey = normalizedType === 'card' ? 'cards' : 'relics';
+    const responseIncludesBucket =
+      next &&
+      typeof next === 'object' &&
+      Object.prototype.hasOwnProperty.call(next, bucketKey);
+
+    if (!responseIncludesBucket) {
+      return { ...normalized, [bucketKey]: [] };
+    }
+  }
+
+  return normalized;
+}

--- a/frontend/tests/reward-staging-payload.test.js
+++ b/frontend/tests/reward-staging-payload.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'vitest';
+
+import { resolveRewardStagingPayload } from '../src/lib/utils/rewardStagingPayload.js';
+
+describe('resolveRewardStagingPayload', () => {
+  test('clears staged card bucket when confirm response omits updates', () => {
+    const current = {
+      cards: [
+        {
+          id: 'radiant-beam',
+          preview: { label: 'Radiant Beam', rarity: 4 }
+        }
+      ],
+      relics: [{ id: 'lucky-pendant' }],
+      items: []
+    };
+
+    const resolved = resolveRewardStagingPayload({
+      current,
+      next: undefined,
+      type: 'card',
+      intent: 'confirm'
+    });
+
+    expect(resolved.cards).toEqual([]);
+    expect(resolved.relics).toEqual(current.relics);
+    expect(resolved.relics).not.toBe(current.relics);
+  });
+
+  test('clones incoming staging payloads from the server', () => {
+    const next = {
+      cards: [
+        {
+          id: 'aurora-strike',
+          preview: { id: 'aurora-strike', label: 'Aurora Strike', stars: 3 }
+        }
+      ],
+      relics: [],
+      items: []
+    };
+
+    const resolved = resolveRewardStagingPayload({
+      current: { cards: [], relics: [], items: [] },
+      next,
+      type: 'card',
+      intent: 'select'
+    });
+
+    expect(resolved.cards).not.toBe(next.cards);
+    expect(resolved.cards).toHaveLength(1);
+    expect(resolved.cards[0]).not.toBe(next.cards[0]);
+    expect(resolved.cards[0]).toMatchObject({ id: 'aurora-strike' });
+    expect(resolved.cards[0]?.preview).not.toBe(next.cards[0]?.preview);
+    expect(resolved.cards[0]?.preview).toMatchObject({ summary: null });
+    expect(Array.isArray(resolved.cards[0]?.preview?.stats)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- ensure the rewards page clears stale staging buckets when confirmations succeed without new payloads
- extract reward staging normalization into a reusable helper that always clones server data
- add a regression test covering confirmation staging cleanup and payload cloning

## Testing
- bun test tests/reward-staging-payload.test.js

------
https://chatgpt.com/codex/tasks/task_b_68f9b8a12138832cb3facce2c64f2d80