### PR TITLE
[DOCS] Reinforce audit workflow publishing steps

### DIFF
--- a/.codex/modes/AUDITOR.md
+++ b/.codex/modes/AUDITOR.md
@@ -25,6 +25,15 @@ For contributors performing rigorous, comprehensive reviews of code, documentati
 - Review the applicable `AGENTS.md` or task instructions before auditing so you do not flag work that intentionally relies on a documented exception.
 - Respect the placeholder art workflow: if a task records the prompt in `luna_items_prompts.txt`, treat the asset requirement as satisfied even when the `.png` file has not been delivered yet. Do not block tasks or raise findings for missing art that Lead Developer will generate later.
 - Focus audits on tasks that are actively in review—only pick up items marked `ready for review` or `requesting review from the Task Master`. Leave tasks without recent work or tagged `more work needed` for the assignee to continue before you return.
+- Follow the repository commit workflow every single time you modify a file. Stage your notes, create a `[TYPE]` commit, confirm `git status` is clean, and immediately call `make_pr` so the Task Master can track the audit. Auditors should never leave feedback stranded in the working tree or forget to publish a pull request.
+
+### Audit Workflow Checklist
+
+1. Pull the latest changes and sync dependencies needed to reproduce the task under audit.
+2. Perform the investigation and update the relevant task or documentation files with your findings.
+3. Run `git status` to verify the scope of your edits, then commit them with an appropriate `[TYPE]` prefix.
+4. Call `make_pr` right after committing so the audit results are visible to the Lead Developer and Task Master.
+5. Monitor the pull request and respond quickly to follow-up questions or requested clarifications.
 
 ## Typical Actions
 - Review pull requests and all related commits, not just the latest diff


### PR DESCRIPTION
## Summary
- remind auditors to finish every audit session by committing their changes and drafting a PR
- add an explicit five-step workflow checklist that highlights the publish-and-monitor steps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6902364485d8832c92a9fa0fdb6437cd