### PR TITLE
[FIX] Address type hint import error in Lady Echo prime passive

### DIFF
--- a/backend/plugins/passives/prime/lady_echo_resonant_static.py
+++ b/backend/plugins/passives/prime/lady_echo_resonant_static.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -21,8 +23,8 @@ class LadyEchoResonantStaticPrime(LadyEchoResonantStatic):
 
     async def apply(
         self,
-        target: "Stats",
-        hit_target: "Stats" | None = None,
+        target: Stats,
+        hit_target: Stats | None = None,
         **kwargs,
     ) -> None:
         entity_id = id(target)
@@ -59,8 +61,8 @@ class LadyEchoResonantStaticPrime(LadyEchoResonantStatic):
 
     async def on_hit_landed(
         self,
-        attacker: "Stats",
-        target_hit: "Stats",
+        attacker: Stats,
+        target_hit: Stats,
         damage: int = 0,
         action_type: str = "attack",
         **_: object,


### PR DESCRIPTION
## Summary
- enable postponed evaluation of annotations in `lady_echo_resonant_static.py` to support union syntax
- update prime Resonant Static type hints to use real `Stats` references, preventing runtime TypeErrors during plugin loading

## Testing
- uv run pytest backend/tests/test_prime_passives_registry.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692449b55050832cb3213f0fdfd206d7)