### PR TITLE
Add Supercell Conductor Tailwind bonus action logic

### DIFF
--- a/.codex/tasks/cards/b00303e1-supercell-conductor-card.md
+++ b/.codex/tasks/cards/b00303e1-supercell-conductor-card.md
@@ -26,3 +26,5 @@ Create a four-star reward that captures LadyStorm's slipstream-and-burst gamepla
 
 ## Player impact
 Supercell Conductor supplies Wind/Lightning lineups with periodic tempo spikes that soften enemy defenses, supporting aggressive combo lines distinct from Overclock's global action flood.
+
+ready for review

--- a/backend/plugins/cards/supercell_conductor.py
+++ b/backend/plugins/cards/supercell_conductor.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from contextlib import suppress
+from dataclasses import dataclass
+from dataclasses import field
+from typing import Any
+from typing import Iterable
+
+from autofighter.stat_effect import StatEffect
+from autofighter.stats import BUS
+from plugins.cards._base import CardBase
+
+
+@dataclass
+class SupercellConductor(CardBase):
+    """Four-star card that injects periodic Tailwind bonus actions."""
+
+    id: str = "supercell_conductor"
+    name: str = "Supercell Conductor"
+    stars: int = 4
+    effects: dict[str, float] = field(
+        default_factory=lambda: {"atk": 2.4, "effect_hit_rate": 2.4}
+    )
+    about: str = (
+        "+240% ATK & +240% Effect Hit Rate; at battle start and every third round, "
+        "the fastest Wind or Lightning ally gains Tailwind: immediately queue a "
+        "bonus action at 50% damage with +30% Effect Hit Rate, then shred -10% "
+        "Mitigation from foes they strike for 1 turn."
+    )
+
+    async def apply(self, party) -> None:  # type: ignore[override]
+        await super().apply(party)
+
+        registry: dict[str, dict[str, Any]] = getattr(
+            party, "_supercell_conductor_state", {}
+        )
+        if not registry:
+            registry = {}
+            party._supercell_conductor_state = registry
+        if registry.get(self.id):
+            return
+
+        state: dict[str, Any] = {
+            "round_counter": 0,
+            "next_activation": 1,
+            "actors_remaining": set(),
+            "current": None,
+            "battle_started": False,
+        }
+        handlers: dict[str, Any] = {}
+        registry[self.id] = {"state": state, "handlers": handlers}
+
+        def _cleanup() -> None:
+            registry.pop(self.id, None)
+            current = state.get("current")
+            if current is not None:
+                _clear_modifier(current)
+                state["current"] = None
+            state["actors_remaining"].clear()
+            state["round_counter"] = 0
+            state["next_activation"] = 1
+            state["battle_started"] = False
+            self.cleanup_subscriptions()
+
+        def _living_members() -> list[Any]:
+            return [
+                member
+                for member in getattr(party, "members", ())
+                if getattr(member, "hp", 0) > 0
+            ]
+
+        def _eligible_members(members: Iterable[Any]) -> list[Any]:
+            eligible: list[Any] = []
+            for member in members:
+                damage_type = getattr(member, "damage_type", None)
+                ident = getattr(damage_type, "id", None)
+                if ident is None:
+                    continue
+                try:
+                    lower_ident = str(ident).lower()
+                except Exception:
+                    continue
+                if lower_ident not in {"wind", "lightning"}:
+                    continue
+                eligible.append(member)
+            return eligible
+
+        def _clear_modifier(current: dict[str, Any]) -> None:
+            ally = current.get("ally")
+            effect_name = current.get("effect_name")
+            if ally is None or not effect_name:
+                current["active"] = False
+                current["foes"] = {}
+                return
+            with suppress(Exception):
+                ally.remove_effect_by_name(effect_name)
+            mods = getattr(ally, "mods", None)
+            if isinstance(mods, list):
+                mods[:] = [mid for mid in mods if mid != effect_name]
+            current["effect_name"] = None
+            current["active"] = False
+            current["foes"] = {}
+
+        async def _apply_mitigation_shred(current: dict[str, Any]) -> None:
+            foes: dict[int, Any] = current.get("foes", {})
+            ally = current.get("ally")
+            if ally is None:
+                return
+            if not foes:
+                return
+            for foe in list(foes.values()):
+                if getattr(foe, "hp", 0) <= 0:
+                    continue
+                mitigation_effect = StatEffect(
+                    name=f"{self.id}_tailwind_shred",
+                    stat_modifiers={"mitigation": -0.1},
+                    duration=1,
+                    source=self.id,
+                )
+                foe.add_effect(mitigation_effect)
+                await BUS.emit_async(
+                    "card_effect",
+                    self.id,
+                    foe,
+                    "tailwind_mitigation_shred",
+                    -10,
+                    {
+                        "target_id": getattr(foe, "id", "foe"),
+                        "mitigation_change_percent": -10,
+                        "duration": 1,
+                        "source": getattr(ally, "id", None),
+                    },
+                )
+
+        async def _activate_bonus_turn(ally: Any) -> None:
+            current = state.get("current")
+            if not current or current.get("active"):
+                return
+            _clear_modifier(current)
+            current_atk = getattr(ally, "atk", 0)
+            target_atk = int(round(current_atk * 0.5))
+            atk_delta = target_atk - current_atk
+
+            current_effect_hit = getattr(ally, "effect_hit_rate", 0.0)
+            target_effect_hit = current_effect_hit * 1.3
+            effect_delta = target_effect_hit - current_effect_hit
+
+            effect_name = f"{self.id}_tailwind_bonus"
+            bonus_effect = StatEffect(
+                name=effect_name,
+                stat_modifiers={
+                    "atk": atk_delta,
+                    "effect_hit_rate": effect_delta,
+                },
+                duration=2,
+                source=self.id,
+            )
+            ally.add_effect(bonus_effect)
+            mods = getattr(ally, "mods", None)
+            if isinstance(mods, list):
+                mods[:] = [mid for mid in mods if mid != effect_name]
+                mods.append(effect_name)
+            current["effect_name"] = effect_name
+            current["active"] = True
+            current["foes"] = {}
+            await BUS.emit_async(
+                "card_effect",
+                self.id,
+                ally,
+                "tailwind_bonus_prepared",
+                50,
+                {
+                    "effect_hit_bonus_percent": 30,
+                    "damage_modifier_percent": 50,
+                    "ally_id": getattr(ally, "id", "ally"),
+                },
+            )
+
+        async def _trigger_tailwind() -> None:
+            if state.get("current") is not None:
+                state["next_activation"] += 3
+                return
+            members = _living_members()
+            candidates = _eligible_members(members)
+            if not candidates:
+                state["next_activation"] += 3
+                return
+            ally = max(
+                candidates,
+                key=lambda member: (
+                    getattr(member, "spd", 0),
+                    getattr(member, "actions_per_turn", 1),
+                    getattr(member, "atk", 0),
+                ),
+            )
+            current = {
+                "ally": ally,
+                "effect_name": None,
+                "foes": {},
+                "has_acted": False,
+                "active": False,
+            }
+            state["current"] = current
+            state["next_activation"] += 3
+            await BUS.emit_async(
+                "card_effect",
+                self.id,
+                ally,
+                "tailwind_granted",
+                1,
+                {
+                    "ally_id": getattr(ally, "id", "ally"),
+                    "next_round_trigger": state["next_activation"],
+                },
+            )
+            await BUS.emit_async("extra_turn", ally)
+
+        async def _handle_battle_start(entity, *_args) -> None:
+            if entity not in getattr(party, "members", ()):  # ignore foe pulses
+                return
+            if state["battle_started"]:
+                return
+            state["battle_started"] = True
+            state["actors_remaining"].clear()
+            state["round_counter"] = 0
+            state["next_activation"] = 1
+            await _trigger_tailwind()
+
+        async def _handle_battle_end(entity) -> None:
+            if entity in getattr(party, "members", ()):
+                _cleanup()
+
+        async def _on_turn_start(actor=None, *_args) -> None:
+            if actor is None:
+                members = _living_members()
+            else:
+                members = _living_members()
+            if not members:
+                return
+            living_ids = {id(member) for member in members}
+            remaining: set[int] = state["actors_remaining"]
+            remaining &= living_ids
+
+            current = state.get("current")
+            if current is not None and (
+                getattr(current.get("ally"), "hp", 0) <= 0 or current.get("ally") not in members
+            ):
+                _clear_modifier(current)
+                state["current"] = None
+
+            if not remaining:
+                state["round_counter"] += 1
+                remaining.update(living_ids)
+                if (
+                    state["round_counter"] >= state["next_activation"]
+                    and state.get("current") is None
+                ):
+                    await _trigger_tailwind()
+
+            if actor in members:
+                actor_id = id(actor)
+                if actor_id in remaining:
+                    remaining.remove(actor_id)
+                current = state.get("current")
+                if current and actor is current.get("ally"):
+                    if not current.get("has_acted"):
+                        current["has_acted"] = True
+                    else:
+                        await _activate_bonus_turn(actor)
+
+        async def _on_hit_landed(attacker, target, *_extra) -> None:
+            current = state.get("current")
+            if not current or not current.get("active"):
+                return
+            ally = current.get("ally")
+            if attacker is not ally:
+                return
+            if getattr(target, "hp", 0) <= 0:
+                return
+            foes = current.setdefault("foes", {})
+            foes[id(target)] = target
+
+        async def _on_action_used(actor, *_extra) -> None:
+            current = state.get("current")
+            if not current or actor is not current.get("ally"):
+                return
+            if not current.get("active"):
+                return
+            await _apply_mitigation_shred(current)
+            ally = current.get("ally")
+            await BUS.emit_async(
+                "card_effect",
+                self.id,
+                ally,
+                "tailwind_bonus_spent",
+                len(current.get("foes", {})),
+                {
+                    "ally_id": getattr(ally, "id", "ally"),
+                    "foes_affected": [
+                        getattr(foe, "id", "foe")
+                        for foe in current.get("foes", {}).values()
+                    ],
+                },
+            )
+            _clear_modifier(current)
+            state["current"] = None
+
+        def _register(event: str, callback) -> None:
+            handlers[event] = callback
+            self.subscribe(event, callback)
+
+        _register("battle_start", _handle_battle_start)
+        _register("battle_end", _handle_battle_end)
+        _register("turn_start", _on_turn_start)
+        _register("hit_landed", _on_hit_landed)
+        _register("action_used", _on_action_used)

