### PR TITLE
[IMPL] Task 36f41aac: Complete Complex Glitched Passives

### DIFF
--- a/backend/plugins/passives/glitched/lady_storm_supercell.py
+++ b/backend/plugins/passives/glitched/lady_storm_supercell.py
@@ -1,26 +1,247 @@
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from typing import ClassVar
+from typing import Iterable
 
+from autofighter.stat_effect import StatEffect
 from plugins.passives.normal.lady_storm_supercell import LadyStormSupercell
+
+if TYPE_CHECKING:
+    from autofighter.stats import Stats
 
 
 @dataclass
 class LadyStormSupercellGlitched(LadyStormSupercell):
-    """[GLITCHED] Lady Storm's Supercell - doubled Wind/Lightning enhancements.
+    """[GLITCHED] Lady Storm's Supercell - doubled Wind/Lightning enhancements."""
 
-    This glitched variant doubles all stat bonuses from Wind and Lightning phases,
-    creating an extremely powerful dual-element stance system.
-    """
     plugin_type = "passive"
     id = "lady_storm_supercell_glitched"
     name = "Glitched Supercell"
-    trigger = "turn_start"
+    trigger = ["turn_start", "action_taken", "hit_landed"]
     max_stacks = 1
     stack_display = "spinner"
+
+    _storm_phase: ClassVar[dict[int, str]] = {}
+    _storm_charge: ClassVar[dict[int, int]] = {}
+
+    async def apply(
+        self,
+        target: "Stats",
+        *,
+        party: Iterable["Stats"] | None = None,
+        foes: Iterable["Stats"] | None = None,
+        **_: object,
+    ) -> None:
+        """Apply doubled Wind and Lightning baselines without altering phase flow."""
+
+        entity_id = id(target)
+        self._storm_phase.setdefault(entity_id, "wind")
+        self._storm_charge.setdefault(entity_id, 0)
+
+        base_attack = getattr(target, "_base_atk", target.atk)
+        base_defense = getattr(target, "_base_defense", target.defense)
+
+        tailwind_effect = StatEffect(
+            name=f"{self.id}_tailwind_core",
+            stat_modifiers={
+                "spd": 16,  # Was 8, now 16
+                "dodge_odds": 0.16,  # Was 0.08, now 0.16
+                "aggro_modifier": -50.0,  # Was -25.0, now -50.0
+            },
+            duration=-1,
+            source=self.id,
+        )
+        target.add_effect(tailwind_effect)
+
+        storm_edge_effect = StatEffect(
+            name=f"{self.id}_storm_edge",
+            stat_modifiers={
+                "atk": int(base_attack * 0.44),  # Was 0.22, now 0.44
+                "crit_rate": 0.24,  # Was 0.12, now 0.24
+                "effect_hit_rate": 0.30,  # Was 0.15, now 0.30
+            },
+            duration=-1,
+            source=self.id,
+        )
+        target.add_effect(storm_edge_effect)
+
+        storm_barrier_effect = StatEffect(
+            name=f"{self.id}_storm_barrier",
+            stat_modifiers={
+                "mitigation": 0.24,  # Was 0.12, now 0.24
+                "effect_resistance": 0.24,  # Was 0.12, now 0.24
+                "defense": int(base_defense * 0.30),  # Was 0.15, now 0.30
+            },
+            duration=-1,
+            source=self.id,
+        )
+        target.add_effect(storm_barrier_effect)
+
+        await self._spread_gale(target, party)
+
+        if foes:
+            for foe in foes:
+                if getattr(foe, "hp", 0) <= 0:
+                    continue
+                squall_marker = StatEffect(
+                    name=f"{self.id}_squall_marker_{entity_id}",
+                    stat_modifiers={"dodge_odds": -0.04},  # Was -0.02, now -0.04
+                    duration=2,
+                    source=self.id,
+                )
+                foe.add_effect(squall_marker)
+
+    async def on_action_taken(self, target: "Stats", **kwargs: object) -> None:
+        """Alternate phases with doubled buffs/debuffs."""
+
+        entity_id = id(target)
+        phase = self._storm_phase.get(entity_id, "wind")
+
+        party = kwargs.get("party")
+        foes = kwargs.get("foes")
+
+        allies: list["Stats"] = []
+        if party is not None:
+            if hasattr(party, "members"):
+                allies = [member for member in party.members if member is not target]
+            else:
+                allies = [member for member in party if member is not target]
+
+        foe_list: list["Stats"] = []
+        if foes is not None:
+            if hasattr(foes, "members"):
+                foe_list = list(foes.members)
+            else:
+                foe_list = list(foes)
+
+        if phase == "wind":
+            gale_effect = StatEffect(
+                name=f"{self.id}_slipstream",
+                stat_modifiers={"spd": 20, "dodge_odds": 0.12},  # Was 10/0.06, now doubled
+                duration=2,
+                source=self.id,
+            )
+            target.add_effect(gale_effect)
+
+            for ally in allies:
+                if getattr(ally, "hp", 0) <= 0:
+                    continue
+                ally_effect = StatEffect(
+                    name=f"{self.id}_slipstream_ally_{entity_id}",
+                    stat_modifiers={"spd": 12, "dodge_odds": 0.08},  # Was 6/0.04, now doubled
+                    duration=2,
+                    source=self.id,
+                )
+                ally.add_effect(ally_effect)
+
+            self._storm_phase[entity_id] = "lightning"
+            return
+
+        new_charge = min(self._storm_charge.get(entity_id, 0) + 1, 3)
+        self._storm_charge[entity_id] = new_charge
+
+        surge_effect = StatEffect(
+            name=f"{self.id}_voltage_field",
+            stat_modifiers={
+                "crit_rate": 0.10 * new_charge,  # Was 0.05 per charge, now doubled
+                "crit_damage": 0.16 * new_charge,  # Was 0.08 per charge, now doubled
+            },
+            duration=1,
+            source=self.id,
+        )
+        target.add_effect(surge_effect)
+
+        for foe in foe_list:
+            if getattr(foe, "hp", 0) <= 0:
+                continue
+            shock_effect = StatEffect(
+                name=f"{self.id}_charged_vulnerability_{entity_id}",
+                stat_modifiers={"mitigation": -0.08 * new_charge},  # Was -0.04, now -0.08
+                duration=1,
+                source=self.id,
+            )
+            foe.add_effect(shock_effect)
+
+        self._storm_phase[entity_id] = "wind"
+
+    async def on_hit_landed(
+        self,
+        attacker: "Stats",
+        target_hit: "Stats",
+        damage: int = 0,
+        action_type: str = "attack",
+        **_: object,
+    ) -> None:
+        """Detonate stored lightning charges with doubled multipliers."""
+
+        attacker_id = id(attacker)
+        charges = self._storm_charge.get(attacker_id, 0)
+        if charges <= 0:
+            return
+
+        bonus_damage = max(
+            int(attacker.atk * (0.60 + 0.30 * (charges - 1))),  # Was 0.3/0.15, now doubled
+            charges * 150,  # Was 75 per charge, now 150
+        )
+        try:
+            await target_hit.apply_damage(
+                bonus_damage,
+                attacker=attacker,
+                trigger_on_hit=False,
+                action_name="Supercell Surge",
+            )
+        except Exception:
+            pass
+
+        shock_lock = StatEffect(
+            name=f"{self.id}_grounding_shock",
+            stat_modifiers={
+                "mitigation": -0.12 * charges,  # Was -0.06, now -0.12
+                "dodge_odds": -0.04 * charges,  # Was -0.02, now -0.04
+            },
+            duration=2,
+            source=self.id,
+        )
+        target_hit.add_effect(shock_lock)
+
+        regen_effect = StatEffect(
+            name=f"{self.id}_storm_regain",
+            stat_modifiers={"regain": charges * 60},  # Was 30, now 60
+            duration=3,
+            source=self.id,
+        )
+        attacker.add_effect(regen_effect)
+
+        self._storm_charge[attacker_id] = 0
+
+    async def _spread_gale(
+        self,
+        target: "Stats",
+        party: Iterable["Stats"] | None,
+    ) -> None:
+        if party is None:
+            return
+
+        if hasattr(party, "members"):
+            members = party.members
+        else:
+            members = party
+
+        for ally in members:
+            if ally is target or getattr(ally, "hp", 0) <= 0:
+                continue
+            gale = StatEffect(
+                name=f"{self.id}_everstorm_aura_{id(target)}",
+                stat_modifiers={"spd": 8, "regain": 40},  # Was 4/20, now doubled
+                duration=3,
+                source=self.id,
+            )
+            ally.add_effect(gale)
 
     @classmethod
     def get_description(cls) -> str:
         return (
-            "[GLITCHED] Persistent Wind enhancements (doubled SPD/dodge) with Lightning charge buildup. "
-            "Alternates between Wind (evasion) and Lightning (offense) phases automatically, "
-            "providing massive stat swings based on current phase."
+            "[GLITCHED] Persistent tailwinds now grant +16 SPD, +16% dodge, and -50 aggro while doubling storm edges (+44% ATK, +24% crit, +30% effect hit). "
+            "Actions alternate wind slipstreams (+20 SPD/+12% dodge self, +12 SPD/+8% dodge allies) with lightning charges that stack doubled crit bonuses and -8% mitigation per charge. "
+            "Charged strikes detonate for doubled surge damage and regen while heavily grounding foes."
         )

--- a/backend/plugins/passives/glitched/persona_light_and_dark_duality.py
+++ b/backend/plugins/passives/glitched/persona_light_and_dark_duality.py
@@ -1,28 +1,227 @@
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+from typing import ClassVar
 
+from autofighter.stat_effect import StatEffect
 from plugins.passives.normal.persona_light_and_dark_duality import (
     PersonaLightAndDarkDuality,
 )
 
+if TYPE_CHECKING:
+    from autofighter.stats import Stats
+
 
 @dataclass
 class PersonaLightAndDarkDualityGlitched(PersonaLightAndDarkDuality):
-    """[GLITCHED] Persona Light and Dark's Duality - doubled stance bonuses.
+    """[GLITCHED] Persona Light and Dark's Duality - doubled stance bonuses."""
 
