### PR TITLE
docs: refresh reward flow references

### DIFF
--- a/.codex/implementation/card-reward-system.md
+++ b/.codex/implementation/card-reward-system.md
@@ -1,12 +1,28 @@
 # Card Reward System
 
-Battles grant unique cards that permanently boost party stats. Cards come in star
-ranks and only one copy of each can be owned. Victories present three unused
-cards of the appropriate star rank; choosing one adds it to the party's inventory.
-Cards are implemented as plugins under `plugins/cards/`, making new rewards easy to add.
-Card and relic bonuses now apply at the start of each combat rather than on
-acquisition so higher-star effects trigger correctly. Subsequent battles skip
-duplicates by rolling only from cards not yet collected.
+Battles grant unique cards that permanently boost party stats. Cards come in star ranks and only one copy of each can be owned. Victories present three unused cards of the appropriate star rank; choosing one adds it to the party's inventory. Cards are implemented as plugins under `plugins/cards/`, making new rewards easy to add. Card and relic bonuses now apply at the start of each combat rather than on acquisition so higher-star effects trigger correctly. Subsequent battles skip duplicates by rolling only from cards not yet collected.【F:backend/services/reward_service.py†L68-L205】【F:backend/plugins/cards/_base.py†L20-L120】
+
+## Reward staging and progression
+
+Selecting a card calls `services.reward_service.select_card`, which validates the choice against `card_choice_options`, instantiates the plugin, and stages a preview payload under `reward_staging['cards']`. The backend records `awaiting_card = True`, clears `awaiting_next`, and advances the four-phase `reward_progression` state machine so reconnecting clients know Cards is the active phase.【F:backend/services/reward_service.py†L68-L205】【F:backend/runs/lifecycle.py†L140-L220】
+
+Confirming the staged card appends it to the party, emits an `activation_record` (with timestamp and activation ID), and adds the entry to the bounded `reward_activation_log`. Once confirmations clear all staging buckets the backend flips `awaiting_next = True`, allowing `/ui?action=advance_room` to progress the run.【F:backend/services/reward_service.py†L490-L574】 Cancelling a staged card sets `awaiting_card = True`, reopens the phase in `reward_progression`, and leaves `reward_staging['cards']` empty so the player can pick again.【F:backend/services/reward_service.py†L541-L608】
+
+## Plugin authoring guidelines
+
+Card plugins subclass `CardBase` and should populate:
+
+- `effects`: base stat modifiers used by `build_preview_from_effects` to derive preview deltas.
+- `preview_summary`, `preview_triggers`, or `build_preview`: optional hooks for custom copy, trigger descriptions, or stack-aware summaries. Returning a dict from `build_preview` allows cards to expose multi-target stats or custom triggers while `merge_preview_payload` backfills missing fields for reconnect stability.【F:backend/plugins/cards/_base.py†L130-L190】【F:backend/autofighter/reward_preview.py†L55-L189】
+- `about`: the inventory tooltip shown when the card is staged or owned. Keep this text accurate so reconnects and doc views stay in sync.
+
+Cards that grant conditional effects (e.g., Balance tokens each round) should describe the trigger via `preview_triggers` so the overlay lists the event and narration. If the card stacks with existing bonuses, include stack maths in the preview payload to surface `previous_total` and `total_amount` fields for the UI formatter.【F:frontend/src/lib/utils/rewardPreviewFormatter.js†L1-L200】
+
+## Telemetry and QA notes
+
+Each selection emits `log_game_action("select_card", …)` with the staged payload, while confirmations log `confirm_card` alongside the generated activation ID. QA can verify the overlay’s phase rail and countdown match the backend `reward_progression` snapshot and that cancelling a staged card re-enables the confirm panel. Automation helpers pause while `awaiting_card` is true and resume once `reward_staging['cards']` is empty.【F:backend/services/reward_service.py†L122-L205】【F:frontend/tests/reward-overlay-confirmation-flow.vitest.js†L21-L205】【F:frontend/tests/reward-automation.vitest.js†L40-L80】
 
 ## Testing
 - `uv run pytest backend/tests/test_card_rewards.py`
+- `uv run pytest backend/tests/test_reward_staging_confirmation.py`
+- `bun test frontend/tests/reward-overlay-confirmation-flow.vitest.js`

