### PR TITLE
Audit: flag Eclipsing Veil double stacking

### DIFF
--- a/.codex/tasks/passives/4bf8857c-lady-darkness-event-hooks.md
+++ b/.codex/tasks/passives/4bf8857c-lady-darkness-event-hooks.md
@@ -25,4 +25,12 @@ No event subscriptions exist for the passive, and `PassiveRegistry` never calls 
 - Lady Darkness passively heals when any DoT ticks on the battlefield and gains stacking attack buffs when she resists debuffs.
 - Event subscriptions are cleaned up to avoid leaks when battles end.
 - Automated tests cover both the DoT siphon and resist bonus flows.
-ready for review
+
+### Audit Findings (2025-02-15)
+- ✅ Event subscriptions exist and DoT siphon healing triggers through the standard healing pipeline.
+- ⚠️ Attack buffs are double-counted after the next `apply()` call. The follow-up instance restores the cached bonus with a new
+  `lady_darkness_eclipsing_veil_debuff_resistance_bonus` effect while the previous
+  `lady_darkness_eclipsing_veil_resist_bonus_{id(target)}` effect remains active, so Lady gains +10% instead of the intended +5%
+  after a single resist. Reuse the same effect name (or otherwise ensure only one attack buff effect remains) when reapplying the passive so cached stacks do not stack twice.
+
+more work needed — Resolve the duplicate attack-buff effect so cached stacks reapply without double-counting before re-requesting review.


### PR DESCRIPTION
## Summary
- update the Lady Darkness Eclipsing Veil task to record audit findings about duplicate attack buff effects when reapplying the passive

## Testing
- uv run pytest tests/test_lady_darkness_eclipsing_veil.py

------
https://chatgpt.com/codex/tasks/task_b_68fd90cda8f0832caf8cde382e0541c7