### PR TITLE
[TASKS] Document party menu cleanup and roster scroll fix

### DIFF
--- a/.codex/tasks/2083f2c4-party-picker-scroll.md
+++ b/.codex/tasks/2083f2c4-party-picker-scroll.md
@@ -1,0 +1,27 @@
+# Fix PartyPicker roster scrolling and add gradient fades
+
+## Problem
+When players open the PartyPicker via the run-start flow with a large roster, the entire overlay grows taller than the viewport. The browser ends up scrolling the full window instead of keeping the menu pinned, and the Party roster header jumps off screen. QA also reported the lack of any visual affordance that more characters are available beyond the fold.
+
+## Why this matters
+* The roster list in `frontend/src/lib/components/PartyRoster.svelte` already uses `overflow-y: auto`, but container sizing and flex rules in `PartyPicker.svelte` and `MenuPanel.svelte` allow the overlay to expand vertically, breaking the modal illusion.
+* Scrolling the whole page can expose background elements and causes focus loss for keyboard/gamepad users, which is a regression from the intended single-column PartyPicker layout.
+* Without fade indicators at the top and bottom of the roster column, players may not realize more characters exist off-screen, especially after we remove the redundant Party entry elsewhere in the UI.
+
+## Requirements
+* Constrain the PartyPicker overlay so only the roster column scrolls:
+  * Audit the grid/flex sizing in `frontend/src/lib/components/PartyPicker.svelte` and ensure the left column with `<PartyRoster>` honors a max height tied to the MenuPanel viewport.
+  * If the issue originates from `MenuPanel.svelte` (e.g., missing `min-height: 0` or overflow handling), patch it so the modal container remains fixed while inner regions scroll independently.
+* Update `PartyRoster.svelte` to keep the Party header, sort controls, and inline divider pinned while the list of characters scrolls beneath them.
+* Add subtle top/bottom gradient fades inside the scrolling region to hint at additional content. Reuse existing color tokens where possible so the fades match the glass UI.
+* Verify the compact roster variant (used in overlays like the Combat Viewer and minimized layouts) still renders correctly without inheriting the fades or scroll constraints.
+* Cover the change with at least one frontend test:
+  * Extend an existing Vitest/Playwright test or add a new component-level test under `frontend/tests/` that mounts `PartyPicker` with >12 characters and asserts the scroll container height stays within the viewport and the gradient elements render.
+* Document the updated behavior:
+  * Append a note to `.codex/implementation/party-ui.md` outlining the roster scroll constraints and gradient indicators.
+  * Update any run-start UX notes in `.codex/instructions/main-menu.md` or related planning docs if they reference the previous scrolling quirk.
+
+## Definition of done
+* Opening PartyPicker with a large roster keeps the overlay anchored; only the roster list scrolls while the Party header remains visible.
+* Top and bottom fades render when the roster overflows and disappear when the list fits without scrolling.
+* Automated coverage captures the scroll container behavior, and the documentation describes the new layout.

--- a/.codex/tasks/9c115642-remove-party-main-menu.md
+++ b/.codex/tasks/9c115642-remove-party-main-menu.md
@@ -1,0 +1,23 @@
+# Remove standalone Party entry from the main menu
+
+## Problem
+The home screen currently advertises a dedicated “Party” entry in both the top navigation bar and the right-hand action list. Opening it duplicates the run-start overlay without providing any additional context, so the extra button feels redundant and confuses players about when party edits are needed.
+
+## Why this matters
+* `frontend/src/lib/components/NavBar.svelte` and `RunButtons.svelte` expose the PartyPicker overlay in multiple places, leading to duplicate affordances that distract from the Run flow.
+* Documentation in `frontend/README.md` and `.codex/implementation/main-menu.md` still promises a Party tile, so the UX copy drifts further from reality each time the run-start overlay is refined.
+* Removing the redundant entry simplifies the top-level menu and narrows QA coverage back to the Run button while keeping the party editor accessible when starting a run.
+
+## Requirements
+* Update `frontend/src/lib/components/NavBar.svelte` so the Users/Party icon no longer renders on the home screen. Ensure nearby keyboard navigation and spacing stay intact after the button is removed.
+* Adjust `frontend/src/lib/components/RunButtons.svelte` to drop the Party item from `buildRunMenu`. Confirm the run panel still renders without layout gaps and no longer references the `handleParty` handler.
+* Remove or refactor any remaining handlers in `frontend/src/routes/+page.svelte` (and related stores) that exist solely to support the redundant main-menu Party entry.
+* Verify players can still edit their lineup when selecting **Run** (the Run chooser should still open the PartyPicker overlay before starting a run).
+* Refresh documentation that mentioned the main-menu Party shortcut:
+  * Update the “Main Menu actions” section in `frontend/README.md`.
+  * Revise `.codex/implementation/main-menu.md` (and any linked overview docs) to reflect the streamlined action list.
+
+## Definition of done
+* The home screen shows no Party icon/button outside of the Run start flow, and keyboard/mouse navigation remains smooth.
+* Clicking **Run** still opens the expected PartyPicker step before a run begins.
+* Documentation describing the main menu no longer lists a standalone Party entry.


### PR DESCRIPTION
## Summary
- add a high-priority task to remove the redundant Party entry from the home menu and refresh docs
- add a companion task to constrain PartyPicker scrolling, add gradient fades, and update coverage/documents

## Testing
- not run (task authoring only)


------
https://chatgpt.com/codex/tasks/task_b_68ff1cceb7c4832c8b54cf4b9850739c