### PR TITLE
Align relic art tasks with prompt workflow

### DIFF
--- a/.codex/tasks/relics/8b9d1bbb-eclipse-reactor-5star-relic.md
+++ b/.codex/tasks/relics/8b9d1bbb-eclipse-reactor-5star-relic.md
@@ -12,5 +12,5 @@ Our 5★ set covers high-risk ally sacrifice (Paradox Hourglass), attrition-focu
 - Implement `backend/plugins/relics/eclipse_reactor.py` with clear state tracking (storing remaining surge duration, hooking `turn_start` to apply the post-surge drain) and a descriptive `describe(stacks)` documenting both phases.
 - Add comprehensive tests covering: initial HP drain clamping at 1 HP, buff duration stacking, transition into the post-surge drain, and cleanup on battle end. Extend `backend/tests/test_relic_effects_advanced.py` or add a new module.
 - Update `.codex/implementation/relic-inventory.md` and the relic plan with Eclipse Reactor's final parameters.【F:.codex/implementation/relic-inventory.md†L40-L47】【F:.codex/planning/archive/bd48a561-relic-plan.md†L52-L73】
-- Supply a placeholder asset under `frontend/src/lib/assets/relics/5star/` and ensure the description surfaces correctly through existing catalog endpoints.【F:frontend/src/lib/systems/assetRegistry.js†L174-L1353】
+- Record a placeholder art prompt for Eclipse Reactor in `luna_items_prompts.txt` under **Missing Relics Art**, noting the relic slug so the Lead Developer can hand-create the icon later without blocking this task.【F:luna_items_prompts.txt†L11-L27】
 - Capture balancing notes (HP drain math, buff multipliers) in `.codex/docs/relics/` for future tuning discussions.

--- a/.codex/tasks/relics/ff95fa3c-graviton-locket-4star-relic.md
+++ b/.codex/tasks/relics/ff95fa3c-graviton-locket-4star-relic.md
@@ -12,5 +12,5 @@ Null Lantern dramatically changes routing, while Traveler's Charm and Timekeeper
 - Implement `backend/plugins/relics/graviton_locket.py` with helper cleanup, duration tracking, and a thorough `describe(stacks)` covering debuff values, duration scaling, and HP drain cost.
 - Add backend tests ensuring: enemies receive the debuff with correct magnitude/duration, HP drain only runs while gravity is active (and scales with stacks), and all modifiers clear after battle. Extend `backend/tests/test_relic_effects_advanced.py` or create a new dedicated module.
 - Update `.codex/implementation/relic-inventory.md` and the relic design plan to include Graviton Locket with final tuning notes.【F:.codex/implementation/relic-inventory.md†L33-L48】【F:.codex/planning/archive/bd48a561-relic-plan.md†L45-L65】
-- Supply a placeholder icon in `frontend/src/lib/assets/relics/4star/` and verify the asset resolves through the registry globs.【F:frontend/src/lib/systems/assetRegistry.js†L174-L1353】
+- Record a placeholder art prompt for Graviton Locket in `luna_items_prompts.txt` under the **Missing Relics Art** section so the Lead Developer can produce the final icon; include the relic slug for tracking.【F:luna_items_prompts.txt†L11-L27】
 - Capture balancing rationale (gravity duration vs. HP drain) in `.codex/docs/relics/` so future tuning has a paper trail.


### PR DESCRIPTION
## Summary
- replace relic task art deliverables with prompt logging instructions so contributors never need to create png assets

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [x] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68fb9c8ce314832c9106534755285b13