### PR TITLE
Normalize healing metadata defaults

### DIFF
--- a/backend/autofighter/stats.py
+++ b/backend/autofighter/stats.py
@@ -1045,7 +1045,7 @@ class Stats:
         )
         return amount
 
-    async def apply_healing(self, amount: int, healer: Optional["Stats"] = None, source_type: str = "heal", source_name: Optional[str] = None) -> int:
+    async def apply_healing(self, amount: int, healer: Optional["Stats"] = None, source_type: str = "Generic", source_name: Optional[str] = None) -> int:
         def _ensure(obj: "Stats") -> DamageTypeBase:
             dt = getattr(obj, "damage_type", Generic())
             if isinstance(dt, str):


### PR DESCRIPTION
## Summary
- default battle-context healing metadata to `Generic` and `system` so BUS events capture sources consistently
- align `Stats.apply_healing` default source type with the Generic damage type rather than the nonexistent "heal" type

## Testing
- [x] Backend tests (`uv run pytest tests/test_action_context.py`)
- [ ] Frontend tests
- [ ] Linting
- [ ] Doc sync updates (README and `.codex/implementation` docs; link tasks below)

## Checklist
- [ ] Linked or updated relevant `.codex/tasks` entries
- [ ] Updated player roster and foe docs if adding or modifying fighters or enemies
- [ ] Referenced `.codex/implementation/ui-animation-guidelines.md` when adding UI animations

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6921d2f65bc8832c9329138ef34bbca9)