### PR TITLE
[FIX] Clear PartyPicker Vitest warnings

### DIFF
--- a/.codex/tasks/2083f2c4-party-picker-scroll.md
+++ b/.codex/tasks/2083f2c4-party-picker-scroll.md
@@ -49,4 +49,9 @@ Tested by the lead dev: This task was not done right as there is no scrolling fo
 - Hoisted roster fixtures in the Vitest suite and verified gradients/scrolling by running `bun x vitest run tests/party-picker-scroll.vitest.js`.
 - Updated `.codex/implementation/party-ui.md` and `.codex/instructions/main-menu.md` to describe the locked overlay and gradient hints.
 
-more work needed — Vitest still reports unused-prop and unused-selector warnings; clean up the stub exports and stale CSS so the suite runs without warnings per frontend guidelines.
+## Status Update (Coder — 2025-02-19)
+- Consumed the unused stub props via hidden meta spans so the Svelte compiler recognises them during Vitest runs.
+- Removed stale pressure-control styles and marked dynamic roster selectors as `:global(...)` to silence the unused-selector warnings.
+- Re-ran `bun x vitest run tests/party-picker-scroll.vitest.js` to confirm a clean signal.
+
+ready for review

--- a/frontend/src/lib/components/PartyPicker.svelte
+++ b/frontend/src/lib/components/PartyPicker.svelte
@@ -628,13 +628,10 @@
     flex: 1 1 auto;
   }
   
-  .pressure-controls { margin-top: 0.5rem; }
-  .pressure-label { display: block; color: #fff; font-size: 0.9rem; margin-bottom: 0.3rem; text-align: center; }
-  .pressure-input { display: flex; align-items: center; justify-content: center; gap: 0.5rem; }
-  .pressure-btn { 
-    background: rgba(0,0,0,0.5); 
-    border: 1px solid rgba(255,255,255,0.35); 
-    color: #fff; 
+  .pressure-btn {
+    background: rgba(0,0,0,0.5);
+    border: 1px solid rgba(255,255,255,0.35);
+    color: #fff;
     padding: 0.3rem 0.5rem; 
     cursor: pointer;
     border-radius: 3px;

--- a/frontend/src/lib/components/PartyRoster.svelte
+++ b/frontend/src/lib/components/PartyRoster.svelte
@@ -565,7 +565,7 @@
 }
 
 /* Sparkle trail when moving into party */
-.char-row.sparkle::after {
+:global(.char-row.sparkle)::after {
   content: '';
   position: absolute;
   inset: 0;
@@ -588,7 +588,9 @@
 }
 
 /* Ensure content renders above the animated sweep */
-.row-img, .row-name, .row-type {
+.row-img,
+.row-name,
+:global(.row-type) {
   position: relative;
   z-index: 1;
 }
@@ -606,7 +608,7 @@
   color: #fff;
   font-size: 0.9rem;
 }
-.row-type { width: 20px; height: 20px; flex-shrink: 0; }
+:global(.row-type) { width: 20px; height: 20px; flex-shrink: 0; }
 
 /* compact mode */
 .roster.list.compact {

--- a/frontend/tests/__fixtures__/StubPlayerPreview.svelte
+++ b/frontend/tests/__fixtures__/StubPlayerPreview.svelte
@@ -7,9 +7,19 @@
   export let upgradeLoading = false;
   export let upgradeError = null;
   export let selectedStat = null;
+
+  $: meta = JSON.stringify({
+    rosterLength: Array.isArray(roster) ? roster.length : 0,
+    hasUpgradeContext: Boolean(upgradeContext),
+    hasUpgradeData: Boolean(upgradeData),
+    upgradeLoading: Boolean(upgradeLoading),
+    upgradeError: upgradeError ? String(upgradeError) : '',
+    selectedStat: selectedStat ?? ''
+  });
 </script>
 
 <div data-testid="stub-player-preview">
   <span data-testid="stub-player-preview-id">{previewId}</span>
   <span data-testid="stub-player-preview-mode">{mode}</span>
+  <span data-testid="stub-player-preview-props" aria-hidden="true" style="display: none">{meta}</span>
 </div>

--- a/frontend/tests/__fixtures__/StubStatTabs.svelte
+++ b/frontend/tests/__fixtures__/StubStatTabs.svelte
@@ -9,9 +9,23 @@
   export let upgradeError = null;
   export let upgradeContext = null;
   export let selectedStat = null;
+
+  $: meta = JSON.stringify({
+    rosterLength: Array.isArray(roster) ? roster.length : 0,
+    previewId: previewId ?? '',
+    selectedCount: Array.isArray(selected) ? selected.length : 0,
+    userBuffPercent: Number.isFinite(userBuffPercent) ? userBuffPercent : 0,
+    upgradeMode: Boolean(upgradeMode),
+    hasUpgradeData: Boolean(upgradeData),
+    upgradeLoading: Boolean(upgradeLoading),
+    upgradeError: upgradeError ? String(upgradeError) : '',
+    hasUpgradeContext: Boolean(upgradeContext),
+    selectedStat: selectedStat ?? ''
+  });
 </script>
 
 <div data-testid="stub-stat-tabs">
   <span data-testid="stub-stat-tabs-count">{roster.length}</span>
   <span data-testid="stub-stat-tabs-upgrade">{upgradeMode ? 'upgrade' : 'portrait'}</span>
+  <span data-testid="stub-stat-tabs-props" aria-hidden="true" style="display: none">{meta}</span>
 </div>


### PR DESCRIPTION
## Summary
- silence Svelte compiler warnings in the PartyPicker Vitest suite by cleaning up stub fixtures and CSS selectors
- remove unused pressure control styles and mark dynamic roster selectors as global so gradients still apply without warnings
- document the cleanup in the linked task file and rerun the targeted Vitest coverage

## Testing
- bun x vitest run tests/party-picker-scroll.vitest.js

------
https://chatgpt.com/codex/tasks/task_b_69021bf5e8cc832cab16f79721e66406