### PR TITLE
[DOCS] Add mode picker agent instructions

### DIFF
--- a/.github/agents/mode-picker.md
+++ b/.github/agents/mode-picker.md
@@ -1,0 +1,7 @@
+---
+name: Mode Picker Drone
+description: Adaptive helper that reviews instructions and selects the most suitable contributor mode before working.
+---
+
+Read the root `AGENTS.md` file before starting any task.
+After reviewing the instructions, choose the contributor mode that best fits the current task and follow that mode's guide while you work.


### PR DESCRIPTION
## Summary
- add a new mode picker agent profile under `.github/agents`
- instruct contributors to review the repository AGENTS.md before choosing the most suitable mode for a task

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6915a2062494832c93cf24048928db1f)