### PR TITLE
Update Bun.js installation in Dockerfile

### DIFF
--- a/Dockerfile.js
+++ b/Dockerfile.js
@@ -26,8 +26,8 @@ RUN yay -Syu --noconfirm npm && yay -Yccc --noconfirm
 # Install unzip
 RUN yay -Syu --noconfirm unzip && yay -Yccc --noconfirm
 
-# Install Bun.js from AUR
-RUN yay -S --noconfirm bun-bin && yay -Yccc --noconfirm
+# Install Bun.js
+RUN yay -S --noconfirm bun && yay -Yccc --noconfirm
 
 WORKDIR /app
 EXPOSE 59001


### PR DESCRIPTION
This pull request updates the installation method for Bun.js in the `Dockerfile.js` to use the standard `bun` package instead of the `bun-bin` package from the AUR. This change ensures that the latest and most appropriate version of Bun.js is installed.

Dependency management:

* Updated the Bun.js installation command to use the `bun` package instead of `bun-bin` in the AUR, which may improve compatibility and maintainability.
