### PR TITLE
[FIX] Replace reward about strings with detailed fields

### DIFF
--- a/backend/autofighter/rooms/battle/resolution.py
+++ b/backend/autofighter/rooms/battle/resolution.py
@@ -164,14 +164,21 @@ async def resolve_rewards(
         log.warning("No card reward options available")
     card_choice_data = []
     for card in card_options:
+        try:
+            base_about = card.get_about_str()
+        except AttributeError:
+            base_about = getattr(card, "about", "")
+        full_about = getattr(card, "full_about", "") or base_about or ""
+        summarized_about = (
+            getattr(card, "summarized_about", "") or full_about or base_about or ""
+        )
         card_choice_data.append(
             {
                 "id": card.id,
                 "name": card.name,
                 "stars": card.stars,
-                "about": card.get_about_str(),
-                "full_about": getattr(card, "full_about", ""),
-                "summarized_about": getattr(card, "summarized_about", ""),
+                "full_about": full_about,
+                "summarized_about": summarized_about,
             }
         )
 
@@ -205,14 +212,18 @@ async def resolve_rewards(
     for relic in relic_options:
         current_stacks = party.relics.count(relic.id)
         next_stack = current_stacks + 1
+        base_about = relic.get_about_str(stacks=next_stack)
+        full_about = relic.full_about_stacks(stacks=next_stack) or base_about or ""
+        summarized_about = (
+            getattr(relic, "summarized_about", "") or full_about or base_about or ""
+        )
         relic_choice_data.append(
             {
                 "id": relic.id,
                 "name": relic.name,
                 "stars": relic.stars,
-                "about": relic.get_about_str(stacks=next_stack),
-                "full_about": relic.full_about_stacks(stacks=next_stack),
-                "summarized_about": getattr(relic, "summarized_about", ""),
+                "full_about": full_about,
+                "summarized_about": summarized_about,
                 "stacks": current_stacks,
             }
         )

--- a/backend/tests/test_card_rewards.py
+++ b/backend/tests/test_card_rewards.py
@@ -94,9 +94,12 @@ async def test_battle_offers_choices_and_applies_effect(app_with_db, monkeypatch
     assert data["party"][0]["atk"] == 100
     if not data["card_choices"]:
         pytest.skip("no card choices returned")
-    chosen = data["card_choices"][0]["id"]
-    assert data["card_choices"][0]["stars"] == 1
-    assert "about" in data["card_choices"][0]
+    first_choice = data["card_choices"][0]
+    chosen = first_choice["id"]
+    assert first_choice["stars"] == 1
+    assert "about" not in first_choice
+    assert isinstance(first_choice.get("full_about"), str)
+    assert isinstance(first_choice.get("summarized_about"), str)
 
     await client.post(f"/cards/{run_id}", json={"card": chosen})
     await client.post(f"/run/{run_id}/next")

--- a/backend/tests/test_relic_rewards.py
+++ b/backend/tests/test_relic_rewards.py
@@ -23,7 +23,7 @@ async def test_battle_offers_relic_choices(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_relic_choice_includes_about_and_stacks(monkeypatch):
+async def test_relic_choice_includes_about_fields_and_stacks(monkeypatch):
     node = MapNode(room_id=1, room_type="battle-normal", floor=1, index=1, loop=1, pressure=0)
     room = rooms_module.BattleRoom(node)
     member = Stats()
@@ -36,7 +36,10 @@ async def test_relic_choice_includes_about_and_stacks(monkeypatch):
     result = await room.resolve(party, {})
     relic = result["relic_choices"][0]
     assert relic["stacks"] == 1
-    assert "6%" in relic["about"]
+    assert "about" not in relic
+    assert relic["full_about"]
+    assert "6%" in relic["full_about"]
+    assert relic["summarized_about"]
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/test_reward_gate.py
+++ b/backend/tests/test_reward_gate.py
@@ -66,7 +66,8 @@ async def test_advance_room_requires_reward_selection(app_with_db):
                     "id": "micro_blade",
                     "name": "Micro Blade",
                     "stars": 1,
-                    "about": "Deal 110% ATK to the front foe.",
+                    "full_about": "Deal 110% ATK to the front foe.",
+                    "summarized_about": "Deal 110% ATK to the front foe.",
                 }
             ],
             "relic_choice_options": [
@@ -74,7 +75,8 @@ async def test_advance_room_requires_reward_selection(app_with_db):
                     "id": "threadbare_cloak",
                     "name": "Threadbare Cloak",
                     "stars": 2,
-                    "about": "Gain 20% damage reduction for 1 turn after a bonus action.",
+                    "full_about": "Gain 20% damage reduction for 1 turn after a bonus action.",
+                    "summarized_about": "Gain 20% damage reduction for 1 turn after a bonus action.",
                 }
             ],
         }
@@ -286,7 +288,8 @@ async def test_card_selection_unlocks_advancement(app_with_db):
                     "id": "micro_blade",
                     "name": "Micro Blade",
                     "stars": 1,
-                    "about": "Deal 110% ATK to the front foe.",
+                    "full_about": "Deal 110% ATK to the front foe.",
+                    "summarized_about": "Deal 110% ATK to the front foe.",
                 }
             ],
         }

--- a/backend/tests/test_reward_staging_confirmation.py
+++ b/backend/tests/test_reward_staging_confirmation.py
@@ -116,7 +116,8 @@ async def test_confirm_card_commits_and_unlocks_next_step() -> None:
                 "id": "arc_lightning",
                 "name": "Arc Lightning",
                 "stars": 3,
-                "about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
+                "full_about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
+                "summarized_about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
             }
         ],
         "relic_choices": [],