--- a/.codex/implementation/post-fight-loot-screen.md
+++ b/.codex/implementation/post-fight-loot-screen.md
@@ -1,18 +1,83 @@
 # Post-Fight Loot Screen
 
-After a battle concludes the frontend polls `roomAction(runId, 'battle', 'snapshot')` until the snapshot includes a `loot` object summarizing gold earned and any reward choices. `OverlayHost.svelte` keeps `BattleView.svelte` mounted during this polling and only opens `RewardOverlay.svelte` once the `loot` data arrives and combat is flagged complete. Players must resolve any card or relic picks and then press the **Next Room** button, which calls `/run/<id>/next` to advance the run.
+After a battle concludes the frontend polls `roomAction(runId, 'battle', 'snapshot')` until the snapshot includes a `loot` object summarizing gold earned and any reward choices. `OverlayHost.svelte` keeps `BattleView.svelte` mounted during this polling and only opens `RewardOverlay.svelte` once the `loot` data arrives and combat is flagged complete. Players must resolve the four reward phases—Drops, Cards, Relics, and optional Battle Review—before pressing **Next Room** to call `/run/<id>/next` and advance the run.【F:frontend/src/lib/components/OverlayHost.svelte†L1-L220】【F:frontend/src/lib/systems/rewardProgression.js†L1-L260】
 
 ## Reward staging persistence
-- The run map JSON stored in the `runs.map` column now includes a `reward_staging` object with `cards`, `relics`, and `items` arrays. These buckets capture unconfirmed selections so reconnecting clients can resume the overlay without mutating the live party loadout. Each staged entry embeds a `preview` payload describing the pending stat changes and any trigger hooks so the UI can narrate the reward before confirmation.
-- `runs.lifecycle.load_map` backfills this structure for older saves and mirrors the data into any in-memory battle snapshot (`battle_snapshots[run_id]`) so `/ui` and `/map/<id>` consumers receive the same staged entries.
-- `runs.lifecycle.save_map` always normalizes the `reward_staging` payload before writing so downstream services can append staged rewards without defensive guards. Future confirmation flows will clear the buckets once rewards are committed.
+- The run map JSON stored in `runs.map` now includes a `reward_staging` object with `cards`, `relics`, and `items` arrays. These buckets capture unconfirmed selections so reconnecting clients can resume the overlay without mutating the live party loadout. Each staged entry embeds a normalised `preview` payload so the UI can narrate the pending stats and trigger hooks before confirmation.【F:backend/services/reward_service.py†L42-L205】
+- `runs.lifecycle.load_map` backfills `reward_staging` and the new `reward_progression` field for older saves, mirroring the data into any in-memory battle snapshot (`battle_snapshots[run_id]`) so `/ui` and `/map/<id>` consumers receive the same staged entries and phase metadata.【F:backend/runs/lifecycle.py†L140-L266】
+- `runs.lifecycle.save_map` always normalises `reward_staging` and recomputes `reward_progression` before writing so downstream services can append staged rewards without defensive guards. Confirmation clears the buckets while cancellation reopens the matching phase and restores the appropriate `awaiting_*` flags.【F:backend/services/reward_service.py†L324-L417】【F:backend/services/reward_service.py†L490-L608】
+- Every confirmation appends an `activation_record` to `reward_activation_log`. Snapshots mirror this bounded log and the latest `reward_progression` payload, giving reconnects and QA an audit trail of staged payloads, completion timestamps, and generated activation IDs.【F:backend/services/reward_service.py†L520-L574】
 
 ## Single-confirm guardrails
