### PR TITLE
[AUDIT] Sign off reward guardrails and Plague Harp tasks

### DIFF
--- a/.codex/tasks/relics/84e6f46d-plague-harp-relic.md
+++ b/.codex/tasks/relics/84e6f46d-plague-harp-relic.md
@@ -17,6 +17,8 @@ Create **Plague Harp**, a 3★ relic that weaponizes the party’s damage-over-t
 - Keep documentation centralized in the plugin; do not duplicate Plague Harp behaviour in `.codex/implementation/relic-system.md` per relic authoring guidance.
 
 ## Audit notes (Auditor)
-- Automated coverage exercises random target selection, fallback behaviour, and battle cleanup in `backend/tests/test_plague_harp.py` to complement the propagation sizing checks.【F:backend/tests/test_plague_harp.py†L1-L173】
+- Verified Plague Harp tracks live foes, echoes DoT damage onto alternates, and applies the health tithe while clearing subscriptions at battle end.【F:backend/plugins/relics/plague_harp.py†L24-L149】
+- Confirmed automated coverage exercises propagation sizing, fallback targeting, RNG determinism, and cleanup in `backend/tests/test_plague_harp.py`.【F:backend/tests/test_plague_harp.py†L52-L207】
+- Ran the relic suite to ensure the new behaviours pass under pytest.【def253†L1-L1】【114098†L1-L9】
 
-ready for review
+requesting review from the Task Master

--- a/.codex/tasks/tests/dc47b2ce-reward-activation-tests-metrics.md
+++ b/.codex/tasks/tests/dc47b2ce-reward-activation-tests-metrics.md
@@ -23,5 +23,6 @@ Do not modify frontend flows; focus on backend testing and observability.
 - Verified the reconnect scenario clears the in-memory snapshot before attempting another confirmation and still records a `confirm_cards_blocked` event in `tests/test_reward_staging_confirmation.py`.【F:backend/tests/test_reward_staging_confirmation.py†L300-L338】
 - Observed the backend now logs `confirm_{bucket}_blocked` events whenever the staging bucket is empty, ensuring operations can detect duplicate activations.【F:backend/services/reward_service.py†L440-L475】
 - Documentation now details how to monitor the `confirm_*_blocked` telemetry, pointing operators to the `game_actions` records documented in `backend/.codex/implementation/battle-endpoint-payload.md`.【F:backend/.codex/implementation/battle-endpoint-payload.md†L147-L184】
+- Re-ran the reward confirmation suites to verify the duplicate guard and reconnect flows pass under pytest. 【0e0e22†L1-L3】【1067c8†L1-L3】
 
-ready for review
+requesting review from the Task Master


### PR DESCRIPTION
## Summary
- update the reward guardrail task with fresh audit notes and escalate it to the Task Master
- capture Plague Harp relic verification details and hand the task back for Task Master review

## Testing
- uv run pytest tests/test_reward_gate.py tests/test_reward_staging_confirmation.py
- uv run pytest tests/test_plague_harp.py

------
https://chatgpt.com/codex/tasks/task_b_68fc4c61ed18832c96c451766b2b9571