-    This glitched variant doubles all bonuses from Light (healing/shields) and
-    Dark (damage/DoTs) stances, creating extreme swings between support and offense.
-    """
     plugin_type = "passive"
     id = "persona_light_and_dark_duality_glitched"
     name = "Glitched Light and Dark Duality"
-    trigger = "turn_start"
-    max_stacks = 1
-    stack_display = "spinner"
+    trigger = ["turn_start", "action_taken"]
+    max_stacks = 5
+    stack_display = "pips"
+
+    _persona_state: ClassVar[dict[int, str]] = {}
+    _stance_rank: ClassVar[dict[int, int]] = {}
+    _flip_counts: ClassVar[dict[int, int]] = {}
+
+    def _apply_light_form(self, target: "Stats", allies: list["Stats"]) -> None:
+        rank = self._stance_rank.get(id(target), 1)
+        base_defense = self._get_base_value(target, "defense")
+        defense_bonus = int(base_defense * (0.20 + 0.04 * (rank - 1)))  # Was 0.10/0.02, now doubled
+        mitigation_bonus = 0.10 + 0.02 * (rank - 1)  # Was 0.05/0.01, now doubled
+        resistance_bonus = 0.12 + 0.02 * (rank - 1)  # Was 0.06/0.01, now doubled
+        regain_bonus = 40 + 10 * (rank - 1)  # Was 20/5, now doubled
+
+        target.add_effect(
+            StatEffect(
+                name=f"{self.id}_light_aegis",
+                stat_modifiers={
+                    "defense": defense_bonus,
+                    "mitigation": mitigation_bonus,
+                    "effect_resistance": resistance_bonus,
+                    "regain": regain_bonus,
+                },
+                duration=-1,
+                source=self.id,
+            )
+        )
+
+        ally_mitigation = 0.06 + 0.01 * (rank - 1)  # Was 0.03/0.005, now doubled
+        ally_resistance = 0.06 + 0.01 * (rank - 1)  # Was 0.03/0.005, now doubled
+        ally_regain = 20 * rank  # Was 10 * rank, now doubled
+        for ally in allies:
+            if ally is target:
+                continue
+            ally.add_effect(
+                StatEffect(
+                    name=f"{self.id}_light_screen",
+                    stat_modifiers={
+                        "mitigation": ally_mitigation,
+                        "effect_resistance": ally_resistance,
+                        "regain": ally_regain,
+                    },
+                    duration=2,
+                    source=self.id,
+                )
+            )
+
+    def _apply_dark_form(
+        self,
+        target: "Stats",
+        allies: list["Stats"],
+        foes: list["Stats"],
+    ) -> None:
+        rank = self._stance_rank.get(id(target), 1)
+        base_max_hp = self._get_base_value(target, "max_hp")
+        base_defense = self._get_base_value(target, "defense")
+        max_hp_bonus = int(base_max_hp * (0.16 + 0.04 * (rank - 1)))  # Was 0.08/0.02, now doubled
+        defense_bonus = int(base_defense * (0.36 + 0.08 * (rank - 1)))  # Was 0.18/0.04, now doubled
+        mitigation_bonus = 0.14 + 0.03 * (rank - 1)  # Was 0.07/0.015, now doubled
+        aggro_bonus = 5.0 + 1.0 * (rank - 1)  # Was 2.5/0.5, now doubled
+
+        target.add_effect(
+            StatEffect(
+                name=f"{self.id}_dark_bastion",
+                stat_modifiers={
+                    "max_hp": max_hp_bonus,
+                    "defense": defense_bonus,
+                    "mitigation": mitigation_bonus,
+                    "aggro_modifier": aggro_bonus,
+                },
+                duration=-1,
+                source=self.id,
+            )
+        )
+
+        ally_guard = 0.04 + 0.01 * (rank - 1)  # Was 0.02/0.005, now doubled
+        for ally in allies:
+            if ally is target:
+                continue
+            ally.add_effect(
+                StatEffect(
+                    name=f"{self.id}_dark_cover",
+                    stat_modifiers={"mitigation": ally_guard},
+                    duration=1,
+                    source=self.id,
+                )
+            )
+
+        debuff_crit = -0.06 * rank  # Was -0.03 * rank, now doubled
+        debuff_effect = -0.08 * rank  # Was -0.04 * rank, now doubled
+        for foe in foes:
+            foe.add_effect(
+                StatEffect(
+                    name=f"{self.id}_dark_smother",
+                    stat_modifiers={
+                        "crit_rate": debuff_crit,
+                        "effect_hit_rate": debuff_effect,
+                    },
+                    duration=1,
+                    source=self.id,
+                )
+            )
+
+    async def _apply_turn_start_aura(
+        self,
+        target: "Stats",
+        persona: str,
+        allies: list["Stats"],
+        foes: list["Stats"],
+    ) -> None:
+        rank = self._stance_rank.get(id(target), 1)
+        if persona == "light":
+            pulse_value = 24 * rank  # Was 12 * rank, now doubled
+            for entity in [target, *[a for a in allies if a is not target]]:
+                entity.add_effect(
+                    StatEffect(
+                        name=f"{self.id}_light_pulse",
+                        stat_modifiers={"regain": pulse_value},
+                        duration=1,
+                        source=self.id,
+                    )
+                )
+        else:
+            base_defense = self._get_base_value(target, "defense")
+            ward_defense = int(base_defense * (0.10 + 0.02 * (rank - 1)))  # Was 0.05/0.01, now doubled
+            ward_mitigation = 0.05 + 0.01 * (rank - 1)  # Was 0.025/0.005, now doubled
+            target.add_effect(
+                StatEffect(
+                    name=f"{self.id}_dark_ward",
+                    stat_modifiers={
+                        "defense": ward_defense,
+                        "mitigation": ward_mitigation,
+                    },
+                    duration=1,
+                    source=self.id,
+                )
+            )
+            for foe in foes:
+                foe.add_effect(
+                    StatEffect(
+                        name=f"{self.id}_dark_glare",
+                        stat_modifiers={"crit_rate": -0.04 * rank},  # Was -0.02, now doubled
+                        duration=1,
+                        source=self.id,
+                    )
+                )
+
+    async def _apply_light_entry(
+        self,
+        target: "Stats",
+        allies: list["Stats"],
+        rank: int,
+    ) -> None:
+        heal_amount = max(int(target.max_hp * (0.06 + 0.02 * (rank - 1))), 50)  # Was 0.03/0.01 and 25 floor, now doubled
+        recipients = [target]
+        recipients.extend(ally for ally in allies if ally is not target)
+        for entity in recipients:
+            try:
+                await entity.apply_healing(
+                    heal_amount,
+                    healer=target,
+                    source_type="passive",
+                    source_name=self.id,
+                )
+            except Exception:
+                continue
+
+    async def _apply_dark_entry(
+        self,
+        target: "Stats",
+        allies: list["Stats"],
+        foes: list["Stats"],
+        rank: int,
+    ) -> None:
+        guard_value = 0.06 + 0.02 * (rank - 1)  # Was 0.03/0.01, now doubled
+        for ally in allies:
+            if ally is target:
+                continue
+            ally.add_effect(
+                StatEffect(
+                    name=f"{self.id}_dark_guard",
+                    stat_modifiers={"mitigation": guard_value},
+                    duration=2,
+                    source=self.id,
+                )
+            )
+
+        suppression = -0.06 * rank  # Was -0.03 * rank, now doubled
+        for foe in foes:
+            foe.add_effect(
+                StatEffect(
+                    name=f"{self.id}_dark_suppression",
+                    stat_modifiers={"effect_hit_rate": suppression},
+                    duration=2,
+                    source=self.id,
+                )
+            )
 
     @classmethod
     def get_description(cls) -> str:
         return (
-            "[GLITCHED] Alternates between Light (doubled healing/shields) and Dark (doubled damage/DoTs) stances. "
-            "Each stance provides doubled bonuses to its element's mechanics. "
-            "Switching costs are reduced when balance is maintained."
+            "[GLITCHED] Opens in Light or Dark stance and still flips after each action, but all stance bonuses are doubled. "
+            "Light: +20%+ def scaling, +10% mitigation, +12% resist, and bigger regen pulses plus doubled entry heals. "
+            "Dark: +16%+ max HP, +36%+ defense, +5 aggro scaling, stronger ally guard, and doubled suppression on foes."
         )


### PR DESCRIPTION
## Task Summary
Completed implementation of two complex glitched-tier passive variants that were previously stubs.

### Changes
- **lady_storm_supercell_glitched**: Full implementation with doubled wind/lightning phase bonuses
  - Doubled SPD, dodge, aggro reduction in tailwind aura
  - Doubled ATK, crit rate, effect hit rate in storm edge
  - Doubled mitigation and defense in storm barrier
  - Wind phase slipstreams doubled for self and allies
  - Lightning charge crit/mitigation bonuses doubled
  - Surge detonation and regen doubled
  
- **persona_light_and_dark_duality_glitched**: Full implementation with doubled stance scaling
  - Light stance: doubled defense, mitigation, resistance, regen bonuses
  - Dark stance: doubled max HP, defense, mitigation, aggro bonuses
  - Light entry heals doubled
  - Dark entry guard and suppression doubled
  - All rank-scaling multipliers doubled

### Testing
- Both passives implement full state machine logic (no simplified wrapper behavior)
- Inline comments document all doubled values for reviewer clarity
- Descriptions updated with [GLITCHED] prefix and complete doubled mechanics list

### Acceptance Criteria
- [x] All numeric multipliers identified and doubled
- [x] Complex state machine logic preserved
- [x] Inline comments document doubled values
- [x] Plugin descriptions accurately reflect doubled mechanics
- [x] No breaking changes to parent classes