-- `services.reward_service.confirm_reward` acquires a per-run `reward_locks[run_id]` mutex before mutating staging data, ensuring duplicate HTTP calls or reconnects cannot race each other while a confirmation is in flight.
-- On success the targeted staging bucket is cleared, the appropriate `awaiting_*` flags are flipped off, and `awaiting_next` is only raised once every bucket is empty. Failed or replayed confirmations raise an error because the staging list is empty.
-- Each activation appends a record to `state["reward_activation_log"]` with a generated `activation_id`, timestamp, bucket name, and the committed payload. Snapshots mirror this log so the frontend can surface audit breadcrumbs and the backend retains the last 20 activations for debugging.
-- `services.run_service.advance_room` now blocks when any staging bucket still contains entries via `runs.lifecycle.has_pending_rewards`, preventing map progression until the overlay has been fully resolved.
+- `services.reward_service.confirm_reward` acquires a per-run `reward_locks[run_id]` mutex before mutating staging data, ensuring duplicate HTTP calls or reconnects cannot race each other while a confirmation is in flight.【F:backend/services/reward_service.py†L520-L574】
+- On success the targeted staging bucket is cleared, the appropriate `awaiting_*` flags are flipped off, and `awaiting_next` is only raised once every bucket is empty. Failed or replayed confirmations raise an error because the staging list is empty.【F:backend/services/reward_service.py†L490-L574】
+- Each activation appends a record to `state["reward_activation_log"]` with a generated `activation_id`, timestamp, bucket name, and the committed payload. Snapshots mirror this log so the frontend can surface audit breadcrumbs and the backend retains the last 20 activations for debugging.【F:backend/services/reward_service.py†L520-L574】
+- `services.run_service.advance_room` now blocks when any staging bucket still contains entries via `runs.lifecycle.has_pending_rewards`, preventing map progression until the overlay has been fully resolved.【F:backend/routes/ui.py†L495-L695】
+
+## Reward progression state machine
+
+The backend exposes a canonical Drops → Cards → Relics → Battle Review sequence through `reward_progression`. The frontend ingests this payload with `rewardPhaseController` to drive the overlay rail, countdowns, and automation fallbacks.【F:backend/runs/lifecycle.py†L140-L220】【F:frontend/src/lib/systems/rewardProgression.js†L1-L260】 The states surface through `awaiting_*` flags and map directly to UI affordances:
+
+```text
+Drops (awaiting_loot = True, reward_progression.current_step = 'drops')
+    │ acknowledge_loot / auto-advance
+    ▼
+Previewed card (reward_staging['cards'] populated, awaiting_card = True)
+    │  ┌─ cancel_card → reopen step (awaiting_card = True)
+    │  │
+    │  └─ confirm_card → activation log entry, awaiting_card = False
+    ▼
+Previewed relic (reward_staging['relics'] populated, awaiting_relic = True)
+    │  ┌─ cancel_relic → reopen step (awaiting_relic = True)
+    │  │
+    │  └─ confirm_relic → activation log entry, awaiting_relic = False
+    ▼
+Battle Review (reward_progression.current_step = 'battle_review')
+    │ auto-completes when countdown fires or automation advances
+    ▼
+Applied (awaiting_next = True) → `/run/<id>/next`
+```
+
+The UI announces each phase transition, activates the confirm panel when staging entries exist, and returns to Drops if cancellation reopens a bucket. When `reward_progression` is missing or malformed the overlay falls back to legacy behaviour and surfaces a warning banner for QA.【F:frontend/src/lib/components/RewardOverlay.svelte†L1-L220】【F:frontend/src/lib/components/RewardOverlay.svelte†L600-L760】
+
+## API contracts
+
+### `POST /rewards/cards/<run_id>`
+- **Body**: `{ "card": "<card_id>" }`
+- **Response**: staged card payload with preview metadata, `reward_staging`, updated `awaiting_*` flags, next room hint, and the current `reward_progression` snapshot. The handler rejects invalid IDs, duplicate ownership, or stale selections so only fresh options can be staged.【F:backend/services/reward_service.py†L68-L205】
+- **Side effects**: persists map state, copies staging into live snapshots, and emits `log_game_action("select_card", …)` telemetry with the staged payload for audit correlation.【F:backend/services/reward_service.py†L122-L171】
+
+### `POST /rewards/relics/<run_id>`
+- **Body**: `{ "relic": "<relic_id>" }`
+- **Response**: mirrors the card endpoint but with relic metadata. Existing stacks are counted so previews reflect the next stack, and the `reward_progression` sequence advances to the relic phase.【F:backend/services/reward_service.py†L206-L324】
+- **Side effects**: persists state, refreshes snapshots, and emits `log_game_action("select_relic", …)` with staging details.【F:backend/services/reward_service.py†L244-L318】
+
+### `POST /rewards/loot/<run_id>`
+- **Body**: none required.
+- **Response**: returns `{ "next_room": <type|null> }`. When loot was already cleared the response includes the next room while logging an idempotent acknowledgement. Otherwise the call clears item staging, advances Drops in `reward_progression`, and rewrites snapshots before returning the next room type.【F:backend/services/reward_service.py†L288-L341】
+- **Side effects**: writes to the run map, updates `awaiting_*` flags, and emits `log_game_action("acknowledge_loot", …)` with an `idempotent` hint so telemetry distinguishes replays.【F:backend/services/reward_service.py†L300-L341】
+
+### `POST /ui`
+- **`action="choose_card" | "choose_relic"`**: thin wrappers around the staging endpoints that forward the response payload directly to the client.【F:backend/routes/ui.py†L702-L752】
+- **`action="confirm_card" | "confirm_relic"`**: call `confirm_reward`, returning the updated staging payload, `activation_record`, and refreshed `reward_progression`. Duplicate confirmations raise `400` with an error message, and telemetry is emitted as `confirm_card` / `confirm_relic`.【F:backend/routes/ui.py†L740-L770】【F:backend/services/reward_service.py†L520-L574】
+- **`action="cancel_card" | "cancel_relic"`**: clear staged entries, reopen the relevant phase, and return updated `awaiting_*` flags. QA should see `awaiting_next` drop back to `False` until a new selection is staged.【F:backend/routes/ui.py†L766-L785】【F:backend/services/reward_service.py†L541-L608】
+- **`action="advance_room"`**: verifies all reward phases are complete. If a bucket is still pending it returns a `pending_rewards` payload describing the blocking phase, current `reward_progression`, and any outstanding choices; otherwise it completes remaining phases (including auto-completing Battle Review) before calling `advance_room`. This call ensures the run cannot progress while staging entries exist.【F:backend/routes/ui.py†L495-L695】
+
+## Telemetry and audit trail
+
+Reward interactions stream structured telemetry through `log_game_action` with unique events for selection, confirmation, cancellation, and loot acknowledgement. Each event includes the run ID, room identifier, and contextual details such as the staged payload, activation ID, `next_room`, or failure reason so Live Ops can trace regressions back to player actions.【F:backend/services/reward_service.py†L120-L341】【F:backend/services/reward_service.py†L520-L574】
+
+## QA checklist
+
+- Verify Drops → Cards → Relics → Battle Review ordering using the phase rail and ensure `reward_progression.current_step` mirrors the visible phase after each action.【F:frontend/src/lib/components/RewardOverlay.svelte†L1-L220】【F:frontend/tests/reward-overlay-confirmation-flow.vitest.js†L21-L133】
+- Stage a card, cancel it, and confirm a different option. Observe that `awaiting_card` toggles back to `True` on cancel and that the confirmation response appends to `reward_activation_log`.【F:backend/services/reward_service.py†L490-L574】【F:frontend/tests/reward-overlay-confirmation-flow.vitest.js†L66-L205】
+- Confirm that loot acknowledgement advances Drops and unblocks Cards without leaving stray staged items. Check `/ui?action=advance_room` returns `pending_rewards` until all buckets clear.【F:backend/services/reward_service.py†L288-L341】【F:backend/routes/ui.py†L495-L695】
+- Reconnect mid-flow and ensure the overlay restores staged previews, countdowns, and `awaiting_*` flags from the snapshot payload. Fallback warnings should only appear when `reward_progression` is absent or malformed.【F:backend/services/reward_service.py†L324-L417】【F:frontend/src/lib/components/RewardOverlay.svelte†L600-L760】
+- Run automation helpers in idle mode and confirm they continue to auto-select choices and advance phases when staging is empty.【F:frontend/src/lib/utils/rewardAutomation.js†L1-L200】【F:frontend/tests/reward-automation.vitest.js†L1-L120】
 
 ## Testing
