### PR TITLE
Adjust target validation to use full candidate pool

### DIFF
--- a/backend/plugins/actions/_base.py
+++ b/backend/plugins/actions/_base.py
@@ -128,6 +128,7 @@ class TargetingRules:
                 actor,
                 context.allies_of(actor),
                 context.enemies_of(actor),
+                limit=False,
             )
         }
         if not allowed:
@@ -143,6 +144,8 @@ class TargetingRules:
         actor: "Stats",
         allies: Sequence["Stats"],
         enemies: Sequence["Stats"],
+        *,
+        limit: bool = True,
     ) -> list["Stats"]:
         """Return the default candidate list for this policy."""
 
@@ -162,6 +165,8 @@ class TargetingRules:
         if not self.allow_self:
             pool = [target for target in pool if target is not actor]
         if self.scope is TargetScope.ALL:
+            return pool
+        if not limit:
             return pool
         if self.scope is TargetScope.SINGLE and pool:
             return [pool[0]]


### PR DESCRIPTION
## Summary
- allow `TargetingRules.filter_targets` to optionally return the full candidate pool by skipping scope-based truncation
- update validation to compare selected targets against that full pool so multi-target selections outside the default slice are accepted

## Testing
- uv run --project backend ruff check backend/plugins/actions

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_691abcfe48f0832ca07d1c8addb5797a)