### PR TITLE
[FIX] Align advance gating with choice entry arrays

### DIFF
--- a/frontend/src/lib/components/RewardOverlay.svelte
+++ b/frontend/src/lib/components/RewardOverlay.svelte
@@ -554,15 +554,15 @@
       case 'drops':
         return true;
       case 'cards':
-        if (!Array.isArray(cardChoices)) return false;
+        if (!Array.isArray(cardChoiceEntries)) return false;
         if (awaitingCard) return false;
-        if (Array.isArray(cardChoices) && cardChoices.length > 0) return false;
+        if (Array.isArray(cardChoiceEntries) && cardChoiceEntries.length > 0) return false;
         if (Array.isArray(stagedCardEntries) && stagedCardEntries.length > 0) return false;
         return true;
       case 'relics':
-        if (!Array.isArray(relicChoices)) return false;
+        if (!Array.isArray(relicChoiceEntries)) return false;
         if (awaitingRelic) return false;
-        if (Array.isArray(relicChoices) && relicChoices.length > 0) return false;
+        if (Array.isArray(relicChoiceEntries) && relicChoiceEntries.length > 0) return false;
         if (Array.isArray(stagedRelicEntries) && stagedRelicEntries.length > 0) return false;
         return true;
       default:


### PR DESCRIPTION
## Summary
- update the reward overlay advance gating to read the new card/relic choice entry arrays
- prevent reference errors during card or relic selection phases by using populated entry lists

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690eb08260fc832c947c11dec5096703)