### PR TITLE
Document confirm blocked telemetry monitoring

### DIFF
--- a/.codex/tasks/tests/dc47b2ce-reward-activation-tests-metrics.md
+++ b/.codex/tasks/tests/dc47b2ce-reward-activation-tests-metrics.md
@@ -17,10 +17,11 @@ Do not modify frontend flows; focus on backend testing and observability.
 
 ## Implementation notes
 - Added telemetry for blocked confirmations and extended backend/unit integration tests to cover duplicate submissions, reconnect reloads, and HTTP retries.
+- Documented how to monitor the `confirm_*_blocked` events in `backend/.codex/implementation/battle-endpoint-payload.md` so ops teams know where to pull the data.
 ## Audit notes
 - Confirmed the `/rewards/card/<run_id>/confirm` handler surfaces telemetry when a second HTTP confirmation arrives, exercising the duplicate guard in `tests/test_reward_gate.py`.【F:backend/tests/test_reward_gate.py†L360-L423】
 - Verified the reconnect scenario clears the in-memory snapshot before attempting another confirmation and still records a `confirm_cards_blocked` event in `tests/test_reward_staging_confirmation.py`.【F:backend/tests/test_reward_staging_confirmation.py†L300-L338】
 - Observed the backend now logs `confirm_{bucket}_blocked` events whenever the staging bucket is empty, ensuring operations can detect duplicate activations.【F:backend/services/reward_service.py†L440-L475】
-- Documentation still lacks guidance on monitoring the new `confirm_*_blocked` telemetry, so ops do not yet know where to watch for these signals.【F:backend/.codex/implementation/battle-endpoint-payload.md†L1-L139】
+- Documentation now details how to monitor the `confirm_*_blocked` telemetry, pointing operators to the `game_actions` records documented in `backend/.codex/implementation/battle-endpoint-payload.md`.【F:backend/.codex/implementation/battle-endpoint-payload.md†L147-L184】
 
-more work needed — Add monitoring guidance for the `confirm_*_blocked` telemetry (e.g., in `backend/.codex/implementation/battle-endpoint-payload.md` or a dedicated ops note).
+ready for review


### PR DESCRIPTION
## Summary
- describe the new `confirm_*_blocked` game-action telemetry in the reward payload reference so operators know how to monitor duplicate confirmations
- mark the reward activation monitoring task as ready after documenting the telemetry guidance

## Testing
- uv run pytest tests/test_reward_staging_confirmation.py::test_confirm_card_duplicate_attempt_is_tracked

------
https://chatgpt.com/codex/tasks/task_b_68fc48478164832cb2543f4ba24c4ccf