### PR TITLE
[FIX] Pause reward automation during battles

### DIFF
--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1182,7 +1182,15 @@
   }
 
   function validateAutomationAction(action) {
-    if (!fullIdleMode || lootAckBlocked || !runId || !roomData || rewardAdvanceInFlight || roomAdvanceInFlight) {
+    if (
+      !fullIdleMode ||
+      lootAckBlocked ||
+      !runId ||
+      !roomData ||
+      rewardAdvanceInFlight ||
+      roomAdvanceInFlight ||
+      battleActive
+    ) {
       return false;
     }
     const next = automationActionForState();
@@ -1238,7 +1246,16 @@
   }
 
   function maybeAutoHandle() {
-    if (!fullIdleMode || autoHandling || rewardAdvanceInFlight || roomAdvanceInFlight || !runId || !roomData || lootAckBlocked) {
+    if (
+      !fullIdleMode ||
+      autoHandling ||
+      rewardAdvanceInFlight ||
+      roomAdvanceInFlight ||
+      !runId ||
+      !roomData ||
+      lootAckBlocked ||
+      battleActive
+    ) {
       resetAutomationQueue();
       return;
     }
@@ -1260,12 +1277,12 @@
     });
   }
 
-  $: fullIdleMode && roomData && maybeAutoHandle();
-  $: if (!fullIdleMode) {
-    resetAutomationQueue();
-  }
-  $: if (!roomData) {
-    resetAutomationQueue();
+  $: {
+    if (fullIdleMode && roomData && !battleActive) {
+      maybeAutoHandle();
+    } else {
+      resetAutomationQueue();
+    }
   }
 
   onDestroy(() => {


### PR DESCRIPTION
## Summary
- stop reward automation from scheduling or running actions while a battle is active and cancel any pending timers when combat starts
- add a vitest to ensure battle review automation waits for combat to finish before advancing

## Testing
- bun x vitest run tests/reward-automation.vitest.js

------
https://chatgpt.com/codex/tasks/task_b_690254a08fe8832c81a1aee9fb2e33ca