### PR TITLE
Fix Eclipse Reactor turn start subscriber signature

### DIFF
--- a/backend/plugins/relics/eclipse_reactor.py
+++ b/backend/plugins/relics/eclipse_reactor.py
@@ -142,7 +142,7 @@ class EclipseReactor(RelicBase):
                     },
                 )
 
-        async def _turn_start() -> None:
+        async def _turn_start(_entity=None, *_ignored) -> None:
             current_state = getattr(party, "_eclipse_reactor_state", state)
             if not current_state.get("surge_active"):
                 return


### PR DESCRIPTION
## Summary
- allow the Eclipse Reactor turn_start subscriber to accept the emitted entity argument

## Testing
- uv run pytest backend/tests/test_relic_effects_advanced.py -k eclipse_reactor

------
https://chatgpt.com/codex/tasks/task_b_690713417428832c848042c8855a0f0b