### PR TITLE
Add task for correcting foe mitigation/vitality stack scaling

### DIFF
--- a/.codex/tasks/dbba174d-foe-mit-vitality-scaling.md
+++ b/.codex/tasks/dbba174d-foe-mit-vitality-scaling.md
@@ -1,0 +1,20 @@
+# Fix foe mitigation/vitality stack scaling in run start flow
+
+## Problem
+The run start flow currently records the `foe_mitigation` and `foe_vitality` modifier stacks with an additive value of `+0.00001` per stack. According to design feedback from Luna Midori, each stack should apply `+2.50` mitigation or vitality instead. The mismatch makes the stored modifier context almost zeroed out, causing downstream systems like the spawn pressure calculation and the autofighter foe factory to underpower stacked runs.
+
+## Why this matters
+* Spawn pressure and foe stat deltas in `backend/services/run_configuration.py` rely on the effective bonus captured in the modifier context. Using `0.00001` per stack effectively neuters these modifiers, invalidating balance assumptions when runs are resumed from their snapshot.
+* The foe factory (`backend/autofighter/rooms/foe_factory.py`) applies `RunModifierContext.foe_stat_deltas` to live enemy stats. Values on the order of `0.00001` are imperceptible, so the feature fails silently for players.
+
+## Requirements
+* Update the modifier definitions for `foe_mitigation` and `foe_vitality` so their additive bonus is `+2.50` per stack before diminishing returns. Ensure the descriptive copy shown in the wizard matches the new scaling.
+* Propagate the new per-stack value through any helper that exposes preview data or persists modifier snapshots (e.g., `_foe_modifier_effect`). Confirm the stored `effective_bonus` reflects the new scaling.
+* Revisit spawn pressure tuning once the higher deltas are in place. If the new `+2.50` bonus destabilizes the pressure curve, adjust the mitigation/vitality weights so the resulting `foe_strength_score` stays within the intended range (1.0–5.0).
+* Add or update regression coverage in `backend/tests/test_run_configuration_context.py` (or introduce a new test) to assert both modifiers report `+2.5` per stack in their effective bonus when no diminishing returns apply.
+* Document the new scaling in the appropriate backend implementation notes (likely `backend/.codex/implementation/foe-scaling.md` or a related file) if those notes currently reference the old values.
+
+## Definition of done
+* The run start wizard snapshots show `+2.50` per stack for both modifiers, and the persisted modifier context records the expected additive bonus.
+* Spawn pressure remains within the documented bounds after applying the revised bonuses (include reasoning or measurements in the PR notes/tests).
+* Tests covering the modifier context pass with the new scaling.


### PR DESCRIPTION
## Summary
- add a high-priority task describing the work needed to raise foe mitigation and vitality modifier stacks to +2.50 per stack

## Testing
- [ ] Backend tests
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [x] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
https://chatgpt.com/codex/tasks/task_b_68fd9423eb80832c8d65d04d8e1b17f5