@@ -141,13 +142,18 @@ async def test_confirm_card_commits_and_unlocks_next_step() -> None:
     assert staged_card["id"] == "arc_lightning"
     assert staged_card["name"] == "Arc Lightning"
     assert staged_card["stars"] == 3
+    assert "about" not in staged_card
     assert (
-        staged_card["about"]
+        staged_card["full_about"]
+        == "+255% ATK; every attack chains 50% of dealt damage to a random foe."
+    )
+    assert (
+        staged_card["summarized_about"]
         == "+255% ATK; every attack chains 50% of dealt damage to a random foe."
     )
     preview = staged_card.get("preview")
     assert isinstance(preview, dict)
-    assert preview.get("summary") == staged_card["about"]
+    assert preview.get("summary") == staged_card["summarized_about"]
     stats = preview.get("stats")
     assert isinstance(stats, list) and stats
     atk_stat = stats[0]
@@ -381,7 +387,8 @@ async def test_cancel_card_reopens_progression_step() -> None:
                 "id": "arc_lightning",
                 "name": "Arc Lightning",
                 "stars": 3,
-                "about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
+                "full_about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
+                "summarized_about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
             }
         ],
         "relic_choices": [],
@@ -460,7 +467,8 @@ async def test_confirm_multiple_steps_advances_sequence() -> None:
                 "id": "old_coin",
                 "name": "Old Coin",
                 "stars": 2,
-                "about": "Gain 20% more gold from all sources.",
+                "full_about": "Gain 20% more gold from all sources.",
+                "summarized_about": "Gain 20% more gold from all sources.",
                 "stacks": 1,
             }
         ],

--- a/backend/tests/test_reward_staging_service_hooks.py
+++ b/backend/tests/test_reward_staging_service_hooks.py
@@ -116,7 +116,8 @@ async def test_select_card_stages_without_modifying_party() -> None:
                 "id": "arc_lightning",
                 "name": "Arc Lightning",
                 "stars": 3,
-                "about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
+                "full_about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
+                "summarized_about": "+255% ATK; every attack chains 50% of dealt damage to a random foe.",
             }
         ],
         "relic_choices": [],
@@ -137,6 +138,12 @@ async def test_select_card_stages_without_modifying_party() -> None:
     staged_cards = result["reward_staging"]["cards"]
     assert len(staged_cards) == 1
     assert staged_cards[0]["id"] == "arc_lightning"
+    assert "about" not in result["card"]
+    assert result["card"]["full_about"]
+    assert result["card"]["summarized_about"]
+    assert "about" not in staged_cards[0]
+    assert staged_cards[0]["full_about"]
+    assert staged_cards[0]["summarized_about"]
 
     assert party_manager is not None
     party = await asyncio.to_thread(party_manager.load_party, run_id)
@@ -150,6 +157,9 @@ async def test_select_card_stages_without_modifying_party() -> None:
     assert isinstance(progression_state, dict)
     assert progression_state.get("current_step") == "cards"
     assert state["reward_staging"]["cards"][0]["id"] == "arc_lightning"
+    assert "about" not in state["reward_staging"]["cards"][0]
+    assert state["reward_staging"]["cards"][0]["full_about"]
+    assert state["reward_staging"]["cards"][0]["summarized_about"]
     snapshot = lifecycle.battle_snapshots[run_id]
     assert snapshot["card_choices"] == []
     assert snapshot["awaiting_card"] is True
@@ -201,7 +211,8 @@ async def test_select_relic_stages_without_duplicate_application() -> None:
                 "id": "old_coin",
                 "name": "Old Coin",
                 "stars": 2,
-                "about": "Gain 20% more gold from all sources.",
+                "full_about": "Gain 20% more gold from all sources.",
+                "summarized_about": "Gain 20% more gold from all sources.",
                 "stacks": 1,
             }
         ],
@@ -224,6 +235,12 @@ async def test_select_relic_stages_without_duplicate_application() -> None:
     assert len(staged_relics) == 1
     assert staged_relics[0]["id"] == "old_coin"
     assert staged_relics[0]["stacks"] == 2
+    assert "about" not in result["relic"]
+    assert result["relic"]["full_about"]
+    assert result["relic"]["summarized_about"]
+    assert "about" not in staged_relics[0]
+    assert staged_relics[0]["full_about"]
+    assert staged_relics[0]["summarized_about"]
 
     assert party_manager is not None
     party = await asyncio.to_thread(party_manager.load_party, run_id)
@@ -239,6 +256,9 @@ async def test_select_relic_stages_without_duplicate_application() -> None:
     staged_state = state["reward_staging"]["relics"][0]
     assert staged_state["id"] == "old_coin"
     assert staged_state["stacks"] == 2
+    assert "about" not in staged_state
+    assert staged_state["full_about"]
+    assert staged_state["summarized_about"]
     snapshot = lifecycle.battle_snapshots[run_id]
     assert snapshot["relic_choices"] == []
     assert snapshot["awaiting_relic"] is True
@@ -248,4 +268,7 @@ async def test_select_relic_stages_without_duplicate_application() -> None:
     assert progression_snapshot.get("current_step") == "relics"
     staged_snapshot = snapshot["reward_staging"]["relics"][0]
     assert staged_snapshot["id"] == "old_coin"
+    assert "about" not in staged_snapshot
+    assert staged_snapshot["full_about"]
+    assert staged_snapshot["summarized_about"]
     assert staged_snapshot["stacks"] == 2


### PR DESCRIPTION
## Summary
- remove legacy about field from reward staging payloads while always populating full and summarized copy
- mirror the new reward copy contract in battle resolution responses and snapshots
- update reward-focused unit tests to enforce the new metadata fields and absence of the about key

## Testing
- not run (per instructions)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690d5bf8f3ac832c84fd7a90cf70b3d0)