-- `uv run pytest tests/test_loot_summary.py`
-- `bun test`
+- `uv run pytest backend/tests/test_loot_summary.py`
+- `uv run pytest backend/tests/test_reward_staging_confirmation.py`
+- `uv run pytest backend/tests/test_reward_gate.py`
+- `bun test frontend/tests/reward-overlay-confirmation-flow.vitest.js`
+- `bun test frontend/tests/reward-automation.vitest.js`

--- a/.codex/implementation/relic-picker.md
+++ b/.codex/implementation/relic-picker.md
@@ -1,5 +1,30 @@
 # Relic Picker Flow
 
-When a battle ends, the backend rolls for a relic drop. Normal fights grant a relic 10% of the time, while boss rooms roll at 50%. If a relic is awarded, its star rank is determined by the encounter type and three relic options of that rank are returned to the frontend.
+When a battle ends, the backend rolls for a relic drop. Normal fights grant a relic 10% of the time, while boss rooms roll at 50%. If a relic is awarded, its star rank is determined by the encounter type and three relic options of that rank are returned to the frontend.【F:backend/services/reward_service.py†L206-L324】
 
-The frontend displays these options in the reward overlay using the same star-color tinting as cards. Selecting a relic posts the choice to `/relics/<run_id>`; the backend saves the relic to the run and only allows advancing rooms once all reward selections are complete.
+The frontend displays these options in the reward overlay using the same star-color tinting as cards. Selecting a relic posts the choice to `/relics/<run_id>`; the backend saves the relic to the run and only allows advancing rooms once all reward selections are complete.【F:frontend/src/lib/components/RewardOverlay.svelte†L1-L220】【F:backend/services/reward_service.py†L206-L417】
+
+## Reward staging and confirmation
+
+`select_relic` instantiates the relic plugin, measures existing stacks on the party, and stages the preview payload under `reward_staging['relics']`. The backend marks `awaiting_relic = True`, clears `awaiting_next`, and advances `reward_progression` so reconnects and automation know the Relics phase is active.【F:backend/services/reward_service.py†L206-L324】【F:backend/runs/lifecycle.py†L140-L220】 The staged payload includes the next-stack preview so the overlay can show the exact stats and triggers that will apply if the relic is confirmed.【F:backend/services/reward_service.py†L206-L324】【F:backend/autofighter/reward_preview.py†L55-L189】
+
+Confirming a relic appends it to the party inventory, pushes an activation snapshot into `reward_activation_log`, and advances the progression sequence. Cancelling clears the staging bucket, reopens the relic phase, and keeps `awaiting_relic = True` until a new choice is staged.【F:backend/services/reward_service.py†L490-L608】
+
+## Plugin authoring guidelines
+
+Relic plugins mirror the card workflow:
+
+- Define `effects` for flat or percentage stat bonuses.
+- Override `build_preview` when stacks or bus subscriptions need bespoke copy, calling `merge_preview_payload` to merge custom fields with default stat math.【F:backend/plugins/relics/_base.py†L70-L150】【F:backend/autofighter/reward_preview.py†L55-L189】
+- Populate `about` with accurate next-stack text so preview summaries stay trustworthy.
+
+Use `preview_triggers` or a custom payload to document event hooks (`on_battle_start`, `on_turn_end`, etc.) so the overlay communicates reactive behaviour. If a relic unlocks abilities when stacked, include the projected totals in the preview stats so QA can validate the math during the confirmation flow.【F:frontend/src/lib/utils/rewardPreviewFormatter.js†L1-L200】
+
+## Telemetry and QA notes
+
+`select_relic` logs `log_game_action("select_relic", …)` with the staged payload, while confirmations emit `confirm_relic` alongside the activation ID. QA should confirm that cancelling returns the phase rail to Relics, that `awaiting_relic` toggles appropriately, and that automation only advances once staging is clear.【F:backend/services/reward_service.py†L244-L341】【F:frontend/tests/reward-overlay-confirmation-flow.vitest.js†L134-L213】【F:frontend/tests/reward-automation.vitest.js†L70-L110】
+
+## Testing
+- `uv run pytest backend/tests/test_relic_rewards.py`
+- `uv run pytest backend/tests/test_reward_staging_confirmation.py`
+- `bun test frontend/tests/reward-overlay-confirmation-flow.vitest.js`

