### PR TITLE
Fix Flux Paradox Engine state cleanup

### DIFF
--- a/backend/plugins/cards/flux_paradox_engine.py
+++ b/backend/plugins/cards/flux_paradox_engine.py
@@ -81,6 +81,12 @@ class FluxParadoxEngine(CardBase):
                 foes = state.get("foes")
                 if isinstance(foes, dict):
                     foes.clear()
+                state_store.pop(self.id, None)
+                if not state_store:
+                    try:
+                        delattr(party, "_flux_paradox_engine_state")
+                    except AttributeError:
+                        pass
                 return
 
             foes = state.get("foes")


### PR DESCRIPTION
## Summary
- clear the cached Flux Paradox Engine state when battles end so subsequent instances can re-register their event hooks

## Testing
- uv run pytest tests/test_flux_paradox_engine.py *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_b_68fd882fc968832c978a18dcc63cdef9