### PR TITLE
Automate confirm actions in reward idle flow

### DIFF
--- a/frontend/src/lib/utils/rewardAutomation.js
+++ b/frontend/src/lib/utils/rewardAutomation.js
@@ -23,8 +23,16 @@ function computeLegacyAction({ roomData, stagedCards, stagedRelics }) {
     return { type: 'select-card', choice: roomData.card_choices[0] };
   }
 
+  if (roomData.awaiting_card && Array.isArray(stagedCards) && stagedCards.length > 0) {
+    return { type: 'confirm-card' };
+  }
+
   if (!roomData.awaiting_card && Array.isArray(roomData.relic_choices) && roomData.relic_choices.length > 0) {
     return { type: 'select-relic', choice: roomData.relic_choices[0] };
+  }
+
+  if (roomData.awaiting_relic && Array.isArray(stagedRelics) && stagedRelics.length > 0) {
+    return { type: 'confirm-relic' };
   }
 
   if (roomData.awaiting_loot || hasLootAvailable(roomData)) {
@@ -57,6 +65,9 @@ function computePhaseAction({ roomData, snapshot, stagedCards, stagedRelics }) {
       break;
     }
     case 'cards': {
+      if (roomData.awaiting_card && stagedCards.length > 0) {
+        return { type: 'confirm-card', phase };
+      }
       if (Array.isArray(roomData.card_choices) && roomData.card_choices.length > 0) {
         return { type: 'select-card', choice: roomData.card_choices[0] };
       }
@@ -66,6 +77,9 @@ function computePhaseAction({ roomData, snapshot, stagedCards, stagedRelics }) {
       break;
     }
     case 'relics': {
+      if (roomData.awaiting_relic && stagedRelics.length > 0) {
+        return { type: 'confirm-relic', phase };
+      }
       if (!roomData.awaiting_card && Array.isArray(roomData.relic_choices) && roomData.relic_choices.length > 0) {
         return { type: 'select-relic', choice: roomData.relic_choices[0] };
       }

--- a/frontend/src/lib/utils/rewardAutomationScheduler.js
+++ b/frontend/src/lib/utils/rewardAutomationScheduler.js
@@ -7,9 +7,17 @@ const DEFAULT_DELAY_BOUNDS = {
     normal: [750, 1200],
     reduced: [320, 480]
   },
+  'confirm-card': {
+    normal: [520, 820],
+    reduced: [260, 420]
+  },
   'select-relic': {
     normal: [750, 1200],
     reduced: [320, 480]
+  },
+  'confirm-relic': {
+    normal: [520, 820],
+    reduced: [260, 420]
   },
   advance: {
     normal: [520, 780],
@@ -63,6 +71,9 @@ export function actionsEqual(a, b) {
     const aId = a.choice?.id ?? a.choice?.value ?? null;
     const bId = b.choice?.id ?? b.choice?.value ?? null;
     if (aId !== bId) return false;
+  }
+  if (a.type === 'confirm-card' || a.type === 'confirm-relic') {
+    return true;
   }
   if (a.type === 'advance') {
     if ((a.phase ?? null) !== (b.phase ?? null)) {

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1212,6 +1212,15 @@
           }
           break;
         }
+        case 'confirm-card': {
+          try {
+            const res = await confirmCard();
+            if (res) {
+              applyRewardPayload(res, { type: 'card', intent: 'confirm' });
+            }
+          } catch {}
+          break;
+        }
         case 'select-relic': {
           if (action.choice) {
             try {
@@ -1221,6 +1230,15 @@
               }
             } catch {}
           }
+          break;
+        }
+        case 'confirm-relic': {
+          try {
+            const res = await confirmRelic();
+            if (res) {
+              applyRewardPayload(res, { type: 'relic', intent: 'confirm' });
+            }
+          } catch {}
           break;
         }
         case 'ack-loot': {


### PR DESCRIPTION
## Summary
- emit confirm-card and confirm-relic automation actions once staging is pending
- invoke confirmCard/confirmRelic during idle automation execution and align scheduler handling
- extend reward automation tests to cover confirm flow sequencing and add an integration-style idle mode scenario

## Testing
- bun x vitest run tests/reward-automation.vitest.js

------
https://chatgpt.com/codex/tasks/task_b_6902586d2a64832ca5413710892371ca