--- a/.codex/implementation/reward-overlay.md
+++ b/.codex/implementation/reward-overlay.md
@@ -4,14 +4,26 @@ After a battle resolves, the backend returns a `loot` object summarizing gold an
 
 `RewardOverlay` also accepts a `partyStats` array derived from `_serialize`, rendering a right-hand table listing each party member and their `damage_dealt`. Placeholder columns reserve space for future metrics like damage taken or healing.
 
-The overlay now subscribes to the shared reward phase state machine so the experience plays out as a deterministic Drops → Cards → Relics → Battle Review flow. While the controller reports `current === 'drops'`, only loot tiles and gold summaries render and later-phase controls are kept out of the DOM. A right-rail "Reward Flow" panel reflects the active phase and upcoming steps without exposing the advance button (that arrives with the countdown task) so screen readers and automation can follow progress. Once the phase machine advances past Drops the usual card and relic widgets mount just as before.
+The overlay now subscribes to the shared reward phase state machine so the experience plays out as a deterministic Drops → Cards → Relics → Battle Review flow. `OverlayHost.svelte` ingests the backend `reward_progression` payload with `rewardPhaseController.ingest`, forwarding the normalised snapshot to `RewardOverlay` via the shared store. While `current === 'drops'`, only loot tiles and gold summaries render and later-phase controls stay out of the DOM. A right-rail "Reward Flow" panel reflects the active phase, completed steps, and upcoming stages without exposing the advance button until the countdown task signals the next phase. If the payload is missing or malformed the controller falls back to legacy rendering and surfaces a warning banner so QA can spot the regression.【F:frontend/src/lib/components/OverlayHost.svelte†L200-L320】【F:frontend/src/lib/systems/rewardProgression.js†L1-L260】【F:frontend/src/lib/components/RewardOverlay.svelte†L1-L220】
 
