### PR TITLE
Fix MenuPanel overflow handling for scrollable overlays

### DIFF
--- a/frontend/src/lib/components/MenuPanel.svelte
+++ b/frontend/src/lib/components/MenuPanel.svelte
@@ -78,6 +78,11 @@
     flex: 1 1 auto;
     width: 100%;
     min-height: 0;
+    overflow-x: hidden;
+    overflow-y: inherit;
+  }
+
+  .panel-content.panel-content--locked {
     overflow: hidden;
   }
 
@@ -112,7 +117,12 @@
   in:fly={flyInOptions}
   out:fly={flyOutOptions}
 >
-  <div class="panel-content" in:fade={fadeOptions} out:fade={fadeOptions}>
+  <div
+    class="panel-content"
+    class:panel-content--locked={!scrollable}
+    in:fade={fadeOptions}
+    out:fade={fadeOptions}
+  >
     <StarStorm color={starColor} reducedMotion={shouldReduceMotion} />
     <slot />
   </div>


### PR DESCRIPTION
## Summary
- let MenuPanel's content wrapper inherit vertical overflow when panels are scrollable so the outer container can expose its scrollbar
- add a locked modifier that still clamps overflow when scrollable panels are disabled

## Testing
- bun test tests/battle-review-menu-overlay.test.js
- bun x vitest run tests/party-picker-scroll.vitest.js *(fails: Unknown Error: [object Object])*

------
https://chatgpt.com/codex/tasks/task_b_68ff5365f5f8832cba57f0f8108b0bf2