--- a/backend/tests/test_supercell_conductor.py
+++ b/backend/tests/test_supercell_conductor.py
@@ -1,0 +1,155 @@
+import asyncio
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+import llms.torch_checker as torch_checker
+
+from autofighter.party import Party
+from autofighter.stats import BUS
+from autofighter.stats import set_battle_active
+from plugins.cards.supercell_conductor import SupercellConductor
+from plugins.characters.ally import Ally
+from plugins.characters.becca import Becca
+from plugins.characters.foe_base import FoeBase
+from plugins.characters.lady_storm import LadyStorm
+from plugins.damage_types import load_damage_type
+
+
+@pytest.mark.asyncio
+async def test_supercell_conductor_bonus_action_and_debuff(monkeypatch):
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+    card = SupercellConductor()
+    storm = LadyStorm()
+    storm.id = "storm"
+    storm.spd = 400
+    storm.atk = 200
+    storm.effect_hit_rate = 1.0
+    storm.damage_type = load_damage_type("Lightning")
+
+    partner = Ally()
+    partner.id = "partner"
+    partner.spd = 220
+    partner.damage_type = load_damage_type("Fire")
+
+    party = Party(members=[storm, partner])
+    await card.apply(party)
+
+    foe = FoeBase()
+    foe.id = "foe"
+    foe.mitigation = 1.0
+
+    extra_turns: list[object] = []
+
+    def _record_extra_turn(actor):
+        extra_turns.append(actor)
+
+    BUS.subscribe("extra_turn", _record_extra_turn)
+    set_battle_active(True)
+    try:
+        await BUS.emit_async("battle_start", storm)
+        await BUS.emit_async("battle_start", partner)
+        await BUS.emit_async("battle_start", foe)
+        await asyncio.sleep(0)
+
+        assert extra_turns and extra_turns[0] is storm
+
+        base_atk = storm.atk
+        base_effect_hit = storm.effect_hit_rate
+
+        await BUS.emit_async("turn_start", storm)
+        await BUS.emit_async("action_used", storm, foe, 0)
+        assert storm.atk == pytest.approx(base_atk)
+        assert storm.effect_hit_rate == pytest.approx(base_effect_hit)
+
+        await BUS.emit_async("turn_start", storm)
+        assert storm.atk == pytest.approx(base_atk * 0.5)
+        assert storm.effect_hit_rate == pytest.approx(base_effect_hit * 1.3)
+
+        await BUS.emit_async("hit_landed", storm, foe, 60, "attack", "tailwind_strike")
+        await BUS.emit_async("action_used", storm, foe, 60)
+        await asyncio.sleep(0)
+
+        assert storm.atk == pytest.approx(base_atk)
+        assert storm.effect_hit_rate == pytest.approx(base_effect_hit)
+        assert foe.mitigation == pytest.approx(0.9)
+    finally:
+        BUS.unsubscribe("extra_turn", _record_extra_turn)
+        await BUS.emit_async("battle_end", storm)
+        await BUS.emit_async("battle_end", partner)
+        await BUS.emit_async("battle_end", foe)
+        set_battle_active(False)
+
+
+@pytest.mark.asyncio
+async def test_supercell_conductor_triggers_every_third_round(monkeypatch):
+    monkeypatch.setattr(torch_checker, "is_torch_available", lambda: False)
+    card = SupercellConductor()
+
+    storm = LadyStorm()
+    storm.id = "storm"
+    storm.spd = 380
+    storm.damage_type = load_damage_type("Wind")
+
+    partner = Becca()
+    partner.id = "becca"
+    partner.spd = 200
+    partner.damage_type = load_damage_type("Fire")
+
+    party = Party(members=[storm, partner])
+    await card.apply(party)
+
+    foe = FoeBase()
+    foe.id = "foe"
+
+    extra_turns: list[str | None] = []
+
+    def _record_extra_turn(actor):
+        extra_turns.append(getattr(actor, "id", None))
+
+    BUS.subscribe("extra_turn", _record_extra_turn)
+    set_battle_active(True)
+    try:
+        await BUS.emit_async("battle_start", storm)
+        await BUS.emit_async("battle_start", partner)
+        await BUS.emit_async("battle_start", foe)
+        await asyncio.sleep(0)
+        assert extra_turns == ["storm"]
+
+        async def resolve_tailwind_turn() -> None:
+            await BUS.emit_async("turn_start", storm)
+            await BUS.emit_async("action_used", storm, foe, 0)
+            await BUS.emit_async("turn_start", storm)
+            await BUS.emit_async("action_used", storm, foe, 0)
+            await asyncio.sleep(0)
+
+        async def resolve_normal_turn(actor) -> None:
+            await BUS.emit_async("turn_start", actor)
+            await BUS.emit_async("action_used", actor, foe, 0)
+            await asyncio.sleep(0)
+
+        await resolve_tailwind_turn()
+        await resolve_normal_turn(partner)
+
+        await resolve_normal_turn(storm)
+        await resolve_normal_turn(partner)
+
+        await resolve_normal_turn(storm)
+        await resolve_normal_turn(partner)
+
+        await BUS.emit_async("turn_start", storm)
+        await asyncio.sleep(0)
+        assert extra_turns.count("storm") == 2
+
+        await BUS.emit_async("action_used", storm, foe, 0)
+        await BUS.emit_async("turn_start", storm)
+        await BUS.emit_async("action_used", storm, foe, 0)
+        await resolve_normal_turn(partner)
+    finally:
+        BUS.unsubscribe("extra_turn", _record_extra_turn)
+        await BUS.emit_async("battle_end", storm)
+        await BUS.emit_async("battle_end", partner)
+        await BUS.emit_async("battle_end", foe)
+        set_battle_active(False)


### PR DESCRIPTION
## Summary
- implement the Supercell Conductor 4★ card plugin with Tailwind bonus-action stat tuning and mitigation shred handling
- add async tests covering the Tailwind bonus action flow and third-round cadence triggers

## Testing
- uv run pytest tests/test_supercell_conductor.py

------
https://chatgpt.com/codex/tasks/task_b_68fc7471eef8832cbd4dd57c5d3da0f3