-When Drops finishes, `RewardOverlay` emits an `autofighter:reward-phase` telemetry event with the `drops-complete` kind so regression automation can confirm the transition before proceeding with card or relic checks.
+When Drops finishes, `RewardOverlay` emits an `autofighter:reward-phase` telemetry event with the `drops-complete` kind so regression automation can confirm the transition before proceeding with card or relic checks. Subsequent phase transitions fire ARIA announcements and update the confirm panel state for keyboard users.【F:frontend/src/lib/components/RewardOverlay.svelte†L1-L220】【F:frontend/src/lib/systems/rewardTelemetry.js†L1-L80】
+
+## Phase controller and countdown
+
+`RewardOverlay` listens for `enter` and `exit` events from `rewardPhaseController`, wiring analytics, countdown timers, and focus management into each transition. A dedicated advance panel opens once both `current` and `next` phases are available, displaying an `Advance` button and a 10-second countdown that auto-confirms staged entries when time elapses. The panel switches to confirm mode whenever a staged card or relic is highlighted so mouse and keyboard users see a single confirmation affordance instead of separate buttons.【F:frontend/src/lib/components/RewardOverlay.svelte†L200-L520】【F:frontend/src/lib/components/RewardOverlay.svelte†L760-L1040】
+
+The controller exposes imperative helpers (`advanceRewardPhase`, `skipToRewardPhase`, `resetRewardProgression`) that automation and idle-mode scripts consume to keep up with backend snapshots. When the snapshot lacks phases, the controller marks itself as a legacy flow; the overlay disables the countdown, shows a warning message, and relies on the older confirm buttons so QA can continue testing without blocking.【F:frontend/src/lib/systems/overlayState.js†L1-L120】【F:frontend/src/lib/systems/rewardProgression.js†L200-L420】【F:frontend/src/lib/components/RewardOverlay.svelte†L520-L760】
+
+## Automation hooks
+
+Idle-mode helpers in `rewardAutomation.js` inspect both the raw room data and the current phase snapshot to decide whether to auto-select a choice, acknowledge loot, or advance to the next step. The overlay exposes `rewardSelect` and `lootAcknowledge` events so automation can respond to countdown completions or pending staged entries, while manual users still drive the confirm workflow through the advance panel.【F:frontend/src/lib/utils/rewardAutomation.js†L1-L200】【F:frontend/src/lib/components/RewardOverlay.svelte†L1120-L1500】
 
 Selecting a card posts to `/cards/<run_id>` via the `chooseCard` API helper once the player confirms, clearing `card_choices`. The "Next Room" button remains disabled until all selections are resolved. Clicking it dismisses the popup, unmounts `BattleView`, and calls `/run/<id>/next` to advance the map.
 
 When a relic reward is selected, the overlay shows its `about` text so players
 see the effect with the next stack applied.
+
+Cancelling a staged entry emits `rewardSelect` with `intent: 'cancel'`, clears the confirm panel, and reopens the phase in the controller so reconnecting clients remain in sync with backend `awaiting_*` flags. The advance panel immediately reverts to countdown mode, signalling that a new selection is required before the run can progress.【F:frontend/src/lib/components/RewardOverlay.svelte†L960-L1200】【F:frontend/src/lib/components/RewardOverlay.svelte†L1500-L1800】
 
 ## Confirm control styling & accessibility
 
@@ -59,8 +71,16 @@ Screenshot references:
 - Card preview — see `.codex/screenshots/reward-overlay-card-preview.png`.
 - Relic preview — see `.codex/screenshots/reward-overlay-relic-preview.png`.
 
+## QA checklist
+
+- Verify phase announcements and countdown prompts when staging cards or relics. The advance panel should flip into confirm mode and display `Highlighted card ready` once a card is selected.【F:frontend/src/lib/components/RewardOverlay.svelte†L760-L1040】【F:frontend/tests/reward-overlay-confirmation-flow.vitest.js†L21-L133】
+- Trigger legacy fallback by omitting `reward_progression` from room data and confirm the overlay surfaces the warning banner instead of hanging the UI.【F:frontend/src/lib/components/RewardOverlay.svelte†L520-L760】【F:frontend/tests/reward-overlay-confirmation-flow.vitest.js†L134-L213】
+- Exercise automation helpers in idle mode to ensure they respect the current phase snapshot and stop issuing actions when staging buckets still contain entries.【F:frontend/src/lib/utils/rewardAutomation.js†L1-L200】【F:frontend/tests/reward-automation.vitest.js†L1-L120】
+
 ## Testing
-- `bun test frontend/tests/rewardoverlay.test.js`
+- `bun test frontend/tests/reward-overlay-confirmation-flow.vitest.js`
+- `bun test frontend/tests/reward-automation.vitest.js`
+- `bun test frontend/tests/reward-overlay-advance-panel.vitest.js`
 
 ## Visual notes
 - Card/relic artwork now renders at full opacity. Heavy darkening over the glyph image was removed from `CardArt.svelte` to avoid the gray overlay appearance while keeping a subtle highlight and border twinkles.

--- a/.codex/instructions/plugin-system.md
+++ b/.codex/instructions/plugin-system.md
@@ -111,3 +111,8 @@ The plugin ecosystem offers two primary coordination patterns:
 - **Passive registry** – Each entity creates its own dispatcher that iterates over its equipped passives.
 
 To align the registry with loop‑responsiveness guidelines, plan to insert a small delay such as `await asyncio.sleep(0.002)` inside long-running registry loops. This mirrors the event bus’s cooperative scheduling while retaining per-entity isolation.
+
+## Reward preview obligations
+
+- Card and relic plugins must either supply `effects` or override `build_preview` so the reward overlay can display preview metadata for staged selections. Use `autofighter.reward_preview.merge_preview_payload` to merge custom payloads with default stat math so reconnects remain deterministic.【F:backend/autofighter/reward_preview.py†L55-L189】【F:backend/services/reward_service.py†L68-L324】
+- Populate `preview_triggers` or embed trigger entries in the custom payload when rewards subscribe to event bus hooks. Without this metadata the Drops → Cards → Relics → Battle Review state machine cannot narrate upcoming activations for QA.【F:backend/plugins/cards/_base.py†L130-L190】【F:backend/plugins/relics/_base.py†L70-L150】

--- a/.codex/tasks/docs/11e73db5-reward-flow-docs-refresh.md
+++ b/.codex/tasks/docs/11e73db5-reward-flow-docs-refresh.md
@@ -21,3 +21,5 @@ Document the new staged reward pipeline so plugin authors, designers, and QA und
 
 ## Why this matters for players
 Clear documentation speeds up adoption of the staging system, meaning more rewards arrive with accurate previews and fewer bugs. Faster iteration keeps the game feeling polished and responsive to player feedback.
+
+ready for review


### PR DESCRIPTION
## Summary
- document the four-phase reward pipeline across the post-fight loot, battle endpoint payload, and reward overlay guides
- expand card and relic author documentation plus battle-room/plugin-system instructions so preview metadata and reward progression stay in sync
- close out the reward flow documentation task with the latest guidance

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_b_68fc69421570832cad6c6e8dd776a914